### PR TITLE
Enhance test coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,9 +11,14 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        scripts: [
+          "misc",
+          "parachain",
+          "standalone"
+        ]
     steps:
     - uses: actions/checkout@v2
     - name: Initializes
@@ -21,15 +26,5 @@ jobs:
         rustup install nightly-2021-03-10
         rustup target add wasm32-unknown-unknown --toolchain nightly-2021-03-10
         rustup component add rustfmt --toolchain nightly-2021-03-10-x86_64-unknown-linux-gnu
-    - name: Rustfmt
-      run: |
-        cargo fmt --all -- --check
-    - name: Builds WASM
-      run: |
-        make build-wasm
-    - name: Build
-      run: |
-        cargo build
-    - name: Runs tests
-      run: |
-        cargo test
+    - name: Tests
+      run: ./scripts/tests/${{ matrix.scripts }}.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,8 @@ jobs:
         scripts: [
           "misc",
           "parachain",
-          "standalone"
+          "standalone",
+          "wasm"
         ]
     steps:
     - uses: actions/checkout@v2

--- a/scripts/tests/all-sequencial.sh
+++ b/scripts/tests/all-sequencial.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Checks everything in a sequential fashion. Useful for debugging but slow to compile/complete.
+#
+# IMPORTANT: CI verifies all of the following scripts in parallel
+
+. "$(dirname "$0")/misc.sh" --source-only
+. "$(dirname "$0")/standalone.sh" --source-only
+. "$(dirname "$0")/parachain.sh" --source-only

--- a/scripts/tests/all-sequencial.sh
+++ b/scripts/tests/all-sequencial.sh
@@ -7,3 +7,4 @@
 . "$(dirname "$0")/misc.sh" --source-only
 . "$(dirname "$0")/standalone.sh" --source-only
 . "$(dirname "$0")/parachain.sh" --source-only
+. "$(dirname "$0")/wasm.sh" --source-only

--- a/scripts/tests/aux-functions.sh
+++ b/scripts/tests/aux-functions.sh
@@ -2,12 +2,12 @@
 
 # Auxiliar functions used by the testing scripts
 
-build_package_with_feature() {
+check_package_with_feature() {
     local package=$1
     local features=$2
 
     /bin/echo -e "\e[0;33m***** Building '$package' with features '$features' *****\e[0m\n"
-    cargo build --features $features --manifest-path $package/Cargo.toml --no-default-features
+    cargo check --features $features --manifest-path $package/Cargo.toml --no-default-features
 }
 
 test_package_with_feature() {

--- a/scripts/tests/aux-functions.sh
+++ b/scripts/tests/aux-functions.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Auxiliar functions used by the testing scripts
+
+build_package_with_feature() {
+    local package=$1
+    local features=$2
+
+    /bin/echo -e "\e[0;33m***** Building '$package' with features '$features' *****\e[0m\n"
+    cargo build --features $features --manifest-path $package/Cargo.toml --no-default-features
+}
+
+test_package_with_feature() {
+    local package=$1
+    local features=$2
+
+    /bin/echo -e "\e[0;33m***** Testing '$package' with features '$features' *****\e[0m\n"
+    cargo test --features $features --manifest-path $package/Cargo.toml --no-default-features
+}

--- a/scripts/tests/misc.sh
+++ b/scripts/tests/misc.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Miscellaneous: Checks everything that is not runtime or node related
+
+set -euxo pipefail
+
+. "$(dirname "$0")/aux-functions.sh" --source-only
+
+cargo fmt --all -- --check
+
+test_package_with_feature primitives default
+test_package_with_feature primitives std
+
+for package in zrml/*
+do
+  test_package_with_feature "$package" std
+done
+
+test_package_with_feature zrml/prediction-markets std,runtime-benchmarks
+test_package_with_feature zrml/swaps std,runtime-benchmarks

--- a/scripts/tests/parachain.sh
+++ b/scripts/tests/parachain.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Parachain node: Runtime and node directories
+
+set -euxo pipefail
+
+. "$(dirname "$0")/aux-functions.sh" --source-only
+
+build_package_with_feature runtime std,parachain
+
+build_package_with_feature node default,parachain

--- a/scripts/tests/parachain.sh
+++ b/scripts/tests/parachain.sh
@@ -6,6 +6,6 @@ set -euxo pipefail
 
 . "$(dirname "$0")/aux-functions.sh" --source-only
 
-build_package_with_feature runtime std,parachain
+check_package_with_feature runtime std,parachain
 
-build_package_with_feature node default,parachain
+check_package_with_feature node default,parachain

--- a/scripts/tests/standalone.sh
+++ b/scripts/tests/standalone.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Standalone node: Runtime and node directories
+
+set -euxo pipefail
+
+. "$(dirname "$0")/aux-functions.sh" --source-only
+
+build_package_with_feature runtime std
+
+build_package_with_feature node default

--- a/scripts/tests/standalone.sh
+++ b/scripts/tests/standalone.sh
@@ -6,6 +6,6 @@ set -euxo pipefail
 
 . "$(dirname "$0")/aux-functions.sh" --source-only
 
-build_package_with_feature runtime std
+check_package_with_feature runtime std
 
-build_package_with_feature node default
+check_package_with_feature node default

--- a/scripts/tests/wasm.sh
+++ b/scripts/tests/wasm.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# WASM runtimes
+
+set -euxo pipefail
+
+. "$(dirname "$0")/aux-functions.sh" --source-only
+
+WASM_BUILD_TYPE=release cargo build --manifest-path runtime/Cargo.toml
+WASM_BUILD_TYPE=release cargo build --features parachain --manifest-path runtime/Cargo.toml


### PR DESCRIPTION
The current CI checking for tests doesn't take into account some features like `parachain` and `runtime-benchmarks`, which brings building failures into `master` that are eventually fixed over time but shouldn't even exist.

To give a better testing coverage, a new `all-sequential.sh` script were included for dev and CI usage. So, once `./scripts/tests/all-sequential.sh` is successful, it is guaranteed that CI will also succeed.