### PR TITLE
[Network] Add Zeitgeist telemetry

### DIFF
--- a/node/res/bp.json
+++ b/node/res/bp.json
@@ -10,6 +10,10 @@
     [
       "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
       0
+    ],
+    [
+      "/dns/telemetry.zeitgeist.pm/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      0
     ]
   ],
   "protocolId": "battery_park",

--- a/node/res/bp_parachain.json
+++ b/node/res/bp_parachain.json
@@ -7,6 +7,10 @@
     [
       "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
       0
+    ],
+    [
+      "/dns/telemetry.zeitgeist.pm/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      0
     ]
   ],
   "protocolId": "battery_park",

--- a/node/src/chain_spec/battery_park.rs
+++ b/node/src/chain_spec/battery_park.rs
@@ -1,4 +1,7 @@
-use crate::chain_spec::{generic_genesis, AdditionalChainSpec, ChainSpec, TELEMETRY_URL};
+use crate::chain_spec::{
+    generic_genesis, AdditionalChainSpec, ChainSpec, POLKADOT_TELEMETRY_URL,
+    ZEITGEIST_TELEMETRY_URL,
+};
 use hex_literal::hex;
 use jsonrpc_core::serde_json::Map;
 use sc_service::{config::TelemetryEndpoints, ChainType};
@@ -52,7 +55,11 @@ pub fn battery_park_staging_config(
             )
         },
         vec![],
-        TelemetryEndpoints::new(vec![(TELEMETRY_URL.into(), 0)]).ok(),
+        TelemetryEndpoints::new(vec![
+            (POLKADOT_TELEMETRY_URL.into(), 0),
+            (ZEITGEIST_TELEMETRY_URL.into(), 0),
+        ])
+        .ok(),
         Some("battery_park_staging"),
         Some(properties),
         #[cfg(feature = "parachain")]

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -48,7 +48,8 @@ const DEFAULT_COLLATOR_INFLATION_INFO: parachain_staking::InflationInfo<Balance>
         },
     }
 };
-const TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
+const POLKADOT_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
+const ZEITGEIST_TELEMETRY_URL: &str = "wss://telemetry.zeitgeist.pm/submit/";
 
 #[cfg(feature = "parachain")]
 pub type ChainSpec = sc_service::GenericChainSpec<zeitgeist_runtime::GenesisConfig, Extensions>;


### PR DESCRIPTION
**Issue**
#179 

**Solution**
Add Zeitgeist telemetry server to telemetry endpoints in genesis configuration inside the code and inside the chain spec files. Does not affect genesis block header hash. The clients will now try to connect to both (Polkadots and Zeitgeitsts) telemetry servers.