### PR TITLE
Chachacha deployment

### DIFF
--- a/.github/workflows/chachacha.sh
+++ b/.github/workflows/chachacha.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+CENTRIFUGE_IMAGE="centrifugeio/rococo:chachacha-v1"
+ZEITGEST_IMAGE="zeitgeistpm/zeitgeist-node-parachain"
+
+CHACHACHA_VALIDATOR_0="chachacha-validator-0"
+CHACHACHA_VALIDATOR_1="chachacha-validator-1"
+ZEITGEST_PARACHAIN_0="zeitgeist-parachain-0"
+
+sudo apt update
+sudo apt install -y docker.io
+sudo docker stop $CHACHACHA_VALIDATOR_0 $CHACHACHA_VALIDATOR_1 $ZEITGEST_PARACHAIN_0
+sudo docker rm $CHACHACHA_VALIDATOR_0 $CHACHACHA_VALIDATOR_1 $ZEITGEST_PARACHAIN_0
+
+sudo docker run \
+    -d \
+    --name $CHACHACHA_VALIDATOR_0 \
+    --restart always \
+    $CENTRIFUGE_IMAGE \
+    /usr/local/bin/polkadot \
+    --bootnodes /ip4/34.89.248.129/tcp/30333/p2p/12D3KooWD8CAZBgpeZiSVVbaj8mijR6mfgUsHNAmCKwsRoRnFod4 \
+    --bootnodes /ip4/35.242.217.240/tcp/30333/p2p/12D3KooWBthdCz4JshkMb4GxJXVwrHPv9GpWAgfh2hAdkyXQDKyN \
+    --chain rococo-chachacha \
+    --name $CHACHACHA_VALIDATOR_0 \
+    --validator
+
+sudo docker run \
+    -d \
+    --name $CHACHACHA_VALIDATOR_1 \
+    --restart always \
+    $CENTRIFUGE_IMAGE \
+    /usr/local/bin/polkadot \
+    --bootnodes /ip4/34.89.248.129/tcp/30333/p2p/12D3KooWD8CAZBgpeZiSVVbaj8mijR6mfgUsHNAmCKwsRoRnFod4 \
+    --bootnodes /ip4/35.242.217.240/tcp/30333/p2p/12D3KooWBthdCz4JshkMb4GxJXVwrHPv9GpWAgfh2hAdkyXQDKyN \
+    --chain rococo-chachacha \
+    --name $CHACHACHA_VALIDATOR_1 \
+    --validator
+
+
+sudo docker run --rm $ZEITGEST_IMAGE export-genesis-state --parachain-id 9123 > zeitgeist-genesis-state
+sudo docker run --rm $ZEITGEST_IMAGE export-genesis-wasm > zeitgeist-genesis-wasm
+curl -o rococo-chachacha.json https://storage.googleapis.com/centrifuge-artifact-releases/rococo-chachacha.json
+
+sudo docker run \
+    -d \
+    --name $ZEITGEST_PARACHAIN_0 \
+    --restart always \
+    $ZEITGEST_IMAGE \
+    --collator \
+    --parachain-id 9123 \
+    -- \
+    --chain rococo-chachacha.json \
+    --execution wasm

--- a/.github/workflows/chachacha.yml
+++ b/.github/workflows/chachacha.yml
@@ -1,0 +1,25 @@
+name: Chachacha
+
+on:
+  push:
+    branches: [ chachacha ]
+  pull_request:
+    # Temporary! Only for this chachacha PR testing  
+    branches: [ "*" ]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Publish
+        uses: appleboy/ssh-action@master
+        with:
+          host: 45.33.117.205
+          key: ${{ secrets.CHACHACHA_VM_PRIVATE_KEY }}
+          passphrase: ${{ secrets.CHACHACHA_VM_PASSWORD }}
+          script: ./.github/workflows/chachacha.sh
+          username: zeitgeist

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,42 @@
+name: Docker Hub
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # Temporary! Only for this chachacha PR testing  
+    branches: [ "*" ]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: [
+          "default",
+          "parachain"
+        ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            FEATURES=${{ matrix.features }}
+          push: true
+          tags: zeitgeistpm/zeitgeist-node-${{ matrix.features }}:latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, chachacha ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, chachacha ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL description="This is the build stage for the Zeitgeist node. Here is creat
 ENV DEBIAN_FRONTEND=noninteractive
 
 ARG PROFILE=release
+ARG FEATURES=default
 WORKDIR /zeitgeist
 
 COPY . /zeitgeist
@@ -20,13 +21,13 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     rustup toolchain install nightly-2020-10-06 && \
     rustup target add wasm32-unknown-unknown --toolchain nightly-2020-10-06 && \
     rustup default stable && \
-    cargo build "--$PROFILE"
+    cargo build "--$PROFILE" --features "$FEATURES" --manifest-path node/Cargo.toml
 
 # ==== SECOND STAGE ====
 
 FROM phusion/baseimage:0.10.2
 LABEL maintainer="hi@zeitgeist.pm"
-LABEL description="THis is the 2nd stage: a very small image where we copy the Zeigeist node binary."
+LABEL description="This is the 2nd stage: a very small image where we copy the Zeigeist node binary."
 ARG PROFILE=release
 
 RUN mv /usr/share/ca* /tmp && \


### PR DESCRIPTION
Also fixes #68 

CI will deploy a parachain on Chachacha everytime a commit is pushed to the `chachacha` branch, preferably when re-basing from `main`.

```
PRs ------>  main ------> chachacha
             |            |
             |            ------> Deploy to Chachacha
             |
             -----> Push images to Docker Hub
```

