### PR TITLE
Define maximum metadata size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11482,6 +11482,7 @@ dependencies = [
 name = "zeitgeist-primitives"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "frame-support",
  "frame-system",
  "orml-currencies",

--- a/misc/types.json
+++ b/misc/types.json
@@ -79,6 +79,11 @@
       "Resolved"
     ]
   },
+  "MultiHash": {
+    "_enum": {
+      "Sha3_384": "[u8; 50]"
+    }
+  },
   "Order": {
     "side": "OrderSide",
     "maker": "AccountId",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+arbitrary = { version = "1.0", default-features = false, optional = true }
 frame-support = { branch = "rococo-v1", default-features = false, git = "https://github.com/paritytech/substrate" }
 frame-system = { branch = "rococo-v1", default-features = false, git = "https://github.com/paritytech/substrate" }
 orml-currencies = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library" }
@@ -12,6 +13,7 @@ sp-runtime = { branch = "rococo-v1", default-features = false, git = "https://gi
 [features]
 default = ["std"]
 std = [
+    "arbitrary",
     "frame-support/std",
     "frame-system/std",
     "orml-currencies/std",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -13,7 +13,6 @@ sp-runtime = { branch = "rococo-v1", default-features = false, git = "https://gi
 [features]
 default = ["std"]
 std = [
-    "arbitrary",
     "frame-support/std",
     "frame-system/std",
     "orml-currencies/std",

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -30,6 +30,12 @@ pub type BlockNumber = u64;
 /// The index of the category for a `CategoricalOutcome` asset.
 pub type CategoryIndex = u16;
 
+/// Multihash for digest sizes up to 384 bit.
+/// The multicodec encoding the hash algorithm uses only 1 byte,
+/// effecitvely limiting the number of available hash types.
+/// HashType (1B) + DigestSize (1B) + Hash (48B).
+pub type MultiHashSha384 = [u8; 50];
+
 pub type CurrencyId = Asset<MarketId>;
 
 /// Index of a transaction in the chain.

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -4,6 +4,11 @@ pub use crate::outcome_report::OutcomeReport;
 pub use crate::pool::Pool;
 pub use crate::pool_status::PoolStatus;
 pub use crate::serde_wrapper::*;
+
+#[cfg(feature = "std")]
+use arbitrary::{Arbitrary, Result, Unstructured};
+
+use frame_support::dispatch::{Decode, Encode};
 use sp_runtime::{
     generic,
     traits::{IdentifyAccount, Verify},
@@ -34,7 +39,27 @@ pub type CategoryIndex = u16;
 /// The multicodec encoding the hash algorithm uses only 1 byte,
 /// effecitvely limiting the number of available hash types.
 /// HashType (1B) + DigestSize (1B) + Hash (48B).
-pub type MultiHashSha384 = [u8; 50];
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+pub enum MultiHash {
+    Sha3_384([u8; 50]),
+}
+
+// Implmenetation for the fuzzer
+#[cfg(feature = "std")]
+impl<'a> Arbitrary<'a> for MultiHash {
+    fn arbitrary(_: &mut Unstructured<'a>) -> Result<Self> {
+        Ok(MultiHash::Sha3_384([0u8; 50]))
+    }
+
+    fn arbitrary_take_rest(mut u: Unstructured<'a>) -> Result<Self> {
+        Self::arbitrary(&mut u)
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let _ = depth;
+        (0, None)
+    }
+}
 
 pub type CurrencyId = Asset<MarketId>;
 

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -5,7 +5,7 @@ pub use crate::pool::Pool;
 pub use crate::pool_status::PoolStatus;
 pub use crate::serde_wrapper::*;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Result, Unstructured};
 
 use frame_support::dispatch::{Decode, Encode};
@@ -45,7 +45,7 @@ pub enum MultiHash {
 }
 
 // Implementation for the fuzzer
-#[cfg(feature = "std")]
+#[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for MultiHash {
     fn arbitrary(_: &mut Unstructured<'a>) -> Result<Self> {
         Ok(MultiHash::Sha3_384([0u8; 50]))

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -44,7 +44,7 @@ pub enum MultiHash {
     Sha3_384([u8; 50]),
 }
 
-// Implmenetation for the fuzzer
+// Implementation for the fuzzer
 #[cfg(feature = "std")]
 impl<'a> Arbitrary<'a> for MultiHash {
     fn arbitrary(_: &mut Unstructured<'a>) -> Result<Self> {

--- a/zrml/prediction-markets/fuzz/Cargo.toml
+++ b/zrml/prediction-markets/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ test = false
 arbitrary = { features = ["derive"], version = "1.0" }
 frame-support = { branch = "rococo-v1", default-features = false, git = "https://github.com/paritytech/substrate" }
 libfuzzer-sys = "0.4"
-zeitgeist-primitives = { default-features = false, path = "../../../primitives" }
+zeitgeist-primitives = { features = ["arbitrary"], default-features = false, path = "../../../primitives" }
 zrml-prediction-markets = { features = ["mock"], path = ".." }
 
 [package]

--- a/zrml/prediction-markets/fuzz/full_workflow.rs
+++ b/zrml/prediction-markets/fuzz/full_workflow.rs
@@ -1,8 +1,9 @@
 #![no_main]
 
+use arbitrary::Arbitrary;
 use frame_support::traits::Hooks;
 use libfuzzer_sys::fuzz_target;
-use zeitgeist_primitives::types::{MarketCreation, MarketEnd, OutcomeReport};
+use zeitgeist_primitives::types::{MarketCreation, MarketEnd, MultiHash, OutcomeReport};
 use zrml_prediction_markets::mock::{ExtBuilder, Origin, PredictionMarkets, System};
 
 fuzz_target!(|data: Data| {
@@ -59,12 +60,12 @@ fuzz_target!(|data: Data| {
     let _ = ext.commit_all();
 });
 
-#[derive(Debug, arbitrary::Arbitrary)]
+#[derive(Debug, Arbitrary)]
 struct Data {
     create_scalar_market_origin: u8,
     create_scalar_market_oracle: u8,
     create_scalar_market_timestamp: u64,
-    create_scalar_market_metadata: Vec<u8>,
+    create_scalar_market_metadata: MultiHash,
     create_scalar_market_creation: u8,
     create_scalar_market_outcome_range: (u128, u128),
 

--- a/zrml/prediction-markets/src/benchmarks.rs
+++ b/zrml/prediction-markets/src/benchmarks.rs
@@ -4,9 +4,7 @@ use super::*;
 use crate::Config;
 #[cfg(test)]
 use crate::Pallet as PredictionMarket;
-use frame_benchmarking::{
-    account, benchmarks, impl_benchmark_test_suite, vec, whitelisted_caller, Vec,
-};
+use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, vec, whitelisted_caller};
 use frame_support::{
     dispatch::UnfilteredDispatchable,
     traits::{Currency, EnsureOrigin, Get, Hooks},
@@ -17,8 +15,7 @@ use sp_runtime::traits::SaturatedConversion;
 use zeitgeist_primitives::{
     constants::{MinLiquidity, MinWeight, BASE},
     types::{
-        Asset, MarketCreation, MarketEnd, MarketType, MultiHashSha384, OutcomeReport,
-        ScalarPosition
+        Asset, MarketCreation, MarketEnd, MarketType, MultiHash, OutcomeReport, ScalarPosition,
     },
 };
 
@@ -31,7 +28,7 @@ fn create_market_common_parameters<T: Config>(
         T::AccountId,
         T::AccountId,
         MarketEnd<T::BlockNumber>,
-        MultiHashSha384,
+        MultiHash,
         MarketCreation,
     ),
     &'static str,
@@ -44,7 +41,7 @@ fn create_market_common_parameters<T: Config>(
     metadata[0] = 0x15;
     metadata[1] = 0x30;
     let creation = permission;
-    Ok((caller, oracle, end, metadata, creation))
+    Ok((caller, oracle, end, MultiHash::Sha3_384(metadata), creation))
 }
 
 // Create a market based on common parameters

--- a/zrml/prediction-markets/src/benchmarks.rs
+++ b/zrml/prediction-markets/src/benchmarks.rs
@@ -16,7 +16,10 @@ use orml_traits::MultiCurrency;
 use sp_runtime::traits::SaturatedConversion;
 use zeitgeist_primitives::{
     constants::{MinLiquidity, MinWeight, BASE},
-    types::{Asset, MarketCreation, MarketEnd, MarketType, OutcomeReport, ScalarPosition},
+    types::{
+        Asset, MarketCreation, MarketEnd, MarketType, MultiHashSha384, OutcomeReport,
+        ScalarPosition
+    },
 };
 
 // Get default values for market creation. Also spawns an account with maximum
@@ -28,7 +31,7 @@ fn create_market_common_parameters<T: Config>(
         T::AccountId,
         T::AccountId,
         MarketEnd<T::BlockNumber>,
-        Vec<u8>,
+        MultiHashSha384,
         MarketCreation,
     ),
     &'static str,
@@ -37,7 +40,9 @@ fn create_market_common_parameters<T: Config>(
     let _ = T::Currency::deposit_creating(&caller, (u128::MAX).saturated_into());
     let oracle = caller.clone();
     let end = <MarketEnd<T::BlockNumber>>::Block((u128::MAX).saturated_into());
-    let metadata = <Vec<u8>>::new();
+    let mut metadata = [0u8; 50];
+    metadata[0] = 0x15;
+    metadata[1] = 0x30;
     let creation = permission;
     Ok((caller, oracle, end, metadata, creation))
 }

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -308,7 +308,7 @@ mod pallet {
             origin: OriginFor<T>,
             oracle: T::AccountId,
             end: MarketEnd<T::BlockNumber>,
-            metadata: MultiHashSha384,
+            metadata: MultiHash,
             creation: MarketCreation,
             categories: u16,
         ) -> DispatchResult {
@@ -323,9 +323,11 @@ mod pallet {
                 categories <= T::MaxCategories::get(),
                 <Error<T>>::TooManyCategories
             );
+
             // Require sha3-384 as multihash.
+            let MultiHash::Sha3_384(multihash) = metadata;
             ensure!(
-                metadata[0] == 0x15 && metadata[1] == 0x30,
+                multihash[0] == 0x15 && multihash[1] == 0x30,
                 <Error<T>>::InvalidMultihash
             );
 
@@ -350,7 +352,7 @@ mod pallet {
                 creator_fee: 0,
                 oracle,
                 end,
-                metadata: Vec::from(metadata),
+                metadata: Vec::from(multihash),
                 market_type: MarketType::Categorical(categories),
                 status,
                 report: None,
@@ -369,7 +371,7 @@ mod pallet {
             origin: OriginFor<T>,
             oracle: T::AccountId,
             end: MarketEnd<T::BlockNumber>,
-            metadata: MultiHashSha384,
+            metadata: MultiHash,
             creation: MarketCreation,
             outcome_range: (u128, u128),
         ) -> DispatchResult {
@@ -377,9 +379,11 @@ mod pallet {
             Self::ensure_create_market_end(end)?;
 
             ensure!(outcome_range.0 < outcome_range.1, "Invalid range provided.");
+
             // Require sha3-384 as multihash.
+            let MultiHash::Sha3_384(multihash) = metadata;
             ensure!(
-                metadata[0] == 0x15 && metadata[1] == 0x30,
+                multihash[0] == 0x15 && multihash[1] == 0x30,
                 <Error<T>>::InvalidMultihash
             );
 
@@ -403,7 +407,7 @@ mod pallet {
                 creator_fee: 0,
                 oracle,
                 end,
-                metadata: Vec::from(metadata),
+                metadata: Vec::from(multihash),
                 market_type: MarketType::Scalar(outcome_range),
                 status,
                 report: None,

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -110,12 +110,12 @@ mod pallet {
         /// in for production
         #[pallet::weight(
             T::WeightInfo::admin_destroy_reported_market(
-                80_000,
-                80_000,
+                4_500,
+                4_500,
                 T::MaxCategories::get() as u32
             ).max(T::WeightInfo::admin_destroy_disputed_market(
-                80_000,
-                80_000,
+                4_500,
+                4_500,
                 T::MaxCategories::get() as u32
             ))
         )]

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -11,16 +11,16 @@ use sp_runtime::traits::AccountIdConversion;
 use zeitgeist_primitives::{
     constants::BASE,
     types::{
-        Asset, Market, MarketCreation, MarketEnd, MarketStatus, MultiHashSha384 OutcomeReport,
+        Asset, Market, MarketCreation, MarketEnd, MarketStatus, MultiHash, OutcomeReport,
         ScalarPosition,
     },
 };
 
-fn gen_metadata(byte: u8) -> MultiHashSha384 {
+fn gen_metadata(byte: u8) -> MultiHash {
     let mut metadata = [byte; 50];
     metadata[0] = 0x15;
     metadata[1] = 0x30;
-    metadata
+    MultiHash::Sha3_384(metadata)
 }
 
 fn simple_create_categorical_market<T: crate::Config>(creation: MarketCreation) {

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -7,17 +7,20 @@ use frame_support::{
     traits::Get,
 };
 use orml_traits::MultiCurrency;
-use sp_core::H256;
 use sp_runtime::traits::AccountIdConversion;
 use zeitgeist_primitives::{
     constants::BASE,
     types::{
-        Asset, Market, MarketCreation, MarketEnd, MarketStatus, OutcomeReport, ScalarPosition,
+        Asset, Market, MarketCreation, MarketEnd, MarketStatus, MultiHashSha384 OutcomeReport,
+        ScalarPosition,
     },
 };
 
-fn gen_metadata(byte: u8) -> Vec<u8> {
-    H256::repeat_byte(byte).to_fixed_bytes().to_vec()
+fn gen_metadata(byte: u8) -> MultiHashSha384 {
+    let mut metadata = [byte; 50];
+    metadata[0] = 0x15;
+    metadata[1] = 0x30;
+    metadata
 }
 
 fn simple_create_categorical_market<T: crate::Config>(creation: MarketCreation) {


### PR DESCRIPTION
Issue: #83 

**Solution**
This PR introduces a static length type, that represents a [multihash](multiformats.io/multihash/) (used in IPFS CIDv1) for the `metadata` in `create_categorical_market` and `create_scalar_market`. The changes have to be discussed, details follow below.
In addition, weight parameters for some functions have been changed. Before the maximum values were calculated wrong, which lead to overweight transactions. This has been fixed. If you are interested in the relatively accurately calculated system capacity, search for *0.75* in the discord *tech* channel.

**CIDv1 multiformat**
Data in IPFS is referenced using an old CIDv0 or CIDv1 multiformat. I suggest we apply the new CIDv1 standard.
According to [multiformat Github repository](https://github.com/multiformats/cid#how-does-it-work):
> \<cidv1> ::= \<mb>\<multicodec-cidv1>\<mc>\<mh>
> \# or, expanded:
> \<cidv1> ::= \<multibase-prefix>\<multicodec-cidv1>\<multicodec-content-type>\<multihash-content-address>

**Distinguishing which project does what**
Those are the elements, split into what different components of the zeitgeist project should do:
- multibase-prefix - appendend in SDK (depends on encoding)
- multicodec-cid - appendend in SDK (currently [CIDv1 0x01](https://github.com/multiformats/multicodec/blob/master/table.csv#L3))
- multicodec-content-type - appended in SDK (we can use [json 0x0200](https://github.com/multiformats/multicodec/blob/master/table.csv#L114) once it is ready, but this type is currently not supported and instead the [raw content type 0x85](https://github.com/multiformats/multicodec/blob/master/table.csv#L38) is used for json files)
- multihash-content-address - hash pointer to the actual data including information about the hash algorithm -> stored in chain storage

**Analysis of the used hash function for metadata IPFS references**
I suggest we use sha3-384 for ipfs hashes, which is already a [permanent multihash](https://github.com/multiformats/multicodec/blob/master/table.csv#L12). I have choosen sha3-384 over sha3-256, because according to [this paper](https://arxiv.org/pdf/quant-ph/9705002.pdf), the security in terms of collision resistance against quantum computers for sha3-256 could be only about 85 bits, which could realistically lead to collision attacks and consequently overshadow our market metadata in the near future. In contrast to sha3-256, sha3-384 still delivers 128 bit security against collision attacks, which is sufficient. I have decided against sha3-512 to save storage space in the long-term, the extra security is not required based on the current state of research. Using sha3-512 would requires 16 bytes more per market, in the very long term we want to save those if possible.

**Result**
This leads to a total requirement of
1 + 1 + 48 = 50 bytes [multihash](multiformats.io/multihash/)
for the market metadata within an extrinsic. 1 byte for the [sha3-384 multihash identifier (0x15)](https://github.com/multiformats/multicodec/blob/master/table.csv#L12), 1 byte for the length (0x30) and 48 bytes for the hash.

This format constraints the hash functions to hash functions which have an 1 byte identifier in the [multicodec table](https://github.com/multiformats/multicodec/blob/master/table.csv). The constraints regarding the hash functions are just limitations in regards to the signature of the dispatchable function, internally our chain will store this data as arbitrary length byte vectors, effectively allowing us to upgrade the function signature to support any hash function, while at the same time avoiding arbitrary storage population due to the limitations in the metadata function parameter.