### PR TITLE
Fix potential storage corruption in sell_complete_set

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -96,7 +96,7 @@ parameter_types! {
   pub const MaxLocks: u32 = 50;
   pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
   pub const SS58Prefix: u8 = 42; // @TODO: Change back to 73 once https://github.com/paritytech/substrate/pull/8509 is merged
-  pub const TransactionByteFee: Balance = 1 * MILLICENTS;
+  pub const TransactionByteFee: Balance = 10 * MILLICENTS;
   pub const Version: RuntimeVersion = VERSION;
   pub DustAccount: AccountId = PalletId(*b"orml/dst").into_account();
   pub RuntimeBlockLength: BlockLength = BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -770,6 +770,7 @@ mod pallet {
 
             let assets = Self::outcome_assets(market_id, market);
 
+            // verify first.
             for asset in assets.iter() {
                 // Ensures that the sender has sufficient amount of each
                 // share in the set.
@@ -777,7 +778,10 @@ mod pallet {
                     T::Shares::free_balance(*asset, &sender) >= amount,
                     Error::<T>::InsufficientShareBalance,
                 );
+            }
 
+            // write last.
+            for asset in assets.iter() {
                 T::Shares::slash(*asset, &sender, amount);
             }
 

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -90,6 +90,7 @@ mod pallet {
             Currency, EnsureOrigin, ExistenceRequirement, Get, Hooks, Imbalance, IsType,
             OnUnbalanced, ReservableCurrency, Time,
         },
+        transactional,
         Blake2_128Concat, PalletId, Parameter,
     };
     use frame_system::{ensure_signed, pallet_prelude::OriginFor};
@@ -272,6 +273,7 @@ mod pallet {
         #[pallet::weight(
             T::WeightInfo::buy_complete_set(T::MaxCategories::get() as u32)
         )]
+        #[transactional]
         pub fn buy_complete_set(
             origin: OriginFor<T>,
             market_id: T::MarketId,
@@ -419,7 +421,7 @@ mod pallet {
         #[pallet::weight(
             T::WeightInfo::deploy_swap_pool_for_market(weights.len() as u32)
         )]
-        #[frame_support::transactional]
+        #[transactional]
         pub fn deploy_swap_pool_for_market(
             origin: OriginFor<T>,
             market_id: T::MarketId,

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -90,8 +90,7 @@ mod pallet {
             Currency, EnsureOrigin, ExistenceRequirement, Get, Hooks, Imbalance, IsType,
             OnUnbalanced, ReservableCurrency, Time,
         },
-        transactional,
-        Blake2_128Concat, PalletId, Parameter,
+        transactional, Blake2_128Concat, PalletId, Parameter,
     };
     use frame_system::{ensure_signed, pallet_prelude::OriginFor};
     use orml_traits::MultiCurrency;


### PR DESCRIPTION
Issue: #89 

Fix: Verify first, write last. This PR also updates `TransactionByteFee` from `1 * MILLICENTS` to `10 * MILLICENTS`, based on the example of Polkadot.