### PR TITLE
Add lower category bound

### DIFF
--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -19,6 +19,7 @@ parameter_types! {
     pub const DisputeBond: Balance = 5 * BASE;
     pub const DisputeFactor: Balance = 2 * BASE;
     pub const DisputePeriod: BlockNumber = DAYS;
+    pub const MinCategories: u16 = 2;
     pub const MaxCategories: u16 = 8;
     pub const MaxDisputes: u16 = 6;
     pub const PmPalletId: PalletId = PalletId(*b"zge/pred");

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -334,6 +334,7 @@ impl zrml_prediction_markets::Config for Runtime {
     type DisputePeriod = DisputePeriod;
     type Event = Event;
     type MarketId = MarketId;
+    type MinCategories = MinCategories;
     type MaxCategories = MaxCategories;
     type MaxDisputes = MaxDisputes;
     type PalletId = PmPalletId;

--- a/zrml/prediction-markets/src/benchmarks.rs
+++ b/zrml/prediction-markets/src/benchmarks.rs
@@ -181,7 +181,7 @@ fn setup_resolve_common_scalar<T: Config>(
 benchmarks! {
     admin_destroy_disputed_market{
         // a = total accounts
-        // A higher number increases the benchmark runtime significantly, while increasing the
+        // An higher number increases the benchmark runtime significantly, while increasing the
         // error due to a lower number of repetitions (the data points that are used to approximate
         // the weight function weight(a) are less precise).
         // The required weight per account is a linear function of degree 1, i.e.
@@ -194,7 +194,7 @@ benchmarks! {
         // Unfortunately frame-benchmarking does not allow to b = b.min(a) here
         let b in 0..10;
         // c = num. asset types
-        let c in 0..T::MaxCategories::get() as u32;
+        let c in (T::MinCategories::get() as u32)..(T::MaxCategories::get() as u32);
         // Complexity: c*a + c*b ∈ O(a)
 
         let c_u16 = c.saturated_into();
@@ -215,7 +215,7 @@ benchmarks! {
         // b = num. accounts with assets
         let b in 0..10;
         // c = num. asset types
-        let c in 0..T::MaxCategories::get() as u32;
+        let c in (T::MinCategories::get() as u32)..(T::MaxCategories::get() as u32);
         // Complexity: c*a + c*b ∈ O(a)
 
         let c_u16 = c.saturated_into();
@@ -256,7 +256,7 @@ benchmarks! {
     }: { call.dispatch_bypass_filter(origin)? }
 
     buy_complete_set {
-        let a in 0..T::MaxCategories::get() as u32;
+        let a in (T::MinCategories::get() as u32)..(T::MaxCategories::get() as u32);
         let (caller, marketid) = create_market_common::<T>(
             MarketCreation::Advised,
             MarketType::Categorical(a.saturated_into())
@@ -284,7 +284,7 @@ benchmarks! {
     }: _(RawOrigin::Signed(caller), oracle, end, metadata, creation, outcome_range)
 
     deploy_swap_pool_for_market {
-        let a in 0..T::MaxCategories::get() as u32;
+        let a in (T::MinCategories::get() as u32)..(T::MaxCategories::get() as u32);
         let (caller, marketid) = create_market_common::<T>(
             MarketCreation::Permissionless,
             MarketType::Categorical(a.saturated_into())
@@ -316,7 +316,7 @@ benchmarks! {
         // b = num. accounts with assets
         let b in 0..10;
         // c = num. asset types
-        let c in 0..T::MaxCategories::get() as u32;
+        let c in (T::MinCategories::get() as u32)..(T::MaxCategories::get() as u32);
 
         let c_u16 = c.saturated_into();
         let (_, marketid) = setup_resolve_common_categorical::<T>(a, b, c_u16)?;
@@ -328,7 +328,7 @@ benchmarks! {
         // b = num. accounts with assets
         let b in 0..10;
         // c = num. asset types
-        let c in 0..T::MaxCategories::get() as u32;
+        let c in (T::MinCategories::get() as u32)..(T::MaxCategories::get() as u32);
         // d = num. disputes
         let d in 0..T::MaxDisputes::get() as u32;
 
@@ -398,7 +398,7 @@ benchmarks! {
     }: _(RawOrigin::Signed(caller), marketid, outcome)
 
     sell_complete_set {
-        let a in 0..T::MaxCategories::get() as u32;
+        let a in (T::MinCategories::get() as u32)..(T::MaxCategories::get() as u32);
         let (caller, marketid) = create_market_common::<T>(
             MarketCreation::Advised,
             MarketType::Categorical(a.saturated_into())

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -320,8 +320,14 @@ mod pallet {
             let sender = ensure_signed(origin)?;
             Self::ensure_create_market_end(end)?;
 
-            ensure!(categories >= T::MinCategories::get(), <Error<T>>::NotEnoughCategories);
-            ensure!(categories <= T::MaxCategories::get(), <Error<T>>::TooManyCategories);
+            ensure!(
+                categories >= T::MinCategories::get(),
+                <Error<T>>::NotEnoughCategories
+            );
+            ensure!(
+                categories <= T::MaxCategories::get(),
+                <Error<T>>::TooManyCategories
+            );
 
             let status: MarketStatus = match creation {
                 MarketCreation::Permissionless => {

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -320,10 +320,8 @@ mod pallet {
             let sender = ensure_signed(origin)?;
             Self::ensure_create_market_end(end)?;
 
-            ensure!(
-                categories <= T::MaxCategories::get(),
-                "Cannot exceed max categories for a new market."
-            );
+            ensure!(categories >= T::MinCategories::get(), <Error<T>>::NotEnoughCategories);
+            ensure!(categories <= T::MaxCategories::get(), <Error<T>>::TooManyCategories);
 
             let status: MarketStatus = match creation {
                 MarketCreation::Permissionless => {
@@ -827,6 +825,9 @@ mod pallet {
             + Member
             + Parameter;
 
+        /// The minimum number of categories available for categorical markets.
+        type MinCategories: Get<u16>;
+
         /// The maximum number of categories available for categorical markets.
         type MaxCategories: Get<u16>;
 
@@ -872,6 +873,8 @@ mod pallet {
         InsufficientFundsInMarketAccount,
         /// Sender does not have enough share balance.
         InsufficientShareBalance,
+        /// An invalid market type was found.
+        InvalidMarketType,
         /// A market with the provided ID does not exist.
         MarketDoesNotExist,
         /// The market status is something other than active.
@@ -896,6 +899,8 @@ mod pallet {
         MarketNotResolved,
         /// The maximum number of disputes has been reached.
         MaxDisputesReached,
+        /// The number of categories for a categorical market is too low
+        NotEnoughCategories,
         /// The user has no winning balance.
         NoWinningBalance,
         /// The report is not coming from designated oracle.
@@ -904,8 +909,8 @@ mod pallet {
         ShareBalanceTooLow,
         /// A swap pool already exists for this market.
         SwapPoolExists,
-        /// An invalid market type was found.
-        InvalidMarketType,
+        /// Too many categories for a categorical market
+        TooManyCategories,
     }
 
     #[pallet::event]

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -14,8 +14,8 @@ use sp_runtime::{
 };
 use zeitgeist_primitives::{
     constants::{
-        ExitFee, MaxAssets, MinCategories, MaxCategories, MaxDisputes, MaxInRatio, MaxOutRatio,
-        MaxTotalWeight, MaxWeight, MinLiquidity, MinWeight, BASE,
+        ExitFee, MaxAssets, MaxCategories, MaxDisputes, MaxInRatio, MaxOutRatio, MaxTotalWeight,
+        MaxWeight, MinCategories, MinLiquidity, MinWeight, BASE,
     },
     types::{
         AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -14,8 +14,8 @@ use sp_runtime::{
 };
 use zeitgeist_primitives::{
     constants::{
-        ExitFee, MaxAssets, MaxCategories, MaxDisputes, MaxInRatio, MaxOutRatio, MaxTotalWeight,
-        MaxWeight, MinLiquidity, MinWeight, BASE,
+        ExitFee, MaxAssets, MinCategories, MaxCategories, MaxDisputes, MaxInRatio, MaxOutRatio,
+        MaxTotalWeight, MaxWeight, MinLiquidity, MinWeight, BASE,
     },
     types::{
         AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
@@ -93,6 +93,7 @@ impl crate::Config for Runtime {
     type DisputePeriod = DisputePeriod;
     type Event = Event;
     type MarketId = MarketId;
+    type MinCategories = MinCategories;
     type MaxCategories = MaxCategories;
     type MaxDisputes = MaxDisputes;
     type PalletId = PmPalletId;

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{market::*, mock::*, Error, Config};
+use crate::{market::*, mock::*, Config, Error};
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchError, traits::Get};
 use orml_traits::MultiCurrency;
 use sp_core::H256;
@@ -47,28 +47,34 @@ fn it_creates_binary_markets() {
 #[test]
 fn it_does_not_create_market_with_too_few_categories() {
     ExtBuilder::default().build().execute_with(|| {
-        assert_noop!(PredictionMarkets::create_categorical_market(
-            Origin::signed(ALICE),
-            BOB,
-            MarketEnd::Block(100),
-            gen_metadata(2),
-            MarketCreation::Advised,
-            <Runtime as Config>::MinCategories::get() - 1
-        ), Error::<Runtime>::NotEnoughCategories);
+        assert_noop!(
+            PredictionMarkets::create_categorical_market(
+                Origin::signed(ALICE),
+                BOB,
+                MarketEnd::Block(100),
+                gen_metadata(2),
+                MarketCreation::Advised,
+                <Runtime as Config>::MinCategories::get() - 1
+            ),
+            Error::<Runtime>::NotEnoughCategories
+        );
     });
 }
 
 #[test]
 fn it_does_not_create_market_with_too_many_categories() {
     ExtBuilder::default().build().execute_with(|| {
-        assert_noop!(PredictionMarkets::create_categorical_market(
-            Origin::signed(ALICE),
-            BOB,
-            MarketEnd::Block(100),
-            gen_metadata(2),
-            MarketCreation::Advised,
-            <Runtime as Config>::MaxCategories::get() + 1
-        ), Error::<Runtime>::TooManyCategories);
+        assert_noop!(
+            PredictionMarkets::create_categorical_market(
+                Origin::signed(ALICE),
+                BOB,
+                MarketEnd::Block(100),
+                gen_metadata(2),
+                MarketCreation::Advised,
+                <Runtime as Config>::MaxCategories::get() + 1
+            ),
+            Error::<Runtime>::TooManyCategories
+        );
     });
 }
 

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -508,31 +508,31 @@ mod pallet {
     where
         T: Config,
     {
-        /// A new pool has been created.
+        /// A new pool has been created. \[account\]
         PoolCreate(CommonPoolEventParams<<T as frame_system::Config>::AccountId>),
-        /// Someone has exited a pool.
+        /// Someone has exited a pool. \[account, amount\]
         PoolExit(PoolAssetsEvent<<T as frame_system::Config>::AccountId, BalanceOf<T>>),
-        /// Exists a pool given an exact amount of an asset
+        /// Exits a pool given an exact amount of an asset. \[account, amount\]
         PoolExitWithExactAssetAmount(
             PoolAssetEvent<<T as frame_system::Config>::AccountId, BalanceOf<T>>,
         ),
-        /// Exists a pool given an exact pool's amount
+        /// Exits a pool given an exact pool's amount. \[account, amount\]
         PoolExitWithExactPoolAmount(
             PoolAssetEvent<<T as frame_system::Config>::AccountId, BalanceOf<T>>,
         ),
-        /// Someone has joined a pool.
+        /// Someone has joined a pool. \[account, amount\]
         PoolJoin(PoolAssetsEvent<<T as frame_system::Config>::AccountId, BalanceOf<T>>),
-        /// Joins a pool given an exact amount of an asset
+        /// Joins a pool given an exact amount of an asset. \[account, amount\]
         PoolJoinWithExactAssetAmount(
             PoolAssetEvent<<T as frame_system::Config>::AccountId, BalanceOf<T>>,
         ),
-        /// Joins a pool given an exact pool's amount
+        /// Joins a pool given an exact pool's amount. \[account, amount\]
         PoolJoinWithExactPoolAmount(
             PoolAssetEvent<<T as frame_system::Config>::AccountId, BalanceOf<T>>,
         ),
-        /// An exact amount of an asset is entering the pool
+        /// An exact amount of an asset is entering the pool. \[account, amount\]
         SwapExactAmountIn(SwapEvent<<T as frame_system::Config>::AccountId, BalanceOf<T>>),
-        /// An exact amount of an asset is leaving the pool
+        /// An exact amount of an asset is leaving the pool. \[account, amount\]
         SwapExactAmountOut(SwapEvent<<T as frame_system::Config>::AccountId, BalanceOf<T>>),
     }
 


### PR DESCRIPTION
**Issue**
#87 (also fixes #71)

**Solution**
Add `MinCategories = 2` constant to *prediction_markets* pallet, which is used to specify the lower category bound for calls to `create_categorical_market`. Also updates tests and benchmarks. Argument names for events in *swaps* pallet have also been added.