### PR TITLE
Properly fix `u128` serialization for RPC calls

### DIFF
--- a/primitives/src/asset.rs
+++ b/primitives/src/asset.rs
@@ -1,3 +1,5 @@
+use crate::SerdeWrapper;
+
 /// The `Asset` enum represents all types of assets available in the Zeitgeist
 /// system.
 ///
@@ -20,7 +22,7 @@ pub enum Asset<MI> {
     CategoricalOutcome(MI, CategoryIndex),
     ScalarOutcome(MI, ScalarPosition),
     CombinatorialOutcome,
-    PoolShare(u128),
+    PoolShare(SerdeWrapper<u128>),
     Ztg,
 }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -3,13 +3,13 @@
 extern crate alloc;
 
 mod asset;
-mod balance_info;
+mod serde_wrapper;
 mod swaps;
 mod zeitgeist_currencies_extension;
 mod zeitgeist_multi_reservable_currency;
 
 pub use asset::*;
-pub use balance_info::BalanceInfo;
+pub use serde_wrapper::SerdeWrapper;
 use sp_runtime::{
     generic,
     traits::{IdentifyAccount, Verify},

--- a/primitives/src/serde_wrapper.rs
+++ b/primitives/src/serde_wrapper.rs
@@ -6,10 +6,21 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// # Types
 ///
 /// * `B`: Balance
-#[derive(Default, Eq, PartialEq, parity_scale_codec::Decode, parity_scale_codec::Encode)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    parity_scale_codec::Decode,
+    parity_scale_codec::Encode,
+)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct BalanceInfo<B>(
+pub struct SerdeWrapper<B>(
     #[cfg_attr(feature = "std", serde(bound(serialize = "B: std::fmt::Display")))]
     #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
     #[cfg_attr(feature = "std", serde(bound(deserialize = "B: std::str::FromStr")))]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -563,16 +563,16 @@ impl_runtime_apis! {
             pool_id: u128,
             asset_in: Asset<MarketId>,
             asset_out: Asset<MarketId>,
-        ) -> BalanceInfo<Balance> {
-            BalanceInfo(Swaps::get_spot_price(pool_id, asset_in, asset_out).ok().unwrap_or(0))
+        ) -> SerdeWrapper<Balance> {
+            SerdeWrapper(Swaps::get_spot_price(pool_id, asset_in, asset_out).ok().unwrap_or(0))
         }
 
         fn pool_account_id(pool_id: u128) -> AccountId {
             Swaps::pool_account_id(pool_id)
         }
 
-        fn pool_shares_id(pool_id: u128) -> Asset<MarketId> {
-            Swaps::pool_shares_id(pool_id)
+        fn pool_shares_id(pool_id: u128) -> Asset<SerdeWrapper<MarketId>> {
+            Asset::PoolShare(SerdeWrapper(pool_id))
         }
     }
 }

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -14,7 +14,7 @@ use sp_runtime::{
 };
 use zeitgeist_primitives::{
     AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
-    MarketId, UncheckedExtrinsicTest, BASE,
+    MarketId, SerdeWrapper, UncheckedExtrinsicTest, BASE,
 };
 
 pub const ALICE: AccountIdTest = 0;
@@ -222,7 +222,7 @@ pub fn run_to_block(n: BlockNumber) {
 sp_api::mock_impl_runtime_apis! {
     impl zrml_prediction_markets_runtime_api::PredictionMarketsApi<Block, MarketId, Hash> for Runtime {
         fn market_outcome_share_id(_: MarketId, _: u16) -> Asset<MarketId> {
-            Asset::PoolShare(1)
+            Asset::PoolShare(SerdeWrapper(1))
         }
     }
 }

--- a/zrml/swaps/rpc/runtime-api/src/lib.rs
+++ b/zrml/swaps/rpc/runtime-api/src/lib.rs
@@ -4,7 +4,7 @@
 
 use parity_scale_codec::Codec;
 use sp_runtime::traits::{MaybeDisplay, MaybeFromStr};
-use zeitgeist_primitives::{Asset, BalanceInfo};
+use zeitgeist_primitives::{Asset, SerdeWrapper};
 
 sp_api::decl_runtime_apis! {
     pub trait SwapsApi<PoolId, AccountId, Balance, MarketId> where
@@ -13,8 +13,8 @@ sp_api::decl_runtime_apis! {
         Balance: Codec + MaybeDisplay + MaybeFromStr,
         MarketId: Codec
     {
-        fn pool_shares_id(pool_id: PoolId) -> Asset<MarketId>;
+        fn pool_shares_id(pool_id: PoolId) -> Asset<SerdeWrapper<MarketId>>;
         fn pool_account_id(pool_id: PoolId) -> AccountId;
-        fn get_spot_price(pool_id: PoolId, asset_in: Asset<MarketId>, asset_out: Asset<MarketId>) -> BalanceInfo<Balance>;
+        fn get_spot_price(pool_id: PoolId, asset_in: Asset<MarketId>, asset_out: Asset<MarketId>) -> SerdeWrapper<Balance>;
     }
 }

--- a/zrml/swaps/src/benchmarks.rs
+++ b/zrml/swaps/src/benchmarks.rs
@@ -10,7 +10,7 @@ use frame_support::traits::Get;
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
 use sp_runtime::traits::SaturatedConversion;
-use zeitgeist_primitives::{Asset, BASE};
+use zeitgeist_primitives::{Asset, SerdeWrapper, BASE};
 
 // Generates ``asset_count`` assets
 fn generate_assets<T: Config>(
@@ -28,7 +28,7 @@ fn generate_assets<T: Config>(
     };
     // Generate MaxAssets assets and generate enough liquidity
     for i in 0..asset_count {
-        let asset = Asset::PoolShare(i as _);
+        let asset = Asset::PoolShare(SerdeWrapper(i as _));
         assets.push(asset.clone());
         T::Shares::deposit(asset, owner, asset_amount_unwrapped).unwrap();
     }

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -52,7 +52,7 @@ mod pallet {
         traits::{AccountIdConversion, AtLeast32Bit, MaybeSerializeDeserialize, Member, Zero},
         DispatchError, DispatchResult, SaturatedConversion,
     };
-    use zeitgeist_primitives::{Asset, Swaps};
+    use zeitgeist_primitives::{Asset, SerdeWrapper, Swaps};
 
     pub(crate) type BalanceOf<T> =
         <<T as Config>::Shares as MultiCurrency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -648,7 +648,7 @@ mod pallet {
         }
 
         pub fn pool_shares_id(pool_id: u128) -> Asset<T::MarketId> {
-            Asset::PoolShare(pool_id)
+            Asset::PoolShare(SerdeWrapper(pool_id))
         }
     }
 

--- a/zrml/swaps/src/mock.rs
+++ b/zrml/swaps/src/mock.rs
@@ -7,8 +7,8 @@ use sp_runtime::{
     traits::{AccountIdConversion, BlakeTwo256, IdentityLookup},
 };
 use zeitgeist_primitives::{
-    AccountIdTest, Amount, Asset, Balance, BalanceInfo, BlockNumber, BlockTest, CurrencyId, Hash,
-    Index, MarketId, PoolId, UncheckedExtrinsicTest, BASE,
+    AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
+    MarketId, PoolId, SerdeWrapper, UncheckedExtrinsicTest, BASE,
 };
 
 parameter_types! {
@@ -170,16 +170,16 @@ sp_api::mock_impl_runtime_apis! {
             pool_id: u128,
             asset_in: Asset<MarketId>,
             asset_out: Asset<MarketId>,
-        ) -> BalanceInfo<Balance> {
-            BalanceInfo(Swaps::get_spot_price(pool_id, asset_in, asset_out).ok().unwrap_or(0))
+        ) -> SerdeWrapper<Balance> {
+            SerdeWrapper(Swaps::get_spot_price(pool_id, asset_in, asset_out).ok().unwrap_or(0))
         }
 
         fn pool_account_id(pool_id: u128) -> AccountIdTest {
             Swaps::pool_account_id(pool_id)
         }
 
-        fn pool_shares_id(pool_id: u128) -> Asset<MarketId> {
-            Swaps::pool_shares_id(pool_id)
+        fn pool_shares_id(pool_id: u128) -> Asset<SerdeWrapper<MarketId>> {
+            Asset::PoolShare(SerdeWrapper(pool_id))
         }
     }
 }

--- a/zrml/swaps/src/tests.rs
+++ b/zrml/swaps/src/tests.rs
@@ -4,9 +4,7 @@ use crate::{
 };
 use frame_support::{assert_noop, assert_ok};
 use orml_traits::MultiCurrency;
-use sp_api::BlockId;
 use zeitgeist_primitives::{Asset, MarketId, BASE};
-use zrml_swaps_runtime_api::SwapsApi;
 
 pub const ASSET_A: Asset<MarketId> = Asset::CategoricalOutcome(0, 65);
 pub const ASSET_B: Asset<MarketId> = Asset::CategoricalOutcome(0, 66);
@@ -30,17 +28,6 @@ const _99: u128 = 99 * BASE;
 const _100: u128 = 100 * BASE;
 const _101: u128 = 101 * BASE;
 const _105: u128 = 105 * BASE;
-
-#[test]
-fn rpc_serialization_deserialization_do_not_panic() {
-    ExtBuilder::default().build().execute_with(|| {
-        let runtime = Runtime;
-        let block_id = BlockId::Number(0);
-        let _ = runtime.get_spot_price(&block_id, 1, Asset::PoolShare(0), Asset::PoolShare(1));
-        let _ = runtime.pool_account_id(&block_id, 1);
-        let _ = runtime.pool_shares_id(&block_id, 1);
-    });
-}
 
 #[test]
 fn allows_the_full_user_lifecycle() {


### PR DESCRIPTION
@lsaether You were right, the problem was related to types or more specifically, types used for serialization, including `Asset::PoolShare(u128)`.

To trigger the panic with the current code-base, just type:
```
curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "swaps_poolSharesId", "params": [0]}' http://localhost:9933/
```