### PR TITLE
Reverts prefix to 42

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -95,7 +95,7 @@ parameter_types! {
   pub const GetNativeCurrencyId: Asset<MarketId> = Asset::Ztg;
   pub const MaxLocks: u32 = 50;
   pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
-  pub const SS58Prefix: u8 = 73;
+  pub const SS58Prefix: u8 = 42; // @TODO: Change back to 73 once https://github.com/paritytech/substrate/pull/8509 is merged
   pub const TransactionByteFee: Balance = 1 * MILLICENTS;
   pub const Version: RuntimeVersion = VERSION;
   pub DustAccount: AccountId = PalletId(*b"orml/dst").into_account();


### PR DESCRIPTION
Temporarily reverts prefix to 42 so we don't break Polkadot-JS Apps while we wait for our prefix PR to be merged.