### PR TITLE
Build optimized binaries on CI

### DIFF
--- a/scripts/tests/aux-functions.sh
+++ b/scripts/tests/aux-functions.sh
@@ -15,5 +15,5 @@ test_package_with_feature() {
     local features=$2
 
     /bin/echo -e "\e[0;33m***** Testing '$package' with features '$features' *****\e[0m\n"
-    cargo test --features $features --manifest-path $package/Cargo.toml --no-default-features
+    cargo test --features $features --manifest-path $package/Cargo.toml --no-default-features --release
 }

--- a/scripts/tests/clippy.sh
+++ b/scripts/tests/clippy.sh
@@ -2,7 +2,7 @@
 
 # Clippy with custom permissions
 
-cargo clippy --all-features -- \
+cargo clippy --all-features --release -- \
   -Dwarnings \
   -Aclippy::from_over_into \
   -Aclippy::let_and_return \

--- a/scripts/tests/wasm.sh
+++ b/scripts/tests/wasm.sh
@@ -6,5 +6,5 @@ set -euxo pipefail
 
 . "$(dirname "$0")/aux-functions.sh" --source-only
 
-WASM_BUILD_TYPE=release cargo build --manifest-path runtime/Cargo.toml
-WASM_BUILD_TYPE=release cargo build --features parachain --manifest-path runtime/Cargo.toml
+WASM_BUILD_TYPE=release cargo build --manifest-path runtime/Cargo.toml --release
+WASM_BUILD_TYPE=release cargo build --features parachain --manifest-path runtime/Cargo.toml --release


### PR DESCRIPTION
Non-optimized Substrate/Polkadot/Cumulus compilations generate very large binaries and CI sometimes doesn't complete a job because of `OutOfSpace` errors.

This PR is just a test to see if optimized builds have a large timing impact. If not, I think it is worth the addition. 