### PR TITLE
[Court] Add remaining tweaks for PM integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11869,7 +11869,19 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "zeitgeist-primitives",
+ "zrml-market-commons",
  "zrml-swaps",
+]
+
+[[package]]
+name = "zrml-market-commons"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "sp-runtime",
+ "zeitgeist-primitives",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "primitives",
     "runtime",
     "zrml/court",
+    "zrml/market-commons",
     "zrml/orderbook-v1",
     "zrml/prediction-markets",
     "zrml/prediction-markets/fuzz",

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -18,6 +18,11 @@ pub const DOLLARS: Balance = BASE / 100; // 100_000_000
 pub const CENTS: Balance = DOLLARS / 100; // 1_000_000
 pub const MILLICENTS: Balance = CENTS / 1000; // 1_000
 
+// Court parameters
+parameter_types! {
+    pub const CourtPalletId: PalletId = PalletId(*b"zge/cout");
+}
+
 // Prediction Market parameters
 parameter_types! {
     pub const AdvisoryBond: Balance = 25 * DOLLARS;
@@ -33,6 +38,11 @@ parameter_types! {
     pub const ValidityBond: Balance = 50 * DOLLARS;
 }
 
+// Staking parameters
+parameter_types! {
+    pub const DefaultBlocksPerRound: u32 = 2 * BLOCKS_PER_MINUTE as u32;
+}
+
 // Swaps parameters
 parameter_types! {
     pub const ExitFee: Balance = 0;
@@ -44,9 +54,4 @@ parameter_types! {
     pub const MinLiquidity: Balance = 100 * BASE;
     pub const MinWeight: Balance = BASE;
     pub const SwapsPalletId: PalletId = PalletId(*b"zge/swap");
-}
-
-// Collator staking
-parameter_types! {
-    pub const DefaultBlocksPerRound: u32 = 2 * BLOCKS_PER_MINUTE as u32;
 }

--- a/zrml/court/Cargo.toml
+++ b/zrml/court/Cargo.toml
@@ -5,6 +5,7 @@ frame-system = { branch = "polkadot-v0.9.3", default-features = false, git = "ht
 parity-scale-codec = { default-features = false, features = ["derive"], version = "2.0" }
 sp-runtime = { branch = "polkadot-v0.9.3", default-features = false, git = "https://github.com/paritytech/substrate" }
 zeitgeist-primitives = { default-features = false, path = "../../primitives" }
+zrml-market-commons = { default-features = false, path = "../market-commons" }
 
 [dev-dependencies]
 orml-currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library" }
@@ -23,6 +24,7 @@ std = [
     "parity-scale-codec/std",
     "sp-runtime/std",
     "zeitgeist-primitives/std",
+    "zrml-market-commons/std",
 ]
 runtime-benchmarks = ["frame-benchmarking"]
 

--- a/zrml/court/src/court_pallet_api.rs
+++ b/zrml/court/src/court_pallet_api.rs
@@ -1,11 +1,79 @@
-use frame_support::dispatch::{DispatchError, DispatchResultWithPostInfo, Weight};
-use zeitgeist_primitives::types::OutcomeReport;
+use crate::ResolutionCounters;
+use alloc::vec::Vec;
+use frame_support::dispatch::{DispatchError, DispatchResultWithPostInfo};
+use zeitgeist_primitives::types::{Market, MarketDispute, OutcomeReport};
 
 /// Court - Pallet Api
 pub trait CourtPalletApi {
+    type AccountId;
     type BlockNumber;
     type MarketId;
     type Origin;
+
+    // Market
+
+    /// Gets a market from the storage.
+    fn market(
+        market_id: &Self::MarketId,
+    ) -> Result<Market<Self::AccountId, Self::BlockNumber>, DispatchError>;
+
+    /// Inserts a market into the storage
+    fn insert_market(
+        market_id: &Self::MarketId,
+        market: Market<Self::AccountId, Self::BlockNumber>,
+    );
+
+    /// Mutates a given market storage
+    fn mutate_market<F>(market_id: &Self::MarketId, cb: F) -> Result<(), DispatchError>
+    where
+        F: FnOnce(&mut Market<Self::AccountId, Self::BlockNumber>);
+
+    /// Removes a market from the storage.
+    fn remove_market(market_id: &Self::MarketId) -> Result<(), DispatchError>;
+
+    // MarketIdPerDisputeBlock
+
+    /// Inserts a disputed market ids of a block into the storage
+    fn insert_market_id_per_dispute_block(
+        block: Self::BlockNumber,
+        market_ids: Vec<Self::MarketId>,
+    );
+
+    /// Gets all disputed market ids of a block from the storage.
+    fn market_ids_per_dispute_block(
+        block: &Self::BlockNumber,
+    ) -> Result<Vec<Self::MarketId>, DispatchError>;
+
+    // MarketIdPerReportBlock
+
+    /// Inserts a reported market ids of a block into the storage
+    fn insert_market_id_per_report_block(block: Self::BlockNumber, market_ids: Vec<Self::MarketId>);
+
+    /// Gets all reported market ids of a block from the storage.
+    fn market_ids_per_report_block(
+        block: &Self::BlockNumber,
+    ) -> Result<Vec<Self::MarketId>, DispatchError>;
+
+    /// Mutates a given set of reported market ids
+    fn mutate_market_ids_per_report_block<F>(
+        block: &Self::BlockNumber,
+        cb: F,
+    ) -> Result<(), DispatchError>
+    where
+        F: FnOnce(&mut Vec<Self::MarketId>);
+
+    // Misc
+
+    /// The number of stored disputes
+    fn disputes(
+        market_id: &Self::MarketId,
+    ) -> Result<Vec<MarketDispute<Self::AccountId, Self::BlockNumber>>, DispatchError>;
+
+    /// The stored disputing period
+    fn dispute_period() -> Self::BlockNumber;
+
+    /// The stored maximum number of disputes
+    fn max_disputes() -> u32;
 
     /// Disputes a reported outcome.
     fn on_dispute(
@@ -15,5 +83,5 @@ pub trait CourtPalletApi {
     ) -> DispatchResultWithPostInfo;
 
     /// Manages markets resolutions moving all reported markets to resolved.
-    fn on_resolution(now: Self::BlockNumber) -> Result<Weight, DispatchError>;
+    fn on_resolution(now: Self::BlockNumber) -> Result<ResolutionCounters, DispatchError>;
 }

--- a/zrml/court/src/court_pallet_api.rs
+++ b/zrml/court/src/court_pallet_api.rs
@@ -1,7 +1,7 @@
 use crate::ResolutionCounters;
 use alloc::vec::Vec;
 use frame_support::dispatch::{DispatchError, DispatchResultWithPostInfo};
-use zeitgeist_primitives::types::{Market, MarketDispute, OutcomeReport};
+use zeitgeist_primitives::types::{MarketDispute, OutcomeReport};
 
 /// Court - Pallet Api
 pub trait CourtPalletApi {
@@ -9,27 +9,6 @@ pub trait CourtPalletApi {
     type BlockNumber;
     type MarketId;
     type Origin;
-
-    // Market
-
-    /// Gets a market from the storage.
-    fn market(
-        market_id: &Self::MarketId,
-    ) -> Result<Market<Self::AccountId, Self::BlockNumber>, DispatchError>;
-
-    /// Inserts a market into the storage
-    fn insert_market(
-        market_id: &Self::MarketId,
-        market: Market<Self::AccountId, Self::BlockNumber>,
-    );
-
-    /// Mutates a given market storage
-    fn mutate_market<F>(market_id: &Self::MarketId, cb: F) -> Result<(), DispatchError>
-    where
-        F: FnOnce(&mut Market<Self::AccountId, Self::BlockNumber>);
-
-    /// Removes a market from the storage.
-    fn remove_market(market_id: &Self::MarketId) -> Result<(), DispatchError>;
 
     // MarketIdPerDisputeBlock
 

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -8,20 +8,22 @@ extern crate alloc;
 
 mod court_pallet_api;
 mod mock;
+mod resolution_counters;
 mod tests;
 
 pub use court_pallet_api::CourtPalletApi;
 pub use pallet::*;
+pub use resolution_counters::ResolutionCounters;
 
 #[frame_support::pallet]
 mod pallet {
-    use crate::CourtPalletApi;
-    use alloc::vec::Vec;
+    use crate::{CourtPalletApi, ResolutionCounters};
+    use alloc::{vec, vec::Vec};
     use core::{cmp, marker::PhantomData};
     use frame_support::{
         dispatch::{DispatchResult, DispatchResultWithPostInfo, Weight},
         ensure,
-        pallet_prelude::{StorageMap, ValueQuery},
+        pallet_prelude::StorageMap,
         traits::{Currency, Get, Hooks, Imbalance, IsType, ReservableCurrency},
         Blake2_128Concat, PalletId, Parameter,
     };
@@ -42,6 +44,8 @@ mod pallet {
     pub const NOT_RESOLVED: DispatchError = DispatchError::Other("Resolved outcome does not exist");
     pub const OUTCOME_MISMATCH: DispatchError =
         DispatchError::Other("Submitted outcome does not match market type");
+    pub const UNKNOWN_BLOCK: DispatchError = DispatchError::Other("Unknown block");
+    pub const UNKNOWN_MARKET_ID: DispatchError = DispatchError::Other("Unknown market id");
 
     pub(crate) type BalanceOf<T> =
         <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -79,7 +83,7 @@ mod pallet {
             + Parameter;
 
         /// The maximum number of disputes allowed on any single market.
-        type MaxDisputes: Get<u16>;
+        type MaxDisputes: Get<u32>;
 
         /// The base amount of currency that must be bonded to ensure the oracle reports
         ///  in a timely manner.
@@ -142,9 +146,108 @@ mod pallet {
     where
         T: Config,
     {
+        type AccountId = T::AccountId;
         type BlockNumber = T::BlockNumber;
         type MarketId = T::MarketId;
         type Origin = T::Origin;
+
+        // Market
+
+        fn market(
+            market_id: &Self::MarketId,
+        ) -> Result<Market<Self::AccountId, Self::BlockNumber>, DispatchError> {
+            <Markets<T>>::try_get(market_id).map_err(|_err| UNKNOWN_MARKET_ID)
+        }
+
+        fn mutate_market<F>(market_id: &Self::MarketId, cb: F) -> Result<(), DispatchError>
+        where
+            F: FnOnce(&mut Market<Self::AccountId, Self::BlockNumber>),
+        {
+            <Markets<T>>::try_mutate(market_id, |opt| {
+                if let Some(market) = opt {
+                    cb(market);
+                    return Ok(());
+                }
+                Err(UNKNOWN_MARKET_ID)
+            })
+        }
+
+        fn insert_market(
+            market_id: &Self::MarketId,
+            market: Market<Self::AccountId, Self::BlockNumber>,
+        ) {
+            <Markets<T>>::insert(market_id, market);
+        }
+
+        fn remove_market(market_id: &Self::MarketId) -> Result<(), DispatchError> {
+            if !<Markets<T>>::contains_key(market_id) {
+                return Err(UNKNOWN_MARKET_ID);
+            }
+            <Markets<T>>::remove(market_id);
+            Ok(())
+        }
+
+        // MarketIdPerDisputeBlock
+
+        fn insert_market_id_per_dispute_block(
+            block: Self::BlockNumber,
+            market_ids: Vec<Self::MarketId>,
+        ) {
+            MarketIdsPerDisputeBlock::<T>::insert(block, market_ids)
+        }
+
+        fn market_ids_per_dispute_block(
+            block: &Self::BlockNumber,
+        ) -> Result<Vec<Self::MarketId>, DispatchError> {
+            MarketIdsPerDisputeBlock::<T>::try_get(block).map_err(|_err| UNKNOWN_BLOCK)
+        }
+
+        fn mutate_market_ids_per_report_block<F>(
+            block: &Self::BlockNumber,
+            cb: F,
+        ) -> Result<(), DispatchError>
+        where
+            F: FnOnce(&mut Vec<Self::MarketId>),
+        {
+            <MarketIdsPerReportBlock<T>>::try_mutate(block, |opt| {
+                if let Some(vec) = opt {
+                    cb(vec);
+                    return Ok(());
+                }
+                Err(UNKNOWN_BLOCK)
+            })
+        }
+
+        // MarketIdPerReportBlock
+
+        fn insert_market_id_per_report_block(
+            block: Self::BlockNumber,
+            market_ids: Vec<Self::MarketId>,
+        ) {
+            MarketIdsPerReportBlock::<T>::insert(block, market_ids)
+        }
+
+        fn market_ids_per_report_block(
+            block: &Self::BlockNumber,
+        ) -> Result<Vec<Self::MarketId>, DispatchError> {
+            MarketIdsPerReportBlock::<T>::try_get(block).map_err(|_err| UNKNOWN_BLOCK)
+        }
+
+        // Misc
+
+        fn disputes(
+            market_id: &Self::MarketId,
+        ) -> Result<Vec<MarketDispute<Self::AccountId, Self::BlockNumber>>, DispatchError> {
+            Disputes::<T>::get(market_id).ok_or(UNKNOWN_MARKET_ID)
+        }
+
+        fn dispute_period() -> Self::BlockNumber {
+            T::DisputePeriod::get()
+        }
+
+        fn max_disputes() -> u32 {
+            T::MaxDisputes::get()
+        }
 
         fn on_dispute(
             origin: Self::Origin,
@@ -175,8 +278,8 @@ mod pallet {
                 }
             }
 
-            let disputes = Self::disputes(market_id);
-            let num_disputes = disputes.len() as u16;
+            let disputes = <Disputes<T>>::get(market_id).unwrap_or_default();
+            let num_disputes = disputes.len() as u32;
             let max_disputes = T::MaxDisputes::get();
             ensure!(num_disputes < max_disputes, Error::<T>::MaxDisputesReached);
 
@@ -196,22 +299,48 @@ mod pallet {
             if num_disputes > 0 {
                 let prev_dispute = disputes[(num_disputes as usize) - 1].clone();
                 let at = prev_dispute.at;
-                let mut old_disputes_per_block = Self::market_ids_per_dispute_block(at);
+                let mut old_disputes_per_block =
+                    Self::market_ids_per_dispute_block(&at).unwrap_or_default();
                 Self::remove_item::<T::MarketId>(&mut old_disputes_per_block, market_id);
                 <MarketIdsPerDisputeBlock<T>>::insert(at, old_disputes_per_block);
             }
 
-            <MarketIdsPerDisputeBlock<T>>::mutate(current_block, |ids| {
-                ids.push(market_id);
+            let does_not_exist = <MarketIdsPerDisputeBlock<T>>::mutate(current_block, |ids_opt| {
+                if let Some(ids) = ids_opt {
+                    ids.push(market_id);
+                    false
+                } else {
+                    true
+                }
             });
+            if does_not_exist {
+                <MarketIdsPerDisputeBlock<T>>::insert(current_block, vec![market_id]);
+            }
 
-            <Disputes<T>>::mutate(market_id, |disputes| {
-                disputes.push(MarketDispute {
-                    at: current_block,
-                    by: sender,
-                    outcome: outcome.clone(),
-                })
+            let does_not_exist = <Disputes<T>>::mutate(market_id, |disputes_opt| {
+                if let Some(disputes) = disputes_opt {
+                    disputes.push(MarketDispute {
+                        at: current_block,
+                        by: sender.clone(),
+                        outcome: outcome.clone(),
+                    });
+                    false
+                } else {
+                    true
+                }
             });
+            if does_not_exist {
+                <Disputes<T>>::insert(
+                    market_id,
+                    vec![MarketDispute {
+                        at: current_block,
+                        by: sender,
+                        outcome: outcome.clone(),
+                    }],
+                );
+            }
+
+            let _a = <Disputes<T>>::get(market_id);
 
             // if not already in dispute
             if market.status != MarketStatus::Disputed {
@@ -224,33 +353,35 @@ mod pallet {
             Self::calculate_actual_weight(|_| 0, num_disputes as u32, max_disputes as u32)
         }
 
-        fn on_resolution(now: Self::BlockNumber) -> Result<Weight, DispatchError> {
+        fn on_resolution(now: Self::BlockNumber) -> Result<ResolutionCounters, DispatchError> {
             let dispute_period = T::DisputePeriod::get();
+            let mut resolution_counters = ResolutionCounters::default();
             if now <= dispute_period {
-                return Ok(1_000_000);
+                return Ok(resolution_counters);
             }
 
             // Resolve all regularly reported markets.
-            let mut total_weight: Weight = 0;
-            let market_ids = Self::market_ids_per_report_block(now - dispute_period);
+            let report_block = now - dispute_period;
+            let market_ids = Self::market_ids_per_report_block(&report_block).unwrap_or_default();
             for id in &market_ids {
-                let market = Self::markets(id).ok_or(DispatchError::Other(
+                let market = <Markets<T>>::get(id).ok_or(DispatchError::Other(
                     "Market stored in report block does not exist",
                 ))?;
                 if let MarketStatus::Reported = market.status {
-                    let weight = Self::internal_resolve(id)?;
-                    total_weight = total_weight.saturating_add(weight);
+                    let local_rc = Self::internal_resolve(id)?;
+                    resolution_counters.saturating_add(&local_rc);
                 }
             }
 
             // Resolve any disputed markets.
-            let disputed = Self::market_ids_per_dispute_block(now - dispute_period);
+            let dispute_block = now - dispute_period;
+            let disputed = Self::market_ids_per_dispute_block(&dispute_block).unwrap_or_default();
             for id in &disputed {
-                let weight = Self::internal_resolve(id)?;
-                total_weight = total_weight.saturating_add(weight);
+                let local_rc = Self::internal_resolve(id)?;
+                resolution_counters.saturating_add(&local_rc);
             }
 
-            Ok(total_weight)
+            Ok(resolution_counters)
         }
     }
 
@@ -260,54 +391,43 @@ mod pallet {
     /// For each market, this holds the dispute information for each dispute that's
     /// been issued.
     #[pallet::storage]
-    #[pallet::getter(fn disputes)]
     pub type Disputes<T: Config> = StorageMap<
         _,
         Blake2_128Concat,
         T::MarketId,
         Vec<MarketDispute<T::AccountId, T::BlockNumber>>,
-        ValueQuery,
     >;
 
     /// A mapping of market identifiers to the block they were disputed at.
     /// A market only ends up here if it was disputed.
     #[pallet::storage]
-    #[pallet::getter(fn market_ids_per_dispute_block)]
     pub type MarketIdsPerDisputeBlock<T: Config> =
-        StorageMap<_, Blake2_128Concat, T::BlockNumber, Vec<T::MarketId>, ValueQuery>;
+        StorageMap<_, Blake2_128Concat, T::BlockNumber, Vec<T::MarketId>>;
 
     /// A mapping of market identifiers to the block that they were reported on.
     #[pallet::storage]
-    #[pallet::getter(fn market_ids_per_report_block)]
     pub type MarketIdsPerReportBlock<T: Config> =
-        StorageMap<_, Blake2_128Concat, T::BlockNumber, Vec<T::MarketId>, ValueQuery>;
+        StorageMap<_, Blake2_128Concat, T::BlockNumber, Vec<T::MarketId>>;
 
     #[pallet::storage]
-    #[pallet::getter(fn market_to_swap_pool)]
-    pub type MarketToSwapPool<T: Config> =
-        StorageMap<_, Blake2_128Concat, T::MarketId, Option<PoolId>, ValueQuery>;
+    pub type MarketToSwapPool<T: Config> = StorageMap<_, Blake2_128Concat, T::MarketId, PoolId>;
 
     /// For each market, this holds the dispute information for each dispute that's
     /// been issued.
     #[pallet::storage]
-    #[pallet::getter(fn markets)]
-    pub type Markets<T: Config> = StorageMap<
-        _,
-        Blake2_128Concat,
-        T::MarketId,
-        Option<Market<T::AccountId, T::BlockNumber>>,
-        ValueQuery,
-    >;
+    pub type Markets<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::MarketId, Market<T::AccountId, T::BlockNumber>>;
 
     impl<T: Config> Pallet<T> {
-        /// Performs the logic for resolving a market, including slashing and distributing
-        /// funds.
-        ///
-        /// NOTE: This function does not perform any checks on the market that is being given.
-        /// In the function calling this you should that the market is already in a reported or
-        /// disputed state.
-        #[allow(unused_assignments, unused_variables)]
-        pub(crate) fn internal_resolve(market_id: &T::MarketId) -> Result<Weight, DispatchError> {
+        // Performs the logic for resolving a market, including slashing and distributing
+        // funds.
+        //
+        // NOTE: This function does not perform any checks on the market that is being given.
+        // In the function calling this you should that the market is already in a reported or
+        // disputed state.
+        pub(crate) fn internal_resolve(
+            market_id: &T::MarketId,
+        ) -> Result<ResolutionCounters, DispatchError> {
             let market = Self::market_by_id(market_id)?;
             let report = market.report.clone().ok_or(NO_REPORT)?;
             let mut total_accounts = 0u32;
@@ -331,8 +451,8 @@ mod pallet {
             let resolved_outcome = match market.status {
                 MarketStatus::Reported => report.clone().outcome,
                 MarketStatus::Disputed => {
-                    let disputes = Self::disputes(market_id);
-                    let num_disputes = disputes.len() as u16;
+                    let disputes = <Disputes<T>>::get(market_id).unwrap_or_default();
+                    let num_disputes = disputes.len() as u32;
                     // count the last dispute's outcome as the winning one
                     let last_dispute = disputes[(num_disputes as usize) - 1].clone();
                     last_dispute.outcome
@@ -340,7 +460,6 @@ mod pallet {
                 _ => panic!("Cannot happen"),
             };
 
-            let market_status = market.status;
             match market.status {
                 MarketStatus::Reported => {
                     // the oracle bond gets returned if the reporter was the oracle
@@ -355,9 +474,8 @@ mod pallet {
                     }
                 }
                 MarketStatus::Disputed => {
-                    let disputes = Self::disputes(market_id);
-                    let num_disputes = disputes.len() as u16;
-                    total_disputes = num_disputes.into();
+                    let disputes = <Disputes<T>>::get(market_id).unwrap_or_default();
+                    total_disputes = disputes.len() as _;
 
                     let mut correct_reporters: Vec<T::AccountId> = Vec::new();
 
@@ -374,10 +492,9 @@ mod pallet {
                         overall_imbalance.subsume(imbalance);
                     }
 
-                    for i in 0..num_disputes {
-                        let dispute = &disputes[i as usize];
+                    for (i, dispute) in disputes.iter().enumerate() {
                         let dispute_bond =
-                            T::DisputeBond::get() + T::DisputeFactor::get() * i.into();
+                            T::DisputeBond::get() + T::DisputeFactor::get() * (i as u32).into();
                         if dispute.outcome == resolved_outcome {
                             T::Currency::unreserve(&dispute.by, dispute_bond);
 
@@ -415,19 +532,12 @@ mod pallet {
                 m.as_mut().unwrap().resolved_outcome = Some(resolved_outcome);
             });
 
-            // Calculate required weight
-            // MUST be updated when new market types are added.
-            if let MarketType::Categorical(_) = market.market_type {
-                if let MarketStatus::Reported = market_status {
-                    Ok(0)
-                } else {
-                    Ok(0)
-                }
-            } else if let MarketStatus::Reported = market_status {
-                Ok(0)
-            } else {
-                Ok(0)
-            }
+            Ok(ResolutionCounters {
+                total_accounts,
+                total_asset_accounts,
+                total_categories,
+                total_disputes,
+            })
         }
 
         fn calculate_actual_weight<F>(
@@ -508,12 +618,12 @@ mod pallet {
         where
             T: Config,
         {
-            Self::markets(market_id).ok_or(Error::<T>::MarketDoesNotExist)
+            <Markets<T>>::get(market_id).ok_or(Error::<T>::MarketDoesNotExist)
         }
 
         // Returns the corresponding **stored** pool id of a market id
         fn market_pool_id(market_id: &T::MarketId) -> Result<u128, DispatchError> {
-            if let Ok(Some(el)) = <MarketToSwapPool<T>>::try_get(market_id) {
+            if let Ok(el) = <MarketToSwapPool<T>>::try_get(market_id) {
                 Ok(el)
             } else {
                 Err(Error::<T>::PoolDoesNotExist.into())

--- a/zrml/court/src/mock.rs
+++ b/zrml/court/src/mock.rs
@@ -58,6 +58,7 @@ construct_runtime!(
         Balances: pallet_balances::{Call, Config<T>, Event<T>, Pallet, Storage},
         Court: court::{Event<T>, Pallet, Storage},
         Currency: orml_currencies::{Call, Event<T>, Pallet, Storage},
+        MarketCommons: zrml_market_commons::{Pallet, Storage},
         Swaps: zrml_swaps::{Call, Event<T>, Pallet},
         System: frame_system::{Config, Event<T>, Pallet, Storage},
         Timestamp: pallet_timestamp::{Pallet},
@@ -71,6 +72,7 @@ impl crate::Config for Runtime {
     type DisputeFactor = DisputeFactor;
     type DisputePeriod = DisputePeriod;
     type Event = Event;
+    type MarketCommons = MarketCommons;
     type MarketId = MarketId;
     type MaxDisputes = MaxDisputes;
     type OracleBond = OracleBond;
@@ -140,6 +142,10 @@ impl pallet_timestamp::Config for Runtime {
     type Moment = u64;
     type OnTimestampSet = ();
     type WeightInfo = ();
+}
+
+impl zrml_market_commons::Config for Runtime {
+    type MarketId = MarketId;
 }
 
 impl zrml_swaps::Config for Runtime {

--- a/zrml/court/src/mock.rs
+++ b/zrml/court/src/mock.rs
@@ -8,8 +8,8 @@ use sp_runtime::{
 };
 use zeitgeist_primitives::{
     constants::{
-        ExitFee, MaxAssets, MaxDisputes, MaxInRatio, MaxOutRatio, MaxTotalWeight, MaxWeight,
-        MinLiquidity, MinWeight, BASE, BLOCK_HASH_COUNT,
+        CourtPalletId, ExitFee, MaxAssets, MaxDisputes, MaxInRatio, MaxOutRatio, MaxTotalWeight,
+        MaxWeight, MinLiquidity, MinWeight, SwapsPalletId, BASE, BLOCK_HASH_COUNT,
     },
     types::{
         AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
@@ -38,8 +38,6 @@ parameter_types! {
     pub const GetNativeCurrencyId: Asset<MarketId> = Asset::Ztg;
     pub const MinimumPeriod: u64 = 0;
     pub const OracleBond: Balance = 100;
-    pub const CourtPalletId: PalletId = PalletId(*b"test/crt");
-    pub const SwapsPalletId: PalletId = PalletId(*b"test/swa");
     pub const ValidityBond: Balance = 200;
     pub DustAccount: AccountIdTest = PalletId(*b"orml/dst").into_account();
 }

--- a/zrml/court/src/resolution_counters.rs
+++ b/zrml/court/src/resolution_counters.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, Default)]
+pub struct ResolutionCounters {
+    pub total_accounts: u32,
+    pub total_asset_accounts: u32,
+    pub total_categories: u32,
+    pub total_disputes: u32,
+}
+
+impl ResolutionCounters {
+    #[inline]
+    pub(crate) fn saturating_add(&mut self, other: &Self) {
+        self.total_accounts = self.total_accounts.saturating_add(other.total_accounts);
+        self.total_asset_accounts += self
+            .total_asset_accounts
+            .saturating_add(other.total_asset_accounts);
+        self.total_categories += self.total_categories.saturating_add(other.total_categories);
+        self.total_disputes += self.total_disputes.saturating_add(other.total_disputes);
+    }
+}

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -92,7 +92,10 @@ fn it_resolves_a_disputed_market() {
         assert_eq!(disputes.len(), 3);
 
         // make sure the old mappings of market id per dispute block are erased
-        assert_noop!(Court::market_ids_per_dispute_block(&0), Error::<Runtime>::BlockDoesNotExist);
+        assert_noop!(
+            Court::market_ids_per_dispute_block(&0),
+            Error::<Runtime>::BlockDoesNotExist
+        );
 
         let market_ids_2 = Court::market_ids_per_dispute_block(&1).unwrap();
         assert_eq!(market_ids_2.len(), 1);

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -1,10 +1,11 @@
 #![cfg(test)]
 
-use crate::{mock::*, CourtPalletApi, Error, MarketIdsPerReportBlock, Markets};
+use crate::{mock::*, CourtPalletApi, Error, MarketIdsPerReportBlock};
 use frame_support::{assert_noop, assert_ok};
 use zeitgeist_primitives::types::{
     Market, MarketCreation, MarketEnd, MarketStatus, MarketType, OutcomeReport, Report,
 };
+use zrml_market_commons::MarketCommonsPalletApi;
 
 #[test]
 fn it_allows_to_dispute_the_outcome_of_a_market() {
@@ -18,7 +19,7 @@ fn it_allows_to_dispute_the_outcome_of_a_market() {
             OutcomeReport::Categorical(0)
         ));
 
-        let market = Court::market(&0).unwrap();
+        let market = MarketCommons::market(&0).unwrap();
         assert_eq!(market.status, MarketStatus::Disputed);
 
         let disputes = Court::disputes(&0).unwrap();
@@ -74,7 +75,7 @@ fn it_resolves_a_disputed_market() {
             OutcomeReport::Categorical(1)
         ));
 
-        let market = Court::market(&0).unwrap();
+        let market = MarketCommons::market(&0).unwrap();
         assert_eq!(market.status, MarketStatus::Disputed);
 
         // check everyone's deposits
@@ -104,13 +105,13 @@ fn it_resolves_a_disputed_market() {
 
         assert_ok!(Court::on_resolution(11));
 
-        let market_after = Court::market(&0).unwrap();
+        let market_after = MarketCommons::market(&0).unwrap();
         assert_eq!(market_after.status, MarketStatus::Resolved);
     });
 }
 
 fn create_reported_permissionless_categorical_market<T: crate::Config>() {
-    Markets::<Runtime>::insert(
+    MarketCommons::insert_market(
         0,
         Market {
             creation: MarketCreation::Permissionless,

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -1,8 +1,7 @@
 #![cfg(test)]
 
-use crate::{mock::*, CourtPalletApi, MarketIdsPerReportBlock, Markets};
-use frame_support::assert_ok;
-use sp_runtime::DispatchError;
+use crate::{mock::*, CourtPalletApi, Error, MarketIdsPerReportBlock, Markets};
+use frame_support::{assert_noop, assert_ok};
 use zeitgeist_primitives::types::{
     Market, MarketCreation, MarketEnd, MarketStatus, MarketType, OutcomeReport, Report,
 };
@@ -93,10 +92,7 @@ fn it_resolves_a_disputed_market() {
         assert_eq!(disputes.len(), 3);
 
         // make sure the old mappings of market id per dispute block are erased
-        assert_eq!(
-            Court::market_ids_per_dispute_block(&0).unwrap_err(),
-            DispatchError::Other("Unknown block")
-        );
+        assert_noop!(Court::market_ids_per_dispute_block(&0), Error::<Runtime>::BlockDoesNotExist);
 
         let market_ids_2 = Court::market_ids_per_dispute_block(&1).unwrap();
         assert_eq!(market_ids_2.len(), 1);

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -2,6 +2,7 @@
 
 use crate::{mock::*, CourtPalletApi, MarketIdsPerReportBlock, Markets};
 use frame_support::assert_ok;
+use sp_runtime::DispatchError;
 use zeitgeist_primitives::types::{
     Market, MarketCreation, MarketEnd, MarketStatus, MarketType, OutcomeReport, Report,
 };
@@ -18,17 +19,17 @@ fn it_allows_to_dispute_the_outcome_of_a_market() {
             OutcomeReport::Categorical(0)
         ));
 
-        let market = Court::markets(0).unwrap();
+        let market = Court::market(&0).unwrap();
         assert_eq!(market.status, MarketStatus::Disputed);
 
-        let disputes = Court::disputes(0);
+        let disputes = Court::disputes(&0).unwrap();
         assert_eq!(disputes.len(), 1);
         let dispute = &disputes[0];
         assert_eq!(dispute.at, 1);
         assert_eq!(dispute.by, CHARLIE);
         assert_eq!(dispute.outcome, OutcomeReport::Categorical(0));
 
-        let market_ids = Court::market_ids_per_dispute_block(1);
+        let market_ids = Court::market_ids_per_dispute_block(&1).unwrap();
         assert_eq!(market_ids.len(), 1);
         assert_eq!(market_ids[0], 0);
     });
@@ -40,7 +41,7 @@ fn it_correctly_resolves_a_market_that_was_reported_on() {
         System::set_block_number(1);
         create_reported_permissionless_categorical_market::<Runtime>();
 
-        let reported_ids = Court::market_ids_per_report_block(1);
+        let reported_ids = Court::market_ids_per_report_block(&1).unwrap();
         assert_eq!(reported_ids.len(), 1);
         let id = reported_ids[0];
         assert_eq!(id, 0);
@@ -74,7 +75,7 @@ fn it_resolves_a_disputed_market() {
             OutcomeReport::Categorical(1)
         ));
 
-        let market = Court::markets(0).unwrap();
+        let market = Court::market(&0).unwrap();
         assert_eq!(market.status, MarketStatus::Disputed);
 
         // check everyone's deposits
@@ -88,21 +89,23 @@ fn it_resolves_a_disputed_market() {
         assert_eq!(eve_reserved, 150);
 
         // check disputes length
-        let disputes = Court::disputes(0);
+        let disputes = Court::disputes(&0).unwrap();
         assert_eq!(disputes.len(), 3);
 
         // make sure the old mappings of market id per dispute block are erased
-        let market_ids_1 = Court::market_ids_per_dispute_block(0);
-        assert_eq!(market_ids_1.len(), 0);
+        assert_eq!(
+            Court::market_ids_per_dispute_block(&0).unwrap_err(),
+            DispatchError::Other("Unknown block")
+        );
 
-        let market_ids_2 = Court::market_ids_per_dispute_block(1);
+        let market_ids_2 = Court::market_ids_per_dispute_block(&1).unwrap();
         assert_eq!(market_ids_2.len(), 1);
 
         System::set_block_number(11);
 
         assert_ok!(Court::on_resolution(11));
 
-        let market_after = Court::markets(0).unwrap();
+        let market_after = Court::market(&0).unwrap();
         assert_eq!(market_after.status, MarketStatus::Resolved);
     });
 }
@@ -110,7 +113,7 @@ fn it_resolves_a_disputed_market() {
 fn create_reported_permissionless_categorical_market<T: crate::Config>() {
     Markets::<Runtime>::insert(
         0,
-        Some(Market {
+        Market {
             creation: MarketCreation::Permissionless,
             creator_fee: 0,
             creator: ALICE,
@@ -125,9 +128,7 @@ fn create_reported_permissionless_categorical_market<T: crate::Config>() {
             }),
             resolved_outcome: None,
             status: MarketStatus::Reported,
-        }),
+        },
     );
-    MarketIdsPerReportBlock::<Runtime>::mutate(System::block_number(), |v| {
-        v.push(0);
-    });
+    MarketIdsPerReportBlock::<Runtime>::insert(System::block_number(), vec![0]);
 }

--- a/zrml/market-commons/Cargo.toml
+++ b/zrml/market-commons/Cargo.toml
@@ -1,0 +1,22 @@
+[dependencies]
+frame-support = { branch = "polkadot-v0.9.3", default-features = false, git = "https://github.com/paritytech/substrate" }
+frame-system = { branch = "polkadot-v0.9.3", default-features = false, git = "https://github.com/paritytech/substrate" }
+parity-scale-codec = { default-features = false, features = ["derive"], version = "2.0" }
+sp-runtime = { branch = "polkadot-v0.9.3", default-features = false, git = "https://github.com/paritytech/substrate" }
+zeitgeist-primitives = { default-features = false, path = "../../primitives" }
+
+[features]
+default = ["std"]
+std = [
+    'frame-support/std',
+    'frame-system/std',
+    'parity-scale-codec/std',
+    'sp-runtime/std',
+    'zeitgeist-primitives/std',
+]
+
+[package]
+authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
+edition = "2018"
+name = "zrml-market-commons"
+version = "0.1.0"

--- a/zrml/market-commons/Cargo.toml
+++ b/zrml/market-commons/Cargo.toml
@@ -7,6 +7,7 @@ zeitgeist-primitives = { default-features = false, path = "../../primitives" }
 
 [features]
 default = ["std"]
+runtime-benchmarks = []
 std = [
     'frame-support/std',
     'frame-system/std',

--- a/zrml/market-commons/src/lib.rs
+++ b/zrml/market-commons/src/lib.rs
@@ -1,0 +1,94 @@
+//! # Common market parameters used by `Court` and `Prediction Markets` pallets.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+mod market_commons_pallet_api;
+
+pub use market_commons_pallet_api::MarketCommonsPalletApi;
+pub use pallet::*;
+
+#[frame_support::pallet]
+mod pallet {
+    use crate::MarketCommonsPalletApi;
+    use core::marker::PhantomData;
+    use frame_support::{pallet_prelude::StorageMap, traits::Hooks, Blake2_128Concat, Parameter};
+    use sp_runtime::{DispatchError, traits::{AtLeast32Bit, MaybeSerializeDeserialize, Member}};
+    use zeitgeist_primitives::types::Market;
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {}
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// The identifier of individual markets.
+        type MarketId: AtLeast32Bit
+            + Copy
+            + Default
+            + MaybeSerializeDeserialize
+            + Member
+            + Parameter;
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// A market with the provided ID does not exist.
+        MarketDoesNotExist,
+    }
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    impl<T> MarketCommonsPalletApi for Pallet<T>
+    where
+        T: Config,
+    {
+        type AccountId = T::AccountId;
+        type BlockNumber = T::BlockNumber;
+        type MarketId = T::MarketId;
+
+        fn market(
+            market_id: &Self::MarketId,
+        ) -> Result<Market<Self::AccountId, Self::BlockNumber>, DispatchError> {
+            <Markets<T>>::try_get(market_id).map_err(|_err| Error::<T>::MarketDoesNotExist.into())
+        }
+
+        fn mutate_market<F>(market_id: &Self::MarketId, cb: F) -> Result<(), DispatchError>
+        where
+            F: FnOnce(&mut Market<Self::AccountId, Self::BlockNumber>),
+        {
+            <Markets<T>>::try_mutate(market_id, |opt| {
+                if let Some(market) = opt {
+                    cb(market);
+                    return Ok(());
+                }
+                Err(Error::<T>::MarketDoesNotExist.into())
+            })
+        }
+
+        fn insert_market(
+            market_id: Self::MarketId,
+            market: Market<Self::AccountId, Self::BlockNumber>,
+        ) {
+            <Markets<T>>::insert(market_id, market);
+        }
+
+        fn remove_market(market_id: &Self::MarketId) -> Result<(), DispatchError> {
+            if !<Markets<T>>::contains_key(market_id) {
+                return Err(Error::<T>::MarketDoesNotExist.into());
+            }
+            <Markets<T>>::remove(market_id);
+            Ok(())
+        }
+    }
+
+    /// Holds all markets
+    #[pallet::storage]
+    #[pallet::getter(fn markets)]
+    pub type Markets<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::MarketId, Market<T::AccountId, T::BlockNumber>>;
+}

--- a/zrml/market-commons/src/lib.rs
+++ b/zrml/market-commons/src/lib.rs
@@ -14,7 +14,10 @@ mod pallet {
     use crate::MarketCommonsPalletApi;
     use core::marker::PhantomData;
     use frame_support::{pallet_prelude::StorageMap, traits::Hooks, Blake2_128Concat, Parameter};
-    use sp_runtime::{DispatchError, traits::{AtLeast32Bit, MaybeSerializeDeserialize, Member}};
+    use sp_runtime::{
+        traits::{AtLeast32Bit, MaybeSerializeDeserialize, Member},
+        DispatchError,
+    };
     use zeitgeist_primitives::types::Market;
 
     #[pallet::call]

--- a/zrml/market-commons/src/market_commons_pallet_api.rs
+++ b/zrml/market-commons/src/market_commons_pallet_api.rs
@@ -13,10 +13,7 @@ pub trait MarketCommonsPalletApi {
     ) -> Result<Market<Self::AccountId, Self::BlockNumber>, DispatchError>;
 
     /// Inserts a market into the storage
-    fn insert_market(
-        market_id: Self::MarketId,
-        market: Market<Self::AccountId, Self::BlockNumber>,
-    );
+    fn insert_market(market_id: Self::MarketId, market: Market<Self::AccountId, Self::BlockNumber>);
 
     /// Mutates a given market storage
     fn mutate_market<F>(market_id: &Self::MarketId, cb: F) -> Result<(), DispatchError>

--- a/zrml/market-commons/src/market_commons_pallet_api.rs
+++ b/zrml/market-commons/src/market_commons_pallet_api.rs
@@ -1,0 +1,28 @@
+use frame_support::dispatch::DispatchError;
+use zeitgeist_primitives::types::Market;
+
+/// Court - Pallet Api
+pub trait MarketCommonsPalletApi {
+    type AccountId;
+    type BlockNumber;
+    type MarketId;
+
+    /// Gets a market from the storage.
+    fn market(
+        market_id: &Self::MarketId,
+    ) -> Result<Market<Self::AccountId, Self::BlockNumber>, DispatchError>;
+
+    /// Inserts a market into the storage
+    fn insert_market(
+        market_id: Self::MarketId,
+        market: Market<Self::AccountId, Self::BlockNumber>,
+    );
+
+    /// Mutates a given market storage
+    fn mutate_market<F>(market_id: &Self::MarketId, cb: F) -> Result<(), DispatchError>
+    where
+        F: FnOnce(&mut Market<Self::AccountId, Self::BlockNumber>);
+
+    /// Removes a market from the storage.
+    fn remove_market(market_id: &Self::MarketId) -> Result<(), DispatchError>;
+}

--- a/zrml/swaps/src/mock.rs
+++ b/zrml/swaps/src/mock.rs
@@ -11,7 +11,7 @@ use sp_runtime::{
 use zeitgeist_primitives::{
     constants::{
         ExitFee, MaxAssets, MaxInRatio, MaxOutRatio, MaxTotalWeight, MaxWeight, MinLiquidity,
-        MinWeight, BLOCK_HASH_COUNT,
+        MinWeight, SwapsPalletId, BLOCK_HASH_COUNT,
     },
     types::{
         AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
@@ -24,7 +24,6 @@ parameter_types! {
     pub const BlockHashCount: u64 = BLOCK_HASH_COUNT;
     pub const ExistentialDeposit: u32 = 1;
     pub const GetNativeCurrencyId: CurrencyId = Asset::Ztg;
-    pub const SwapsPalletId: PalletId = PalletId(*b"test/swa");
     pub DustAccount: AccountIdTest = PalletId(*b"orml/dst").into_account();
 }
 


### PR DESCRIPTION
Locally, the `court` pallet is already integrated into the PM pallet but all changes would create a sizeable PR. Therefore, this PR only touches self-contained `court` modifications for an easier review.