### PR TITLE
Enhance robustness of `u128` serialization/de-serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11412,11 +11412,13 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "zeitgeist-primitives",
+ "zrml-prediction-markets-runtime-api",
  "zrml-swaps",
 ]
 
@@ -11460,11 +11462,13 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "serde",
+ "sp-api",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
  "zeitgeist-primitives",
+ "zrml-swaps-runtime-api",
 ]
 
 [[package]]

--- a/primitives/src/balance_info.rs
+++ b/primitives/src/balance_info.rs
@@ -1,0 +1,35 @@
+#[cfg(feature = "std")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Used to workaround serde serialization/de-serialization problems involving `u128`.
+///
+/// # Types
+///
+/// * `B`: Balance
+#[derive(Default, Eq, PartialEq, parity_scale_codec::Decode, parity_scale_codec::Encode)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+pub struct BalanceInfo<B>(
+    #[cfg_attr(feature = "std", serde(bound(serialize = "B: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "B: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    pub B,
+);
+
+#[cfg(feature = "std")]
+fn serialize_as_string<S: Serializer, T: std::fmt::Display>(
+    t: &T,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&t.to_string())
+}
+
+#[cfg(feature = "std")]
+fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(
+    deserializer: D,
+) -> Result<T, D::Error> {
+    let s = String::deserialize(deserializer)?;
+    s.parse::<T>()
+        .map_err(|_| serde::de::Error::custom("Parse from string failed"))
+}

--- a/primitives/src/balance_info.rs
+++ b/primitives/src/balance_info.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Used to workaround serde serialization/de-serialization problems involving `u128`.
+/// Used to workaround serde serialization/deserialization problems involving `u128`.
 ///
 /// # Types
 ///

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -3,11 +3,13 @@
 extern crate alloc;
 
 mod asset;
+mod balance_info;
 mod swaps;
 mod zeitgeist_currencies_extension;
 mod zeitgeist_multi_reservable_currency;
 
 pub use asset::*;
+pub use balance_info::BalanceInfo;
 use sp_runtime::{
     generic,
     traits::{IdentifyAccount, Verify},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -44,7 +44,6 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use zeitgeist_primitives::*;
-use zrml_swaps_runtime_api::BalanceInfo;
 
 pub const DAYS: BlockNumber = HOURS * 24;
 pub const DOLLARS: Balance = BASE / 100; // 100_000_000
@@ -72,7 +71,6 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 pub type AdaptedBasicCurrency =
     orml_currencies::BasicCurrencyAdapter<Runtime, Balances, Amount, Balance>;
 pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
-pub type Balance = u128;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type BlockId = generic::BlockId<Block>;
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExtra>;
@@ -566,9 +564,7 @@ impl_runtime_apis! {
             asset_in: Asset<MarketId>,
             asset_out: Asset<MarketId>,
         ) -> BalanceInfo<Balance> {
-            BalanceInfo {
-                amount: Swaps::get_spot_price(pool_id, asset_in, asset_out).ok().unwrap_or(0),
-            }
+            BalanceInfo(Swaps::get_spot_price(pool_id, asset_in, asset_out).ok().unwrap_or(0))
         }
 
         fn pool_account_id(pool_id: u128) -> AccountId {

--- a/zrml/prediction-markets/Cargo.toml
+++ b/zrml/prediction-markets/Cargo.toml
@@ -15,6 +15,8 @@ zrml-swaps = { default-features = false, path = "../swaps" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library" }
 pallet-balances = { branch = "rococo-v1", git = "https://github.com/paritytech/substrate" }
 serde = "1.0"
+sp-api = { branch = "rococo-v1", git = "https://github.com/paritytech/substrate" }
+zrml-prediction-markets-runtime-api = { default-features = false, features = ["std"], path = "./rpc/runtime-api" }
 
 [features]
 default = ["std"]

--- a/zrml/prediction-markets/rpc/Cargo.toml
+++ b/zrml/prediction-markets/rpc/Cargo.toml
@@ -8,7 +8,7 @@ sp-api = { branch = "rococo-v1", default-features = false, git = "https://github
 sp-blockchain = { branch = "rococo-v1", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-runtime = { branch = "rococo-v1", default-features = false, git = "https://github.com/paritytech/substrate" }
 zeitgeist-primitives = { default-features = false, path = '../../../primitives' }
-zrml-prediction-markets-runtime-api = { default-features = false, path = "runtime-api" }
+zrml-prediction-markets-runtime-api = { default-features = false, features = ["std"], path = "runtime-api" }
 
 [package]
 authors = ["Logan Saether <x@logansaether.com>"]

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -13,8 +13,8 @@ use sp_runtime::{
     Perbill,
 };
 use zeitgeist_primitives::{
-    AccountIdTest, Amount, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index, MarketId,
-    UncheckedExtrinsicTest, BASE,
+    AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
+    MarketId, UncheckedExtrinsicTest, BASE,
 };
 
 pub const ALICE: AccountIdTest = 0;
@@ -216,5 +216,13 @@ pub fn run_to_block(n: BlockNumber) {
         System::on_initialize(System::block_number());
         PredictionMarkets::on_initialize(System::block_number());
         Balances::on_initialize(System::block_number());
+    }
+}
+
+sp_api::mock_impl_runtime_apis! {
+    impl zrml_prediction_markets_runtime_api::PredictionMarketsApi<Block, MarketId, Hash> for Runtime {
+        fn market_outcome_share_id(_: MarketId, _: u16) -> Asset<MarketId> {
+            Asset::PoolShare(1)
+        }
     }
 }

--- a/zrml/swaps/Cargo.toml
+++ b/zrml/swaps/Cargo.toml
@@ -18,6 +18,8 @@ pallet-balances = { optional = true, default-features = false, branch = "rococo-
 orml-currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library" }
 pallet-balances = { branch = "rococo-v1", git = "https://github.com/paritytech/substrate" }
+sp-api = { branch = "rococo-v1", git = "https://github.com/paritytech/substrate" }
+zrml-swaps-runtime-api = { default-features = false, features = ["std"], path = "./rpc/runtime-api" }
 
 [features]
 default = ["std"]

--- a/zrml/swaps/rpc/Cargo.toml
+++ b/zrml/swaps/rpc/Cargo.toml
@@ -9,7 +9,7 @@ sp-blockchain = { branch = "rococo-v1", default-features = false, git = "https:/
 sp-core = { branch = "rococo-v1", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-runtime = { branch = "rococo-v1", default-features = false, git = "https://github.com/paritytech/substrate" }
 zeitgeist-primitives = { default-features = false, path = '../../../primitives' }
-zrml-swaps-runtime-api = { default-features = false, path = "runtime-api" }
+zrml-swaps-runtime-api = { default-features = false, features = ["std"], path = "runtime-api" }
 
 [package]
 authors = ["Logan Saether <x@logansaether.com>"]

--- a/zrml/swaps/rpc/runtime-api/src/lib.rs
+++ b/zrml/swaps/rpc/runtime-api/src/lib.rs
@@ -2,45 +2,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use parity_scale_codec::{Codec, Decode, Encode};
-#[cfg(feature = "std")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use parity_scale_codec::Codec;
 use sp_runtime::traits::{MaybeDisplay, MaybeFromStr};
-use zeitgeist_primitives::Asset;
-
-#[derive(Eq, PartialEq, Encode, Decode, Default)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct BalanceInfo<Balance> {
-    #[cfg_attr(
-        feature = "std",
-        serde(bound(serialize = "Balance: std::fmt::Display"))
-    )]
-    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
-    #[cfg_attr(
-        feature = "std",
-        serde(bound(deserialize = "Balance: std::str::FromStr"))
-    )]
-    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
-    pub amount: Balance,
-}
-
-#[cfg(feature = "std")]
-fn serialize_as_string<S: Serializer, T: std::fmt::Display>(
-    t: &T,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    serializer.serialize_str(&t.to_string())
-}
-
-#[cfg(feature = "std")]
-fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(
-    deserializer: D,
-) -> Result<T, D::Error> {
-    let s = String::deserialize(deserializer)?;
-    s.parse::<T>()
-        .map_err(|_| serde::de::Error::custom("Parse from string failed"))
-}
+use zeitgeist_primitives::{Asset, BalanceInfo};
 
 sp_api::decl_runtime_apis! {
     pub trait SwapsApi<PoolId, AccountId, Balance, MarketId> where

--- a/zrml/swaps/rpc/src/lib.rs
+++ b/zrml/swaps/rpc/src/lib.rs
@@ -12,9 +12,9 @@ use sp_runtime::{
     traits::{Block as BlockT, MaybeDisplay, MaybeFromStr},
 };
 use std::sync::Arc;
-use zeitgeist_primitives::Asset;
+use zeitgeist_primitives::{Asset, BalanceInfo};
 
-pub use zrml_swaps_runtime_api::{BalanceInfo, SwapsApi as SwapsRuntimeApi};
+pub use zrml_swaps_runtime_api::SwapsApi as SwapsRuntimeApi;
 
 #[rpc]
 pub trait SwapsApi<BlockHash, PoolId, AccountId, Balance, BalanceType, MarketId>

--- a/zrml/swaps/rpc/src/lib.rs
+++ b/zrml/swaps/rpc/src/lib.rs
@@ -1,12 +1,11 @@
 //! RPC interface for the Swaps pallet.
 
-use core::convert::TryFrom;
+use core::{fmt, str::FromStr};
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use parity_scale_codec::Codec;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
-use sp_core::U256;
 use sp_runtime::{
     generic::BlockId,
     traits::{Block as BlockT, MaybeDisplay, MaybeFromStr},
@@ -17,9 +16,9 @@ use zeitgeist_primitives::{Asset, BalanceInfo};
 pub use zrml_swaps_runtime_api::SwapsApi as SwapsRuntimeApi;
 
 #[rpc]
-pub trait SwapsApi<BlockHash, PoolId, AccountId, Balance, BalanceType, MarketId>
+pub trait SwapsApi<BlockHash, PoolId, AccountId, Balance, MarketId>
 where
-    Balance: core::str::FromStr,
+    Balance: FromStr + fmt::Display,
 {
     #[rpc(name = "swaps_poolSharesId")]
     fn pool_shares_id(&self, pool_id: PoolId, at: Option<BlockHash>) -> Result<Asset<MarketId>>;
@@ -34,7 +33,7 @@ where
         asset_in: Asset<MarketId>,
         asset_out: Asset<MarketId>,
         at: Option<BlockHash>,
-    ) -> Result<BalanceType>;
+    ) -> Result<BalanceInfo<Balance>>;
 
     #[rpc(name = "swaps_getSpotPrices")]
     fn get_spot_prices(
@@ -43,7 +42,7 @@ where
         asset_in: Asset<MarketId>,
         asset_out: Asset<MarketId>,
         blocks: Vec<BlockHash>,
-    ) -> Result<Vec<BalanceType>>;
+    ) -> Result<Vec<BalanceInfo<Balance>>>;
 }
 
 /// A struct that implements the [`SwapsApi`].
@@ -95,16 +94,14 @@ macro_rules! get_spot_price_rslt {
 }
 
 impl<C, Block, PoolId, AccountId, Balance, MarketId>
-    SwapsApi<<Block as BlockT>::Hash, PoolId, AccountId, Balance, BalanceInfo<Balance>, MarketId>
-    for Swaps<C, Block>
+    SwapsApi<<Block as BlockT>::Hash, PoolId, AccountId, Balance, MarketId> for Swaps<C, Block>
 where
     Block: BlockT,
     C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
     C::Api: SwapsRuntimeApi<Block, PoolId, AccountId, Balance, MarketId>,
     PoolId: Clone + Codec,
     AccountId: Codec,
-    Balance: Codec + MaybeDisplay + MaybeFromStr + TryFrom<U256>,
-    <Balance as TryFrom<U256>>::Error: core::fmt::Debug,
+    Balance: Codec + MaybeDisplay + MaybeFromStr,
     MarketId: Clone + Codec,
 {
     fn pool_shares_id(

--- a/zrml/swaps/src/benchmarks.rs
+++ b/zrml/swaps/src/benchmarks.rs
@@ -9,7 +9,7 @@ use frame_support::dispatch::UnfilteredDispatchable;
 use frame_support::traits::Get;
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
-use sp_runtime::traits::{Hash, SaturatedConversion};
+use sp_runtime::traits::SaturatedConversion;
 use zeitgeist_primitives::{Asset, BASE};
 
 // Generates ``asset_count`` assets
@@ -28,7 +28,7 @@ fn generate_assets<T: Config>(
     };
     // Generate MaxAssets assets and generate enough liquidity
     for i in 0..asset_count {
-        let asset = Asset::Share(T::Hashing::hash_of(&(i as u32)));
+        let asset = Asset::PoolShare(i as _);
         assets.push(asset.clone());
         T::Shares::deposit(asset, owner, asset_amount_unwrapped).unwrap();
     }

--- a/zrml/swaps/src/mock.rs
+++ b/zrml/swaps/src/mock.rs
@@ -7,8 +7,8 @@ use sp_runtime::{
     traits::{AccountIdConversion, BlakeTwo256, IdentityLookup},
 };
 use zeitgeist_primitives::{
-    AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
-    MarketId, UncheckedExtrinsicTest, BASE,
+    AccountIdTest, Amount, Asset, Balance, BalanceInfo, BlockNumber, BlockTest, CurrencyId, Hash,
+    Index, MarketId, PoolId, UncheckedExtrinsicTest, BASE,
 };
 
 parameter_types! {
@@ -159,5 +159,27 @@ impl ExtBuilder {
         .unwrap();
 
         t.into()
+    }
+}
+
+sp_api::mock_impl_runtime_apis! {
+    impl zrml_swaps_runtime_api::SwapsApi<Block, PoolId, AccountIdTest, Balance, MarketId>
+      for Runtime
+    {
+        fn get_spot_price(
+            pool_id: u128,
+            asset_in: Asset<MarketId>,
+            asset_out: Asset<MarketId>,
+        ) -> BalanceInfo<Balance> {
+            BalanceInfo(Swaps::get_spot_price(pool_id, asset_in, asset_out).ok().unwrap_or(0))
+        }
+
+        fn pool_account_id(pool_id: u128) -> AccountIdTest {
+            Swaps::pool_account_id(pool_id)
+        }
+
+        fn pool_shares_id(pool_id: u128) -> Asset<MarketId> {
+            Swaps::pool_shares_id(pool_id)
+        }
     }
 }

--- a/zrml/swaps/src/tests.rs
+++ b/zrml/swaps/src/tests.rs
@@ -4,7 +4,9 @@ use crate::{
 };
 use frame_support::{assert_noop, assert_ok};
 use orml_traits::MultiCurrency;
+use sp_api::BlockId;
 use zeitgeist_primitives::{Asset, MarketId, BASE};
+use zrml_swaps_runtime_api::SwapsApi;
 
 pub const ASSET_A: Asset<MarketId> = Asset::CategoricalOutcome(0, 65);
 pub const ASSET_B: Asset<MarketId> = Asset::CategoricalOutcome(0, 66);
@@ -28,6 +30,17 @@ const _99: u128 = 99 * BASE;
 const _100: u128 = 100 * BASE;
 const _101: u128 = 101 * BASE;
 const _105: u128 = 105 * BASE;
+
+#[test]
+fn rpc_serialization_deserialization_do_not_panic() {
+    ExtBuilder::default().build().execute_with(|| {
+        let runtime = Runtime;
+        let block_id = BlockId::Number(0);
+        let _ = runtime.get_spot_price(&block_id, 1, Asset::PoolShare(0), Asset::PoolShare(1));
+        let _ = runtime.pool_account_id(&block_id, 1);
+        let _ = runtime.pool_shares_id(&block_id, 1);
+    });
+}
 
 #[test]
 fn allows_the_full_user_lifecycle() {


### PR DESCRIPTION
Tries to prevent runtime panics by tweaking some types, structures and crate features.

Some tests were created for RPC calls involving the **runtime** (RPC calls involving nodes would require a SDK) to prevent future panics related to serde `u128` serialization/de-serialization.

In order to create more tests with different inputs, it would be cool to do some external node interaction while recording the actual network activity to catch and reproduce possible errors -> https://support.box.com/hc/en-us/articles/360043696054-How-to-Generate-Network-Captures-for-Troubleshooting.

![Capture d’écran de 2021-04-23 14-43-48](https://user-images.githubusercontent.com/17877264/115909882-7ef95b80-a442-11eb-8785-8334056a0f3c.png)

