### PR TITLE
[Rikiddo] Implement Rikiddo trait and tests - part 1

### DIFF
--- a/zrml/rikiddo/src/constants.rs
+++ b/zrml/rikiddo/src/constants.rs
@@ -18,14 +18,6 @@ pub const EMA_LONG: Timespan = Timespan::Hours(6);
 pub const SMOOTHING: FixedU32<U24> = <FixedU32<U24>>::from_bits(0x0200_0000);
 
 // --- Default configuration for FeeSigmoidConfig struct ---
-/// Initial fee f
-/// 0.005
-pub const INITIAL_FEE: FixedU32<U32> = <FixedU32<U32>>::from_bits(0x0147_AE14);
-
-/// Minimal revenue w (proportion of initial fee f)
-/// f * β = 0.005 * 0.7 = 0.0035
-pub const MINIMAL_REVENUE: FixedU32<U32> = <FixedU32<U32>>::from_bits(0x00E5_6042);
-
 /// m value
 /// 0.01
 pub const M: FixedI32<U24> = <FixedI32<U24>>::from_bits(0x0002_8F5C);
@@ -37,3 +29,12 @@ pub const P: FixedI32<U24> = <FixedI32<U24>>::from_bits(0x0200_0000);
 /// n value
 /// 0.0
 pub const N: FixedI32<U24> = <FixedI32<U24>>::from_bits(0x0000_0000);
+
+// --- Default configuration for RikiddoConfig struct ---
+/// Initial fee f
+/// 0.005
+pub const INITIAL_FEE: FixedU32<U32> = <FixedU32<U32>>::from_bits(0x0147_AE14);
+
+/// Minimal revenue w (proportion of initial fee f)
+/// f * β = 0.005 * 0.7 = 0.0035
+pub const MINIMAL_REVENUE: FixedU32<U32> = <FixedU32<U32>>::from_bits(0x00E5_6042);

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use frame_support::assert_err;
-use substrate_fixed::{types::extra::U7, FixedI8, FixedU8};
+use substrate_fixed::{
+    types::extra::{U1, U2, U3, U7, U8},
+    FixedI8, FixedU8,
+};
 
 use crate::{
     mock::*,
@@ -17,12 +20,47 @@ fn max_allowed_error(fractional_bits: u8) -> f64 {
 }
 
 #[test]
-fn convert_to_unsigned_error_when_msb_is_set() {
-    let num = <FixedI8<U7>>::from_num(-1.42f32);
+fn convert_signed_to_unsigned_fails() {
+    let num = <FixedI8<U8>>::from_num(-0.5f32);
     assert_err!(
-        convert_to_unsigned::<FixedI8<U7>, FixedU8<U7>>(num),
-        "Signed fixed point to unsigned fixed point number conversion failed: MSB is set"
+        convert_to_unsigned::<FixedI8<U8>, FixedU8<U8>>(num),
+        "Cannot convert negative signed number into unsigned number"
     );
+}
+
+#[test]
+fn convert_number_does_not_fit_in_destination_type() {
+    let num = <FixedU8<U7>>::from_num(1);
+    assert_err!(
+        convert_to_signed::<FixedU8<U7>, FixedI8<U7>>(num),
+        "Fixed point conversion failed: FROM type does not fit in TO type"
+    );
+}
+
+#[test]
+fn convert_unsigned_to_signed_returns_correct_result() -> Result<(), &'static str> {
+    // lossless - exact fit
+    let num1 = <FixedU8<U2>>::from_num(4.75);
+    let num1_converted: FixedI8<U3> = convert_to_signed(num1)?;
+    assert_eq!(num1_converted, num1);
+    // lossy - loses fractional bits
+    let num2 = <FixedU8<U2>>::from_num(4.75);
+    let num2_converted: FixedI8<U1> = convert_to_signed(num2)?;
+    assert_eq!(num2_converted.to_num::<f32>(), 4.5f32);
+    Ok(())
+}
+
+#[test]
+fn convert_signed_to_unsigned_returns_correct_result() -> Result<(), &'static str> {
+    // lossless - exact fit
+    let num1 = <FixedI8<U2>>::from_num(4.75);
+    let num1_converted: FixedU8<U3> = convert_to_unsigned(num1)?;
+    assert_eq!(num1_converted, num1);
+    // lossy - loses fractional bits
+    let num2 = <FixedI8<U2>>::from_num(4.75);
+    let num2_converted: FixedU8<U1> = convert_to_unsigned(num2)?;
+    assert_eq!(num2_converted.to_num::<f32>(), 4.5f32);
+    Ok(())
 }
 
 #[test]

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -1,6 +1,12 @@
 #![cfg(test)]
 
-use crate::mock::*;
+use frame_support::assert_err;
+use substrate_fixed::{types::extra::U7, FixedI8, FixedU8};
+
+use crate::{
+    mock::*,
+    types::{convert_to_signed, convert_to_unsigned},
+};
 
 mod ema_market_volume;
 mod rikiddo_sigmoid_mv;
@@ -8,6 +14,15 @@ mod sigmoid_fee;
 
 fn max_allowed_error(fractional_bits: u8) -> f64 {
     1.0 / (1u128 << (fractional_bits - 1)) as f64
+}
+
+#[test]
+fn convert_to_unsigned_error_when_msb_is_set() {
+    let num = <FixedI8<U7>>::from_num(-1.42f32);
+    assert_err!(
+        convert_to_unsigned::<FixedI8<U7>, FixedU8<U7>>(num),
+        "Signed fixed point to unsigned fixed point number conversion failed: MSB is set"
+    );
 }
 
 #[test]

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -3,6 +3,7 @@
 use crate::mock::*;
 
 mod ema_market_volume;
+mod rikiddo_sigmoid_mv;
 mod sigmoid_fee;
 
 fn max_allowed_error(fractional_bits: u8) -> f64 {

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -5,8 +5,8 @@ use crate::mock::*;
 mod ema_market_volume;
 mod sigmoid_fee;
 
-fn max_allowed_error(fixed_point_bits: u8) -> f64 {
-    1.0 / (1u128 << (fixed_point_bits - 1)) as f64
+fn max_allowed_error(fractional_bits: u8) -> f64 {
+    1.0 / (1u128 << (fractional_bits - 1)) as f64
 }
 
 #[test]

--- a/zrml/rikiddo/src/tests/ema_market_volume.rs
+++ b/zrml/rikiddo/src/tests/ema_market_volume.rs
@@ -1,7 +1,7 @@
 use super::max_allowed_error;
 use crate::{
     traits::MarketAverage,
-    types::{EmaMarketVolume, EmaConfig, MarketVolumeState, Timespan, TimestampedVolume},
+    types::{EmaConfig, EmaMarketVolume, MarketVolumeState, Timespan, TimestampedVolume},
 };
 use frame_support::assert_err;
 use substrate_fixed::{types::extra::U64, FixedU128};

--- a/zrml/rikiddo/src/tests/ema_market_volume.rs
+++ b/zrml/rikiddo/src/tests/ema_market_volume.rs
@@ -1,13 +1,13 @@
 use super::max_allowed_error;
 use crate::{
     traits::MarketAverage,
-    types::{EmaMarketVolume, EmaVolumeConfig, MarketVolumeState, Timespan, TimestampedVolume},
+    types::{EmaMarketVolume, EmaConfig, MarketVolumeState, Timespan, TimestampedVolume},
 };
 use frame_support::assert_err;
 use substrate_fixed::{types::extra::U64, FixedU128};
 
 fn ema_create_test_struct(period: u32, smoothing: f64) -> EmaMarketVolume<FixedU128<U64>> {
-    let emv_cfg = EmaVolumeConfig::<FixedU128<U64>> {
+    let emv_cfg = EmaConfig::<FixedU128<U64>> {
         ema_period: Timespan::Seconds(period),
         smoothing: <FixedU128<U64>>::from_num(smoothing),
     };
@@ -107,7 +107,7 @@ fn ema_added_volume_is_older_than_previous() {
 
 #[test]
 fn ema_overflow_sma_times_vpp() {
-    let emv_cfg = EmaVolumeConfig::<FixedU128<U64>> {
+    let emv_cfg = EmaConfig::<FixedU128<U64>> {
         ema_period: Timespan::Seconds(3),
         smoothing: <FixedU128<U64>>::from_num(2),
     };

--- a/zrml/rikiddo/src/tests/ema_market_volume.rs
+++ b/zrml/rikiddo/src/tests/ema_market_volume.rs
@@ -4,7 +4,10 @@ use crate::{
     types::{EmaConfig, EmaMarketVolume, MarketVolumeState, Timespan, TimestampedVolume},
 };
 use frame_support::assert_err;
-use substrate_fixed::{types::extra::U64, FixedU128};
+use substrate_fixed::{
+    types::extra::{U64, U96},
+    FixedU128,
+};
 
 pub(super) fn ema_create_test_struct(
     period: u32,
@@ -12,6 +15,7 @@ pub(super) fn ema_create_test_struct(
 ) -> EmaMarketVolume<FixedU128<U64>> {
     let emv_cfg = EmaConfig::<FixedU128<U64>> {
         ema_period: Timespan::Seconds(period),
+        ema_period_estimate_after: None,
         smoothing: <FixedU128<U64>>::from_num(smoothing),
     };
 
@@ -85,6 +89,41 @@ fn ema_returns_correct_ema() {
 }
 
 #[test]
+fn ema_returns_correct_ema_after_estimated_period() {
+    let mut emv = EmaMarketVolume::new(EmaConfig::<FixedU128<U64>> {
+        ema_period: Timespan::Seconds(8),
+        ema_period_estimate_after: Some(Timespan::Seconds(2)),
+        smoothing: <FixedU128<U64>>::from_num(2.0),
+    });
+    let _ = emv.update(&TimestampedVolume { timestamp: 0, volume: 2u32.into() }).unwrap();
+    let _ = emv.update(&TimestampedVolume { timestamp: 1, volume: 6u32.into() }).unwrap();
+    let _ = emv.update(&TimestampedVolume { timestamp: 2, volume: 4u32.into() }).unwrap();
+    // Currently it's a sma
+    let ema = emv.ema.to_num::<f64>();
+    assert_eq!(ema, (2.0 + 6.0 + 4.0) / 3.0);
+
+    let _ = emv.update(&TimestampedVolume { timestamp: 3, volume: 20u32.into() }).unwrap();
+    // Now it's an ema (using estimated transaction count per period)
+    let ema_fixed_f64: f64 = emv.ema.to_num();
+    let extrapolation_factor = emv.config.ema_period.to_seconds() as f64
+        / emv.config.ema_period_estimate_after.unwrap().to_seconds() as f64;
+    let multiplier = ema_get_multiplier(
+        (3f64 * extrapolation_factor).ceil() as u64,
+        emv.config.smoothing.to_num(),
+    );
+    let ema_f64 = ema_calculate(ema, multiplier, 20f64);
+    let difference_abs = (ema_fixed_f64 - ema_f64).abs();
+    assert!(
+        difference_abs <= max_allowed_error(64),
+        "\nFixed result: {}\nFloat result: {}\nDifference: {}\nMax_Allowed_Difference: {}",
+        ema_fixed_f64,
+        ema_f64,
+        difference_abs,
+        max_allowed_error(64)
+    );
+}
+
+#[test]
 fn ema_clear_ereases_data() {
     let mut emv = ema_create_test_struct(2, 2.0);
     let _ = emv.update(&TimestampedVolume { timestamp: 0, volume: 2u32.into() }).unwrap();
@@ -128,5 +167,20 @@ fn ema_overflow_sma_times_vpp_plus_volume() {
     assert_err!(
         emv.update(&TimestampedVolume { timestamp: 2, volume: max_u64_fixed }),
         "[EmaMarketVolume] Overflow during calculation: sma * volumes_per_period + volume"
+    );
+}
+
+#[test]
+fn ema_overflow_estimated_tx_per_period_does_not_fit() {
+    let mut emv = EmaMarketVolume::new(EmaConfig::<FixedU128<U96>> {
+        ema_period: Timespan::Hours(2_386_093),
+        ema_period_estimate_after: Some(Timespan::Seconds(0)),
+        smoothing: <FixedU128<U96>>::from_num(2.0),
+    });
+    let _ = emv.update(&TimestampedVolume { timestamp: 0, volume: 2u32.into() }).unwrap();
+    let _ = emv.update(&TimestampedVolume { timestamp: 0, volume: 2u32.into() }).unwrap();
+    assert_err!(
+        emv.update(&TimestampedVolume { timestamp: 1, volume: 6u32.into() }),
+        "[EmaMarketVolume] Overflow during estimation of transactions per period"
     );
 }

--- a/zrml/rikiddo/src/tests/ema_market_volume.rs
+++ b/zrml/rikiddo/src/tests/ema_market_volume.rs
@@ -6,7 +6,10 @@ use crate::{
 use frame_support::assert_err;
 use substrate_fixed::{types::extra::U64, FixedU128};
 
-fn ema_create_test_struct(period: u32, smoothing: f64) -> EmaMarketVolume<FixedU128<U64>> {
+pub(super) fn ema_create_test_struct(
+    period: u32,
+    smoothing: f64,
+) -> EmaMarketVolume<FixedU128<U64>> {
     let emv_cfg = EmaConfig::<FixedU128<U64>> {
         ema_period: Timespan::Seconds(period),
         smoothing: <FixedU128<U64>>::from_num(smoothing),

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -1,5 +1,8 @@
 use frame_support::assert_err;
-use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
+use substrate_fixed::{
+    types::extra::{U120, U127, U128, U32, U64},
+    FixedI128, FixedU128,
+};
 
 use super::{ema_market_volume::ema_create_test_struct, max_allowed_error};
 use crate::{
@@ -158,6 +161,42 @@ fn rikiddo_default_ln_sum_exp_strategy_ln_zero() {
         "[RikiddoSigmoidMV] ln(exp_sum), exp_sum <= 0"
     );
 }
+
+#[test]
+fn rikiddo_optimized_ln_sum_exp_strategy_exponent_subtract_overflow() {
+    let rikiddo = Rikiddo::default();
+    let param = vec![<FixedI128<U64>>::from_num(1i64 << 63)];
+    assert_err!(
+        rikiddo.optimized_cost_strategy(&param, &<FixedI128<U64>>::from_num(1i64 << 62)),
+        "[RikiddoSigmoidFee] Overflow during calculation: current_exponent - biggest_exponent"
+    );
+}
+
+#[test]
+fn rikiddo_optimized_ln_sum_exp_strategy_sum_exp_i_overflow() {
+    let rikiddo = Rikiddo::default();
+    let exponent = <FixedI128<U64>>::from_num(42.7f64);
+    let param = vec![exponent, exponent, exponent];
+    assert_err!(
+        rikiddo.optimized_cost_strategy(&param, &<FixedI128<U64>>::from_num(0)),
+        "[RikiddoSigmoidFee] Overflow during calculation: sum_i(e^(i - biggest_exponent))"
+    );
+}
+
+#[test]
+fn rikiddo_optimized_ln_sum_exp_strategy_result_overflow() {
+    let rikiddo = Rikiddo::default();
+    let biggest_exponent = <FixedI128<U64>>::from_num(i64::MAX);
+    let exponent = biggest_exponent - <FixedI128<U64>>::from_num(0.0000001f64);
+    let param = vec![exponent, exponent, exponent];
+    assert_err!(
+        rikiddo.optimized_cost_strategy(&param, &biggest_exponent),
+        "[RikiddoSigmoidMV] Overflow during calculation: biggest_exponent + ln(exp_sum) \
+         (optimized)"
+    );
+}
+
+/*
 #[test]
 fn rikiddo_default_ln_sum_exp_strategy_returns_correct_result() -> Result<(), &'static str>{
     let rikiddo = Rikiddo::default();
@@ -177,6 +216,51 @@ fn rikiddo_default_ln_sum_exp_strategy_returns_correct_result() -> Result<(), &'
     // The fixed calculation seems to be quite errorneous: Difference = 0.00000007886511177446209
     assert!(
         difference_abs <= 0.000001f64,
+        "\nFixed result: {}\nFloat result: {}\nDifference: {}\nMax_Allowed_Difference: {}",
+        result_fixed_f64,
+        result_f64,
+        difference_abs,
+        max_allowed_error(64)
+    );
+
+    Ok(())
+}
+*/
+
+#[test]
+fn rikiddo_ln_sum_exp_strategies_return_correct_results() -> Result<(), &'static str> {
+    let rikiddo = Rikiddo::default();
+    let exponent0 = 3.5f64;
+    let exponent1 = 4.5f64;
+    let exponent2 = 5.5f64;
+    let param_f64 = vec![exponent0, exponent1, exponent2];
+    let param_fixed = vec![
+        <FixedI128<U64>>::from_num(exponent0),
+        <FixedI128<U64>>::from_num(exponent1),
+        <FixedI128<U64>>::from_num(exponent2),
+    ];
+    // Evaluate the result of the default cost strategy
+    let mut result_fixed = rikiddo.default_cost_strategy(&param_fixed)?;
+    let result_f64: f64 = ln_exp_sum(&param_f64);
+    let mut result_fixed_f64: f64 = result_fixed.to_num();
+    let mut difference_abs = (result_f64 - result_fixed_f64).abs();
+    // The fixed calculation seems to be quite errorneous: Difference = 0.00000007886511177446209
+    assert!(
+        difference_abs <= 0.000001f64,
+        "\nFixed result: {}\nFloat result: {}\nDifference: {}\nMax_Allowed_Difference: {}",
+        result_fixed_f64,
+        result_f64,
+        difference_abs,
+        max_allowed_error(64)
+    );
+
+    // Evaluate teh result of the optimize cost strategy
+    result_fixed = rikiddo.optimized_cost_strategy(&param_fixed, &param_fixed[2])?;
+    result_fixed_f64 = result_fixed.to_num();
+    difference_abs = (result_f64 - result_fixed_f64).abs();
+    // The fixed calculation seems to be quite errorneous: Difference = 0.00000007886511177446209
+    assert!(
+        difference_abs <= 0.00000001f64,
         "\nFixed result: {}\nFloat result: {}\nDifference: {}\nMax_Allowed_Difference: {}",
         result_fixed_f64,
         result_f64,

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -114,7 +114,6 @@ fn rikiddo_get_fee_returns_the_correct_result() {
     assert_ne!(rikiddo.ma_long.get(), None);
     // We don't want to test the exact result (that is the responsibility of the fee module),
     // but rather if rikiddo toggles properly between initial fee and the calculated fee
-    println!("{}", rikiddo.get_fee().unwrap());
     assert_ne!(rikiddo.get_fee().unwrap(), rikiddo.config.initial_fee);
 }
 
@@ -285,7 +284,6 @@ fn rikiddo_cost_function_overflow_during_log2e_times_biggest_exponent() {
     rikiddo.config.initial_fee = <FixedI128<U64>>::from_bits(0x0000_0000_0000_0000_0000_0000_0000_0003);
     rikiddo.config.log2_e = <FixedI128<U64>>::from_num(i64::MAX);
     let param = <FixedU128<U64>>::from_num(i64::MAX as u64);
-    println!("{} * {}", rikiddo.config.initial_fee, param);
     assert_err!(
         rikiddo.cost(&vec![param]),
         "[RikiddoSigmoidMV] Overflow during calculation: log2_e * biggest_exponent"
@@ -293,21 +291,29 @@ fn rikiddo_cost_function_overflow_during_log2e_times_biggest_exponent() {
 }
 
 #[test]
-fn rikiddo_cost_function_overflow_during_calculation_of_required_bits() {
-    let rikiddo = Rikiddo::default();
-    // TODO: implement
+fn rikiddo_cost_function_overflow_during_calculation_of_required_bits_minus_one() {
+    let mut rikiddo = Rikiddo::default();
+    rikiddo.config.initial_fee =  <FixedI128<U64>>::from_num(1);
+    rikiddo.config.log2_e = <FixedI128<U64>>::from_num(i64::MAX);
+    let param = <FixedU128<U64>>::from_num(i64::MAX as u64);
+    let zero = <FixedU128<U64>>::from_num(0);
+    assert_err!(
+        rikiddo.cost(&vec![param, zero]),
+        "[RikiddoSigmoidMV] Overflow during calculation: biggest_exp * log2(e) + log2(num_assets)"
+    );
 }
 
 #[test]
-fn rikiddo_cost_function_overflow_during_ceil_required_bits() {
-    let rikiddo = Rikiddo::default();
-    // TODO: implement
-}
-
-#[test]
-fn rikiddo_cost_function_overflow_during_ceil_required_bits_plus_one() {
-    let rikiddo = Rikiddo::default();
-    // TODO: implement
+fn rikiddo_cost_function_overflow_during_ceil_required_bits_minus_one() {
+    let mut rikiddo = Rikiddo::default();
+    rikiddo.config.initial_fee =  <FixedI128<U64>>::from_num(1);
+    rikiddo.config.log2_e = <FixedI128<U64>>::from_num(i64::MAX) + <FixedI128<U64>>::from_num(0.1);
+    let param = <FixedU128<U64>>::from_num(i64::MAX as u64);
+    assert_err!(
+        rikiddo.cost(&vec![param]),
+        "[RikiddoSigmoidMV] Overflow during calculation: ceil(biggest_exp * \
+            log2(e) + log2(num_assets))"
+    );
 }
 
 #[test]

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -2,10 +2,7 @@ use frame_support::assert_err;
 use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
 
 use super::ema_market_volume::ema_create_test_struct;
-use crate::{
-    traits::{MarketAverage, RikiddoMV},
-    types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume},
-};
+use crate::{constants::INITIAL_FEE, traits::{MarketAverage, RikiddoMV}, types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume, convert_to_signed}};
 
 type Rikiddo = RikiddoSigmoidMV<
     FixedU128<U64>,
@@ -105,4 +102,17 @@ fn rikiddo_get_fee_returns_the_correct_result() {
     // but rather if rikiddo toggles properly between initial fee and the calculated fee
     println!("{}", rikiddo.get_fee().unwrap());
     assert_ne!(rikiddo.get_fee().unwrap(), rikiddo.config.initial_fee);
+}
+
+#[test]
+fn rikiddo_default_does_not_panic() -> Result<(), &'static str> {
+    let default_rikiddo = Rikiddo::default();
+    let rikiddo = Rikiddo::new(
+        RikiddoConfig::new(convert_to_signed(INITIAL_FEE)?)?,
+        FeeSigmoid::default(),
+        EmaMarketVolume::default(),
+        EmaMarketVolume::default(),
+    );
+    assert_eq!(default_rikiddo, rikiddo);
+    Ok(())
 }

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -1,8 +1,15 @@
 use frame_support::assert_err;
 use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
 
-use super::ema_market_volume::ema_create_test_struct;
-use crate::{constants::INITIAL_FEE, traits::{MarketAverage, RikiddoMV}, types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume, convert_to_signed}};
+use super::{ema_market_volume::ema_create_test_struct, max_allowed_error};
+use crate::{
+    constants::INITIAL_FEE,
+    traits::{MarketAverage, RikiddoMV},
+    types::{
+        convert_to_signed, EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV,
+        TimestampedVolume,
+    },
+};
 
 type Rikiddo = RikiddoSigmoidMV<
     FixedU128<U64>,
@@ -10,6 +17,10 @@ type Rikiddo = RikiddoSigmoidMV<
     FeeSigmoid<FixedI128<U64>, FixedU128<U64>>,
     EmaMarketVolume<FixedU128<U64>>,
 >;
+
+fn ln_exp_sum(exponents: &Vec<f64>) -> f64 {
+    exponents.iter().fold(0f64, |acc, val| acc + val.exp()).ln()
+}
 
 #[test]
 fn rikiddo_updates_mv_and_returns_some() {
@@ -108,11 +119,70 @@ fn rikiddo_get_fee_returns_the_correct_result() {
 fn rikiddo_default_does_not_panic() -> Result<(), &'static str> {
     let default_rikiddo = Rikiddo::default();
     let rikiddo = Rikiddo::new(
-        RikiddoConfig::new(convert_to_signed(INITIAL_FEE)?)?,
+        RikiddoConfig::new(convert_to_signed(INITIAL_FEE)?),
         FeeSigmoid::default(),
         EmaMarketVolume::default(),
         EmaMarketVolume::default(),
     );
     assert_eq!(default_rikiddo, rikiddo);
+    Ok(())
+}
+
+#[test]
+fn rikiddo_default_ln_sum_exp_strategy_exp_i_overflow() {
+    let rikiddo = Rikiddo::default();
+    let param = vec![<FixedI128<U64>>::from_num(100u64)];
+    assert_err!(
+        rikiddo.default_cost_strategy(&param),
+        "[RikiddoSigmoidMV] Error during calculation: exp(i) in ln sum_i(exp^i)"
+    );
+}
+
+#[test]
+fn rikiddo_default_ln_sum_exp_strategy_sum_exp_i_overflow() {
+    let rikiddo = Rikiddo::default();
+    let exponent = <FixedI128<U64>>::from_num(42.7f64);
+    let param = vec![exponent, exponent, exponent];
+    assert_err!(
+        rikiddo.default_cost_strategy(&param),
+        "[RikiddoSigmoidMV] Overflow during calculation: sum_i(e^i)"
+    );
+}
+
+#[test]
+fn rikiddo_default_ln_sum_exp_strategy_ln_zero() {
+    let rikiddo = Rikiddo::default();
+    let param = vec![];
+    assert_err!(
+        rikiddo.default_cost_strategy(&param),
+        "[RikiddoSigmoidMV] ln(exp_sum), exp_sum <= 0"
+    );
+}
+#[test]
+fn rikiddo_default_ln_sum_exp_strategy_returns_correct_result() -> Result<(), &'static str>{
+    let rikiddo = Rikiddo::default();
+    let exponent0 = 3.5f64;
+    let exponent1 = 4.5f64;
+    let exponent2 = 5.5f64;
+    let param_f64 = vec![exponent0, exponent1, exponent2];
+    let param_fixed = vec![
+        <FixedI128<U64>>::from_num(exponent0),
+        <FixedI128<U64>>::from_num(exponent1),
+        <FixedI128<U64>>::from_num(exponent2),
+    ];
+    let result_fixed = rikiddo.default_cost_strategy(&param_fixed)?;
+    let result_f64: f64 = ln_exp_sum(&param_f64);
+    let result_fixed_f64: f64 = result_fixed.to_num();
+    let difference_abs = (result_f64 - result_fixed_f64).abs();
+    // The fixed calculation seems to be quite errorneous: Difference = 0.00000007886511177446209
+    assert!(
+        difference_abs <= 0.000001f64,
+        "\nFixed result: {}\nFloat result: {}\nDifference: {}\nMax_Allowed_Difference: {}",
+        result_fixed_f64,
+        result_f64,
+        difference_abs,
+        max_allowed_error(64)
+    );
+
     Ok(())
 }

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -2,10 +2,7 @@ use frame_support::assert_err;
 use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
 
 use super::ema_market_volume::ema_create_test_struct;
-use crate::{
-    traits::RikiddoMV,
-    types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume},
-};
+use crate::{traits::{MarketAverage, RikiddoMV}, types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume}};
 
 type Rikiddo = RikiddoSigmoidMV<
     FixedU128<U64>,
@@ -84,9 +81,26 @@ fn rikiddo_get_fee_ratio_does_not_fit_in_type() {
     );
 }
 
-/*
+
 #[test]
 fn rikiddo_get_fee_returns_the_correct_result() {
-    assert!(false);
+    let emv_short = ema_create_test_struct(1, 2.0);
+    let emv_long = ema_create_test_struct(2, 2.0);
+    let mut rikiddo =
+        Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv_short, emv_long);
+    assert_eq!(rikiddo.ma_short.get(), None);
+    assert_eq!(rikiddo.ma_long.get(), None);
+    assert_eq!(rikiddo.get_fee().unwrap(), rikiddo.config.initial_fee);
+    let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 100u32.into() });
+    let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 100u32.into() });
+    assert_ne!(rikiddo.ma_short.get(), None);
+    assert_eq!(rikiddo.ma_long.get(), None);
+    assert_eq!(rikiddo.get_fee().unwrap(), rikiddo.config.initial_fee);
+    let _ = rikiddo.update(&TimestampedVolume { timestamp: 3, volume: 100u32.into() });
+    assert_ne!(rikiddo.ma_short.get(), None);
+    assert_ne!(rikiddo.ma_long.get(), None);
+    // We don't want to test the exactl result (that is the responsibility of the fee module),
+    // but rather if rikiddo toggles properly between initial fee and the calculated fee
+    println!("{}", rikiddo.get_fee().unwrap());
+    assert_ne!(rikiddo.get_fee().unwrap(), rikiddo.config.initial_fee);
 }
-*/

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -1,4 +1,4 @@
-use substrate_fixed::{traits::ToFixed, types::extra::U64, FixedI128, FixedU128};
+use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
 
 use super::ema_market_volume::ema_create_test_struct;
 use crate::{
@@ -31,4 +31,19 @@ fn rikiddo_updates_mv_and_returns_none() {
     >>::default();
     let vol = TimestampedVolume::default();
     assert_eq!(rikiddo.update(&vol).unwrap(), None);
+}
+
+#[test]
+fn rikiddo_clear_clears_market_data() {
+    let mut rikiddo = <RikiddoSigmoidMV<
+        FixedU128<U64>,
+        FixedI128<U64>,
+        FeeSigmoid<FixedI128<U64>, FixedU128<U64>>,
+        EmaMarketVolume<FixedU128<U64>>,
+    >>::default();
+    let rikiddo_clone = rikiddo.clone();
+    let _ = rikiddo.update(&<TimestampedVolume<FixedU128<U64>>>::default());
+    assert_ne!(rikiddo, rikiddo_clone);
+    rikiddo.clear();
+    assert_eq!(rikiddo, rikiddo_clone);
 }

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -14,7 +14,7 @@ use crate::{
 type Rikiddo = RikiddoSigmoidMV<
     FixedU128<U64>,
     FixedI128<U64>,
-    FeeSigmoid<FixedI128<U64>, FixedU128<U64>>,
+    FeeSigmoid<FixedI128<U64>>,
     EmaMarketVolume<FixedU128<U64>>,
 >;
 

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -1,5 +1,5 @@
 use frame_support::assert_err;
-use substrate_fixed::{FixedI128, FixedU128, traits::ToFixed, types::extra::{U120, U127, U128, U32, U64}};
+use substrate_fixed::{traits::ToFixed, types::extra::U64, FixedI128, FixedU128};
 
 use super::{ema_market_volume::ema_create_test_struct, max_allowed_error};
 use crate::{

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -1,0 +1,34 @@
+use substrate_fixed::{traits::ToFixed, types::extra::U64, FixedI128, FixedU128};
+
+use super::ema_market_volume::ema_create_test_struct;
+use crate::{
+    traits::RikiddoMV,
+    types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume},
+};
+
+#[test]
+fn rikiddo_updates_mv_and_returns_some() {
+    let emv = ema_create_test_struct(1, 2.0);
+    let mut rikiddo = <RikiddoSigmoidMV<
+        FixedU128<U64>,
+        FixedI128<U64>,
+        FeeSigmoid<FixedI128<U64>, FixedU128<U64>>,
+        EmaMarketVolume<FixedU128<U64>>,
+    >>::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
+    rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 1u32.into() }).unwrap();
+    let res = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 2u32.into() }).unwrap();
+    assert_eq!(res, Some(1u32.into()));
+
+}
+
+#[test]
+fn rikiddo_updates_mv_and_returns_none() {
+    let mut rikiddo = <RikiddoSigmoidMV<
+        FixedU128<U64>,
+        FixedI128<U64>,
+        FeeSigmoid<FixedI128<U64>, FixedU128<U64>>,
+        EmaMarketVolume<FixedU128<U64>>,
+    >>::default();
+    let vol = TimestampedVolume::default();
+    assert_eq!(rikiddo.update(&vol).unwrap(), None);
+}

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -1,3 +1,4 @@
+use frame_support::assert_err;
 use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
 
 use super::ema_market_volume::ema_create_test_struct;
@@ -6,44 +7,86 @@ use crate::{
     types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume},
 };
 
+type Rikiddo = RikiddoSigmoidMV<
+    FixedU128<U64>,
+    FixedI128<U64>,
+    FeeSigmoid<FixedI128<U64>, FixedU128<U64>>,
+    EmaMarketVolume<FixedU128<U64>>,
+>;
+
 #[test]
 fn rikiddo_updates_mv_and_returns_some() {
     let emv = ema_create_test_struct(1, 2.0);
-    let mut rikiddo = <RikiddoSigmoidMV<
-        FixedU128<U64>,
-        FixedI128<U64>,
-        FeeSigmoid<FixedI128<U64>, FixedU128<U64>>,
-        EmaMarketVolume<FixedU128<U64>>,
-    >>::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
+    let mut rikiddo =
+        Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
     rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 1u32.into() }).unwrap();
     let res = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 2u32.into() }).unwrap();
     assert_eq!(res, Some(1u32.into()));
-
 }
 
 #[test]
 fn rikiddo_updates_mv_and_returns_none() {
-    let mut rikiddo = <RikiddoSigmoidMV<
-        FixedU128<U64>,
-        FixedI128<U64>,
-        FeeSigmoid<FixedI128<U64>, FixedU128<U64>>,
-        EmaMarketVolume<FixedU128<U64>>,
-    >>::default();
+    let mut rikiddo = Rikiddo::default();
     let vol = TimestampedVolume::default();
     assert_eq!(rikiddo.update(&vol).unwrap(), None);
 }
 
 #[test]
 fn rikiddo_clear_clears_market_data() {
-    let mut rikiddo = <RikiddoSigmoidMV<
-        FixedU128<U64>,
-        FixedI128<U64>,
-        FeeSigmoid<FixedI128<U64>, FixedU128<U64>>,
-        EmaMarketVolume<FixedU128<U64>>,
-    >>::default();
+    let mut rikiddo = Rikiddo::default();
     let rikiddo_clone = rikiddo.clone();
     let _ = rikiddo.update(&<TimestampedVolume<FixedU128<U64>>>::default());
     assert_ne!(rikiddo, rikiddo_clone);
     rikiddo.clear();
     assert_eq!(rikiddo, rikiddo_clone);
 }
+
+#[test]
+fn rikiddo_get_fee_catches_zero_divison() {
+    let emv = ema_create_test_struct(1, 0.0);
+    let mut rikiddo =
+        Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
+    let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
+    let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
+    assert_err!(
+        rikiddo.get_fee(),
+        "[RikiddoSigmoidMV] Zero division error during calculation: ma_short / ma_long"
+    );
+}
+
+#[test]
+fn rikiddo_get_fee_overflows_during_ratio_calculation() {
+    let emv = ema_create_test_struct(1, 2.0);
+    let mut rikiddo =
+        Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
+    let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
+    let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
+    rikiddo.ma_short.ema = <FixedU128<U64>>::from_num(u64::MAX);
+    rikiddo.ma_long.ema = <FixedU128<U64>>::from_num(0.1f64);
+    assert_err!(
+        rikiddo.get_fee(),
+        "[RikiddoSigmoidMV] Overflow during calculation: ma_short / ma_long"
+    );
+}
+
+#[test]
+fn rikiddo_get_fee_ratio_does_not_fit_in_type() {
+    let emv = ema_create_test_struct(1, 2.0);
+    let mut rikiddo =
+        Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
+    let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
+    let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
+    rikiddo.ma_short.ema = <FixedU128<U64>>::from_num(u64::MAX);
+    rikiddo.ma_long.ema = <FixedU128<U64>>::from_num(1u64);
+    assert_err!(
+        rikiddo.get_fee(),
+        "[RikiddoSigmoidMV] Overflow during conversion from ma. ratio into type FS"
+    );
+}
+
+/*
+#[test]
+fn rikiddo_get_fee_returns_the_correct_result() {
+    assert!(false);
+}
+*/

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -80,7 +80,7 @@ fn rikiddo_get_fee_ratio_does_not_fit_in_type() {
     rikiddo.ma_long.ema = <FixedU128<U64>>::from_num(1u64);
     assert_err!(
         rikiddo.get_fee(),
-        "[RikiddoSigmoidMV] Overflow during conversion from ma. ratio into type FS"
+        "Fixed point conversion failed: FROM type does not fit in TO type"
     );
 }
 
@@ -101,7 +101,7 @@ fn rikiddo_get_fee_returns_the_correct_result() {
     let _ = rikiddo.update(&TimestampedVolume { timestamp: 3, volume: 100u32.into() });
     assert_ne!(rikiddo.ma_short.get(), None);
     assert_ne!(rikiddo.ma_long.get(), None);
-    // We don't want to test the exactl result (that is the responsibility of the fee module),
+    // We don't want to test the exact result (that is the responsibility of the fee module),
     // but rather if rikiddo toggles properly between initial fee and the calculated fee
     println!("{}", rikiddo.get_fee().unwrap());
     assert_ne!(rikiddo.get_fee().unwrap(), rikiddo.config.initial_fee);

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -2,7 +2,10 @@ use frame_support::assert_err;
 use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
 
 use super::ema_market_volume::ema_create_test_struct;
-use crate::{traits::{MarketAverage, RikiddoMV}, types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume}};
+use crate::{
+    traits::{MarketAverage, RikiddoMV},
+    types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume},
+};
 
 type Rikiddo = RikiddoSigmoidMV<
     FixedU128<U64>,
@@ -80,7 +83,6 @@ fn rikiddo_get_fee_ratio_does_not_fit_in_type() {
         "[RikiddoSigmoidMV] Overflow during conversion from ma. ratio into type FS"
     );
 }
-
 
 #[test]
 fn rikiddo_get_fee_returns_the_correct_result() {

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -4,21 +4,25 @@ use crate::{
     types::{FeeSigmoid, FeeSigmoidConfig},
 };
 use frame_support::assert_err;
-use substrate_fixed::{types::extra::U64, FixedI128};
+use substrate_fixed::{FixedI128, FixedU128, types::extra::U64};
 
 fn sigmoid_fee(m: f64, n: f64, p: f64, r: f64) -> f64 {
     (m * (r - n)) / (p + (r - n).powi(2)).sqrt()
 }
 
-fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>>, f64, f64, f64) {
+fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>, FixedU128<U64>>, f64, f64, f64) {
     let m = 0.01f64;
     let n = 0f64;
     let p = 2.0f64;
+    let initial_fee = 0.005;
+    let min_revenue = 0.0035;
 
     let config = FeeSigmoidConfig {
         m: <FixedI128<U64>>::from_num(m),
         n: <FixedI128<U64>>::from_num(n),
         p: <FixedI128<U64>>::from_num(p),
+        initial_fee: <FixedU128<U64>>::from_num(initial_fee),
+        min_revenue: <FixedU128<U64>>::from_num(min_revenue),
     };
 
     let fee = FeeSigmoid { config };

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -21,7 +21,6 @@ fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>, FixedU128<U6
         m: <FixedI128<U64>>::from_num(m),
         n: <FixedI128<U64>>::from_num(n),
         p: <FixedI128<U64>>::from_num(p),
-        initial_fee: <FixedU128<U64>>::from_num(initial_fee),
         min_revenue: <FixedU128<U64>>::from_num(min_revenue),
     };
 

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -97,7 +97,6 @@ fn fee_sigmoid_correct_result() -> Result<(), &'static str> {
         max_allowed_error(64)
     );
 
-    // TODO: Test min_revenue
     fee.config.min_revenue = <FixedU128<U64>>::from_num(1u64 << 63);
     assert_eq!(fee.calculate(r_fixed)?, fee.config.min_revenue);
     Ok(())

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -10,7 +10,7 @@ fn sigmoid_fee(m: f64, n: f64, p: f64, r: f64) -> f64 {
     (m * (r - n)) / (p + (r - n).powi(2)).sqrt()
 }
 
-fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>, FixedU128<U64>>, f64, f64, f64)
+fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>>, f64, f64, f64)
 {
     let m = 0.01f64;
     let n = 0f64;
@@ -23,7 +23,7 @@ fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>, FixedU128<U6
         n: <FixedI128<U64>>::from_num(n),
         p: <FixedI128<U64>>::from_num(p),
         initial_fee: <FixedI128<U64>>::from_num(initial_fee),
-        min_revenue: <FixedU128<U64>>::from_num(min_revenue),
+        min_revenue: <FixedI128<U64>>::from_num(min_revenue),
     };
 
     let fee = FeeSigmoid { config };
@@ -97,7 +97,7 @@ fn fee_sigmoid_correct_result() -> Result<(), &'static str> {
         max_allowed_error(64)
     );
 
-    fee.config.min_revenue = <FixedU128<U64>>::from_num(1u64 << 63);
+    fee.config.min_revenue = <FixedI128<U64>>::from_num(1u64 << 62);
     assert_eq!(fee.calculate(r_fixed)?, fee.config.min_revenue);
     Ok(())
 }

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -79,9 +79,10 @@ fn fee_sigmoid_overflow_numerator_div_denominator() {
 #[test]
 fn fee_sigmoid_correct_result() -> Result<(), &'static str> {
     let r = 1.5f64;
-    let (fee, m, n, p) = init_default_sigmoid_fee_struct();
+    let (mut fee, m, n, p) = init_default_sigmoid_fee_struct();
     let fee_f64 = sigmoid_fee(m, n, p, r);
-    let fee_fixed = fee.calculate(<FixedI128<U64>>::from_num(r))?;
+    let r_fixed = <FixedI128<U64>>::from_num(r);
+    let fee_fixed = fee.calculate(r_fixed)?;
     let fee_fixed_f64: f64 = fee_fixed.to_num();
     let difference_abs = (fee_f64 - fee_fixed_f64).abs();
 
@@ -95,6 +96,7 @@ fn fee_sigmoid_correct_result() -> Result<(), &'static str> {
     );
 
     // TODO: Test min_revenue
-
+    fee.config.min_revenue = <FixedU128<U64>>::from_num(1u64 << 63);
+    assert_eq!(fee.calculate(r_fixed)?, fee.config.min_revenue);
     Ok(())
 }

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -4,13 +4,14 @@ use crate::{
     types::{FeeSigmoid, FeeSigmoidConfig},
 };
 use frame_support::assert_err;
-use substrate_fixed::{FixedI128, FixedU128, types::extra::U64};
+use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
 
 fn sigmoid_fee(m: f64, n: f64, p: f64, r: f64) -> f64 {
     (m * (r - n)) / (p + (r - n).powi(2)).sqrt()
 }
 
-fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>, FixedU128<U64>>, f64, f64, f64) {
+fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>, FixedU128<U64>>, f64, f64, f64)
+{
     let m = 0.01f64;
     let n = 0f64;
     let p = 2.0f64;

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -15,12 +15,14 @@ fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>, FixedU128<U6
     let m = 0.01f64;
     let n = 0f64;
     let p = 2.0f64;
+    let initial_fee = 0.005;
     let min_revenue = 0.0035;
 
     let config = FeeSigmoidConfig {
         m: <FixedI128<U64>>::from_num(m),
         n: <FixedI128<U64>>::from_num(n),
         p: <FixedI128<U64>>::from_num(p),
+        initial_fee: <FixedI128<U64>>::from_num(initial_fee),
         min_revenue: <FixedU128<U64>>::from_num(min_revenue),
     };
 
@@ -80,7 +82,7 @@ fn fee_sigmoid_overflow_numerator_div_denominator() {
 fn fee_sigmoid_correct_result() -> Result<(), &'static str> {
     let r = 1.5f64;
     let (mut fee, m, n, p) = init_default_sigmoid_fee_struct();
-    let fee_f64 = sigmoid_fee(m, n, p, r);
+    let fee_f64 = fee.config.initial_fee.to_num::<f64>() + sigmoid_fee(m, n, p, r);
     let r_fixed = <FixedI128<U64>>::from_num(r);
     let fee_fixed = fee.calculate(r_fixed)?;
     let fee_fixed_f64: f64 = fee_fixed.to_num();

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -94,5 +94,7 @@ fn fee_sigmoid_correct_result() -> Result<(), &'static str> {
         max_allowed_error(64)
     );
 
+    // TODO: Test min_revenue
+
     Ok(())
 }

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -14,7 +14,6 @@ fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>, FixedU128<U6
     let m = 0.01f64;
     let n = 0f64;
     let p = 2.0f64;
-    let initial_fee = 0.005;
     let min_revenue = 0.0035;
 
     let config = FeeSigmoidConfig {
@@ -88,8 +87,8 @@ fn fee_sigmoid_correct_result() -> Result<(), &'static str> {
     assert!(
         difference_abs <= max_allowed_error(64),
         "\nFixed result: {}\nFloat result: {}\nDifference: {}\nMax_Allowed_Difference: {}",
-        fee_f64,
         fee_fixed_f64,
+        fee_f64,
         difference_abs,
         max_allowed_error(64)
     );

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -4,14 +4,13 @@ use crate::{
     types::{FeeSigmoid, FeeSigmoidConfig},
 };
 use frame_support::assert_err;
-use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
+use substrate_fixed::{types::extra::U64, FixedI128};
 
 fn sigmoid_fee(m: f64, n: f64, p: f64, r: f64) -> f64 {
     (m * (r - n)) / (p + (r - n).powi(2)).sqrt()
 }
 
-fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>>, f64, f64, f64)
-{
+fn init_default_sigmoid_fee_struct() -> (FeeSigmoid<FixedI128<U64>>, f64, f64, f64) {
     let m = 0.01f64;
     let n = 0f64;
     let p = 2.0f64;

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -36,16 +36,16 @@ pub trait Lmsr {
     type FU: FixedUnsigned;
 
     /// Return price P_i(q) for all assets in q
-    fn all_prices(&self, asset_balances: Vec<Self::FU>) -> Result<Vec<Self::FU>, &'static str>;
+    fn all_prices(&self, asset_balances: &Vec<Self::FU>) -> Result<Vec<Self::FU>, &'static str>;
 
     /// Return cost C(q) for all assets in q
-    fn cost(&self, asset_balances: Vec<Self::FU>) -> Result<Self::FU, &'static str>;
+    fn cost(&self, asset_balances: &Vec<Self::FU>) -> Result<Self::FU, &'static str>;
 
     /// Return price P_i(q) for asset q_i in q
     fn price(
         &self,
-        asset_in_question_balance: Self::FU,
-        asset_balances: Vec<Self::FU>,
+        asset_in_question_balance: &Self::FU,
+        asset_balances: &Vec<Self::FU>,
     ) -> Result<Self::FU, &'static str>;
 }
 

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -9,14 +9,15 @@ use sp_std::fmt::Debug;
 use substrate_fixed::traits::{Fixed, FixedSigned, FixedUnsigned};
 
 pub trait Sigmoid {
-    type F: Fixed;
+    type FIN: Fixed;
+    type FOUT: Fixed;
 
     /// Calculate fee
-    fn calculate(&self, r: Self::F) -> Result<Self::F, &'static str>;
+    fn calculate(&self, r: Self::FIN) -> Result<Self::FOUT, &'static str>;
 }
 
 pub trait MarketAverage {
-    type F: Fixed;
+    type F: FixedUnsigned;
 
     /// Get average (sma, ema, wma, depending on the concrete implementation) of market volume
     fn get(&self) -> Option<Self::F>;
@@ -32,7 +33,7 @@ pub trait MarketAverage {
 }
 
 pub trait Lmsr {
-    type F: Fixed;
+    type F: FixedUnsigned;
 
     /// Return price P_i(q) for all assets in q
     fn all_prices(asset_balances: Vec<Self::F>) -> Result<Vec<Self::F>, &'static str>;
@@ -83,7 +84,7 @@ pub trait RikiddoSigmoidMVPallet {
     /// Create Rikiddo instance for specifc asset pool
     fn create(
         poolid: u128,
-        fee_config: FeeSigmoidConfig<Self::FS>,
+        fee_config: FeeSigmoidConfig<Self::FS, Self::FU>,
         ema_config_short: EmaConfig<Self::FU>,
         ema_config_long: EmaConfig<Self::FU>,
         balance_one_unit: Self::Balance,

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -35,16 +35,16 @@ pub trait Lmsr {
     type FU: FixedUnsigned;
 
     /// Return price P_i(q) for all assets in q
-    fn all_prices(&self, asset_balances: &Vec<Self::FU>) -> Result<Vec<Self::FU>, &'static str>;
+    fn all_prices(&self, asset_balances: &[Self::FU]) -> Result<Vec<Self::FU>, &'static str>;
 
     /// Return cost C(q) for all assets in q
-    fn cost(&self, asset_balances: &Vec<Self::FU>) -> Result<Self::FU, &'static str>;
+    fn cost(&self, asset_balances: &[Self::FU]) -> Result<Self::FU, &'static str>;
 
     /// Return price P_i(q) for asset q_i in q
     fn price(
         &self,
         asset_in_question_balance: &Self::FU,
-        asset_balances: &Vec<Self::FU>,
+        asset_balances: &[Self::FU],
     ) -> Result<Self::FU, &'static str>;
 }
 

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -9,11 +9,10 @@ use sp_std::fmt::Debug;
 use substrate_fixed::traits::{Fixed, FixedSigned, FixedUnsigned};
 
 pub trait Sigmoid {
-    type FIN: Fixed;
-    type FOUT: Fixed;
+    type FS: Fixed;
 
     /// Calculate fee
-    fn calculate(&self, r: Self::FIN) -> Result<Self::FOUT, &'static str>;
+    fn calculate(&self, r: Self::FS) -> Result<Self::FS, &'static str>;
 }
 
 pub trait MarketAverage {
@@ -85,7 +84,7 @@ pub trait RikiddoSigmoidMVPallet {
     /// Create Rikiddo instance for specifc asset pool
     fn create(
         poolid: u128,
-        fee_config: FeeSigmoidConfig<Self::FS, Self::FU>,
+        fee_config: FeeSigmoidConfig<Self::FS>,
         ema_config_short: EmaConfig<Self::FU>,
         ema_config_long: EmaConfig<Self::FU>,
         balance_one_unit: Self::Balance,

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -8,42 +8,57 @@ use sp_runtime::traits::AtLeast32BitUnsigned;
 use sp_std::fmt::Debug;
 use substrate_fixed::traits::{Fixed, FixedSigned, FixedUnsigned};
 
-pub trait Sigmoid<F: Fixed> {
+pub trait Sigmoid {
+    type F: Fixed;
+
     /// Calculate fee
-    fn calculate(&self, r: F) -> Result<F, &'static str>;
+    fn calculate(&self, r: Self::F) -> Result<Self::F, &'static str>;
 }
 
-pub trait MarketAverage<F: Fixed> {
+pub trait MarketAverage {
+    type F: Fixed;
+
     /// Get average (sma, ema, wma, depending on the concrete implementation) of market volume
-    fn get(&self) -> Option<F>;
+    fn get(&self) -> Option<Self::F>;
 
     /// Clear market data
     fn clear(&mut self);
 
     /// Update market volume
-    fn update(&mut self, volume: TimestampedVolume<F>) -> Result<Option<F>, &'static str>;
+    fn update(
+        &mut self,
+        volume: TimestampedVolume<Self::F>,
+    ) -> Result<Option<Self::F>, &'static str>;
 }
 
-pub trait Lmsr<F: Fixed> {
+pub trait Lmsr {
+    type F: Fixed;
+
     /// Return price P_i(q) for all assets in q
-    fn all_prices(asset_balances: Vec<F>) -> Result<Vec<F>, &'static str>;
+    fn all_prices(asset_balances: Vec<Self::F>) -> Result<Vec<Self::F>, &'static str>;
 
     /// Return cost C(q) for all assets in q
-    fn cost(asset_balances: Vec<F>) -> Result<F, &'static str>;
+    fn cost(asset_balances: Vec<Self::F>) -> Result<Self::F, &'static str>;
 
     /// Return price P_i(q) for asset q_i in q
-    fn price(asset_in_question_balance: F, asset_balances: Vec<F>) -> Result<F, &'static str>;
+    fn price(
+        asset_in_question_balance: Self::F,
+        asset_balances: Vec<Self::F>,
+    ) -> Result<Self::F, &'static str>;
 }
 
-pub trait RikiddoMV<F: Fixed>: Lmsr<F> {
+pub trait RikiddoMV: Lmsr {
     /// Clear market data
     fn clear(&mut self);
 
     /// Update market data
-    fn update(&mut self, volume: TimestampedVolume<F>) -> Result<Option<F>, &'static str>;
+    fn update(
+        &mut self,
+        volume: TimestampedVolume<Self::F>,
+    ) -> Result<Option<Self::F>, &'static str>;
 }
 
-pub trait RikiddoSigmoidMVPallet<FS: FixedSigned, FU: FixedUnsigned> {
+pub trait RikiddoSigmoidMVPallet {
     type Balance: Parameter
         + Member
         + AtLeast32BitUnsigned
@@ -52,6 +67,9 @@ pub trait RikiddoSigmoidMVPallet<FS: FixedSigned, FU: FixedUnsigned> {
         + Copy
         + MaybeSerializeDeserialize
         + Debug;
+
+    type FS: FixedSigned;
+    type FU: FixedUnsigned;
 
     /// Clear market data for specific asset pool
     fn clear(poolid: u128);
@@ -65,9 +83,9 @@ pub trait RikiddoSigmoidMVPallet<FS: FixedSigned, FU: FixedUnsigned> {
     /// Create Rikiddo instance for specifc asset pool
     fn create(
         poolid: u128,
-        fee_config: FeeSigmoidConfig<FS>,
-        ema_config_short: EmaVolumeConfig<FU>,
-        ema_config_long: EmaVolumeConfig<FU>,
+        fee_config: FeeSigmoidConfig<Self::FS>,
+        ema_config_short: EmaVolumeConfig<Self::FU>,
+        ema_config_long: EmaVolumeConfig<Self::FU>,
         balance_one_unit: Self::Balance,
     );
 

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -17,10 +17,10 @@ pub trait Sigmoid {
 }
 
 pub trait MarketAverage {
-    type F: FixedUnsigned;
+    type FU: FixedUnsigned;
 
     /// Get average (sma, ema, wma, depending on the concrete implementation) of market volume
-    fn get(&self) -> Option<Self::F>;
+    fn get(&self) -> Option<Self::FU>;
 
     /// Clear market data
     fn clear(&mut self);
@@ -28,24 +28,24 @@ pub trait MarketAverage {
     /// Update market volume
     fn update(
         &mut self,
-        volume: TimestampedVolume<Self::F>,
-    ) -> Result<Option<Self::F>, &'static str>;
+        volume: &TimestampedVolume<Self::FU>,
+    ) -> Result<Option<Self::FU>, &'static str>;
 }
 
 pub trait Lmsr {
-    type F: FixedUnsigned;
+    type FU: FixedUnsigned;
 
     /// Return price P_i(q) for all assets in q
-    fn all_prices(asset_balances: Vec<Self::F>) -> Result<Vec<Self::F>, &'static str>;
+    fn all_prices(asset_balances: Vec<Self::FU>) -> Result<Vec<Self::FU>, &'static str>;
 
     /// Return cost C(q) for all assets in q
-    fn cost(asset_balances: Vec<Self::F>) -> Result<Self::F, &'static str>;
+    fn cost(asset_balances: Vec<Self::FU>) -> Result<Self::FU, &'static str>;
 
     /// Return price P_i(q) for asset q_i in q
     fn price(
-        asset_in_question_balance: Self::F,
-        asset_balances: Vec<Self::F>,
-    ) -> Result<Self::F, &'static str>;
+        asset_in_question_balance: Self::FU,
+        asset_balances: Vec<Self::FU>,
+    ) -> Result<Self::FU, &'static str>;
 }
 
 pub trait RikiddoMV: Lmsr {
@@ -55,8 +55,8 @@ pub trait RikiddoMV: Lmsr {
     /// Update market data
     fn update(
         &mut self,
-        volume: TimestampedVolume<Self::F>,
-    ) -> Result<Option<Self::F>, &'static str>;
+        volume: &TimestampedVolume<Self::FU>,
+    ) -> Result<Option<Self::FU>, &'static str>;
 }
 
 pub trait RikiddoSigmoidMVPallet {

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -36,13 +36,14 @@ pub trait Lmsr {
     type FU: FixedUnsigned;
 
     /// Return price P_i(q) for all assets in q
-    fn all_prices(asset_balances: Vec<Self::FU>) -> Result<Vec<Self::FU>, &'static str>;
+    fn all_prices(&self, asset_balances: Vec<Self::FU>) -> Result<Vec<Self::FU>, &'static str>;
 
     /// Return cost C(q) for all assets in q
-    fn cost(asset_balances: Vec<Self::FU>) -> Result<Self::FU, &'static str>;
+    fn cost(&self, asset_balances: Vec<Self::FU>) -> Result<Self::FU, &'static str>;
 
     /// Return price P_i(q) for asset q_i in q
     fn price(
+        &self,
         asset_in_question_balance: Self::FU,
         asset_balances: Vec<Self::FU>,
     ) -> Result<Self::FU, &'static str>;

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::types::{EmaVolumeConfig, FeeSigmoidConfig, TimestampedVolume};
+use crate::types::{EmaConfig, FeeSigmoidConfig, TimestampedVolume};
 use frame_support::{
     pallet_prelude::{MaybeSerializeDeserialize, Member},
     Parameter,
@@ -84,8 +84,8 @@ pub trait RikiddoSigmoidMVPallet {
     fn create(
         poolid: u128,
         fee_config: FeeSigmoidConfig<Self::FS>,
-        ema_config_short: EmaVolumeConfig<Self::FU>,
-        ema_config_long: EmaVolumeConfig<Self::FU>,
+        ema_config_short: EmaConfig<Self::FU>,
+        ema_config_long: EmaConfig<Self::FU>,
         balance_one_unit: Self::Balance,
     );
 

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -1,5 +1,5 @@
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
-use substrate_fixed::traits::Fixed;
+use substrate_fixed::traits::{Fixed, ToFixed};
 
 mod ema_market_volume;
 mod rikiddo_sigmoid_mv;
@@ -36,4 +36,33 @@ impl Timespan {
             Timespan::Weeks(d) => u32::from(d) * 60 * 60 * 24 * 7,
         }
     }
+}
+
+/// Converts one Fixed number into another (fallible)
+// TODO: test
+fn convert<FROM: Fixed, TO: Fixed>(num: FROM) -> Result<TO, &'static str> {
+        let msb_num = 1.to_fixed::<FROM>() << (FROM::int_nbits() - 1);
+
+        // Check if msb is set
+        if num & msb_num != 0 {
+            return Err("Fixed conversion failed: MSB is set");
+        }
+
+        // PartialOrd is bugged, therefore the workaround
+        // https://github.com/encointer/substrate-fixed/issues/9
+        if TO::max_value().int().to_num::<u128>() < num.int().to_num::<u128>() {
+            return Err("Fixed conversion failed: FROM type does not fit in TO type");
+        }
+
+        let integer_part_signed = i128::from_fixed(sigmoid_result.int());
+        // We can safely cast because until here we know that the integer part is unsigned.
+        let integer_part: Self::FOUT = (integer_part_signed as u128).to_fixed();
+        let fractional_part: FixedU128<U128> = sigmoid_result.frac().to_fixed();
+
+        if let Some(res) = integer_part.checked_add(fractional_part.lossy_into()) {
+            return Ok(res);
+        } else {
+            // This error should be impossible to reach.
+            return Err("[FeeSigmoid] Something went wrong during FIN to FOUT type conversion");
+        };
 }

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -1,12 +1,12 @@
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
 use substrate_fixed::traits::Fixed;
 
-// use crate::traits::{MarketAverage, Sigmoid};
-
 mod ema_market_volume;
+mod rikiddo;
 mod sigmoid_fee;
 
 pub use ema_market_volume::*;
+pub use rikiddo::*;
 pub use sigmoid_fee::*;
 
 pub type UnixTimestamp = u64;
@@ -37,13 +37,3 @@ impl Timespan {
         }
     }
 }
-
-/*
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
-pub struct RikiddoSigmoidMV<FI: Fixed, FE: Sigmoid<FI>, MA: MarketAverage<FI>> {
-    pub fees: FE,
-    pub ma_short: MA,
-    pub ma_long: MA,
-    pub _marker: PhantomData<FI>,
-}
-*/

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -75,11 +75,11 @@ pub fn convert_to_signed<FROM: FixedUnsigned, TO: FixedSigned + LossyFrom<FixedI
     let fractional_part: FixedI128<U127> = num.frac().to_fixed();
 
     if let Some(res) = integer_part.checked_add(fractional_part.lossy_into()) {
-        return Ok(res);
+        Ok(res)
     } else {
         // This error should be impossible to reach.
-        return Err("Something went wrong during FixedUnsigned to FixedSigned type conversion");
-    };
+        Err("Something went wrong during FixedUnsigned to FixedSigned type conversion")
+    }
 }
 
 /// Converts a signed fixed point number into an unsigned fixed point number (fallible)
@@ -91,9 +91,9 @@ pub fn convert_to_unsigned<FROM: FixedSigned, TO: FixedUnsigned + LossyFrom<Fixe
     let fractional_part: FixedU128<U128> = num.frac().to_fixed();
 
     if let Some(res) = integer_part.checked_add(fractional_part.lossy_into()) {
-        return Ok(res);
+        Ok(res)
     } else {
         // This error should be impossible to reach.
-        return Err("Something went wrong during FixedSigned to FixedUnsigned type conversion");
-    };
+        Err("Something went wrong during FixedSigned to FixedUnsigned type conversion")
+    }
 }

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -2,16 +2,16 @@ use frame_support::dispatch::{fmt::Debug, Decode, Encode};
 use substrate_fixed::traits::Fixed;
 
 mod ema_market_volume;
-mod rikiddo;
+mod rikiddo_sigmoid_mv;
 mod sigmoid_fee;
 
 pub use ema_market_volume::*;
-pub use rikiddo::*;
+pub use rikiddo_sigmoid_mv::*;
 pub use sigmoid_fee::*;
 
 pub type UnixTimestamp = u64;
 
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+#[derive(Clone, Debug, Decode, Default, Encode, Eq, PartialEq)]
 pub struct TimestampedVolume<F: Fixed> {
     pub timestamp: UnixTimestamp,
     pub volume: F,

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -154,9 +154,11 @@ impl<F: FixedUnsigned + From<u32> + LossyFrom<FixedU32<U24>>> Default for EmaMar
     }
 }
 
-impl<F: FixedUnsigned + From<u32>> MarketAverage<F> for EmaMarketVolume<F> {
+impl<F: FixedUnsigned + From<u32>> MarketAverage for EmaMarketVolume<F> {
+    type F = F;
+
     /// Calculate average (sma, ema, wma, depending on the concrete implementation) of market volume
-    fn get(&self) -> Option<F> {
+    fn get(&self) -> Option<Self::F> {
         match &self.state {
             MarketVolumeState::DataCollected => Some(self.ema),
             _ => None,
@@ -174,7 +176,10 @@ impl<F: FixedUnsigned + From<u32>> MarketAverage<F> for EmaMarketVolume<F> {
     }
 
     /// Update market volume
-    fn update(&mut self, volume: TimestampedVolume<F>) -> Result<Option<F>, &'static str> {
+    fn update(
+        &mut self,
+        volume: TimestampedVolume<Self::F>,
+    ) -> Result<Option<Self::F>, &'static str> {
         if let Some(res) = volume.timestamp.checked_sub(self.last_time) {
             res
         } else {

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -11,18 +11,18 @@ use substrate_fixed::{
 };
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
-pub struct EmaVolumeConfig<F: Fixed> {
+pub struct EmaConfig<F: Fixed> {
     pub ema_period: Timespan,
     pub smoothing: F,
 }
 
-impl<F: FixedUnsigned + LossyFrom<FixedU32<U24>>> EmaVolumeConfig<F> {
+impl<F: FixedUnsigned + LossyFrom<FixedU32<U24>>> EmaConfig<F> {
     pub fn new(ema_period: Timespan, smoothing: F) -> Self {
         Self { ema_period, smoothing }
     }
 }
 
-impl<F: FixedUnsigned + LossyFrom<FixedU32<U24>>> Default for EmaVolumeConfig<F> {
+impl<F: FixedUnsigned + LossyFrom<FixedU32<U24>>> Default for EmaConfig<F> {
     fn default() -> Self {
         Self::new(EMA_SHORT, SMOOTHING.lossy_into())
     }
@@ -37,7 +37,7 @@ pub enum MarketVolumeState {
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub struct EmaMarketVolume<F: FixedUnsigned> {
-    pub config: EmaVolumeConfig<F>,
+    pub config: EmaConfig<F>,
     pub ema: F,
     multiplier: F,
     last_time: UnixTimestamp,
@@ -47,7 +47,7 @@ pub struct EmaMarketVolume<F: FixedUnsigned> {
 }
 
 impl<F: FixedUnsigned> EmaMarketVolume<F> {
-    pub fn new(config: EmaVolumeConfig<F>) -> Self {
+    pub fn new(config: EmaConfig<F>) -> Self {
         Self {
             config,
             ema: F::from_num(0),
@@ -150,7 +150,7 @@ impl<F: FixedUnsigned> EmaMarketVolume<F> {
 
 impl<F: FixedUnsigned + From<u32> + LossyFrom<FixedU32<U24>>> Default for EmaMarketVolume<F> {
     fn default() -> Self {
-        EmaMarketVolume::new(EmaVolumeConfig::default())
+        EmaMarketVolume::new(EmaConfig::default())
     }
 }
 

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -232,7 +232,7 @@ impl<FU: FixedUnsigned + From<u32>> MarketAverage for EmaMarketVolume<FU> {
                     && (*self.volumes_per_period() + 1.into()) >= self.config.smoothing
                 {
                     // We extrapolate the txs per period
-                    if let Some(_) = self.config.ema_period_estimate_after {
+                    if self.config.ema_period_estimate_after.is_some() {
                         // Ensure that we don't divide by 0
                         if comparison_value == 0 {
                             comparison_value = 1

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -59,7 +59,10 @@ impl<FU: FixedUnsigned> EmaMarketVolume<FU> {
         }
     }
 
-    fn calculate_ema(&mut self, volume: &TimestampedVolume<FU>) -> Result<Option<FU>, &'static str> {
+    fn calculate_ema(
+        &mut self,
+        volume: &TimestampedVolume<FU>,
+    ) -> Result<Option<FU>, &'static str> {
         // Overflow is impossible here (the library ensures that multiplier ∊ [0,1])
         let volume_times_multiplier = if let Some(res) = volume.volume.checked_mul(self.multiplier)
         {
@@ -96,7 +99,10 @@ impl<FU: FixedUnsigned> EmaMarketVolume<FU> {
         Ok(Some(self.ema))
     }
 
-    fn calculate_sma(&mut self, volume: &TimestampedVolume<FU>) -> Result<Option<FU>, &'static str> {
+    fn calculate_sma(
+        &mut self,
+        volume: &TimestampedVolume<FU>,
+    ) -> Result<Option<FU>, &'static str> {
         // This can only overflow if the ema field is set manually
         let sma_times_vpp = if let Some(res) = self.ema.checked_mul(self.volumes_per_period) {
             res
@@ -224,7 +230,7 @@ impl<FU: FixedUnsigned + From<u32>> MarketAverage for EmaMarketVolume<FU> {
                     result = self.calculate_ema(&volume)?;
                 } else {
                     // During this phase the ema is still a sma.
-                    result = self.calculate_sma(&volume)?;
+                    let _ = self.calculate_sma(&volume)?;
                     // In the context of blockchains, overflowing here is irrelevant (technically
                     // not realizable). In other contexts, ensure that FU can represent a number
                     // that is equal to the number of incoming volumes during one period.

--- a/zrml/rikiddo/src/types/rikiddo.rs
+++ b/zrml/rikiddo/src/types/rikiddo.rs
@@ -1,40 +1,35 @@
 use crate::{
-    constants::{INITIAL_FEE, MINIMAL_REVENUE},
+    constants::INITIAL_FEE,
     traits::{Lmsr, MarketAverage, RikiddoMV, Sigmoid},
 };
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
-use substrate_fixed::{
-    traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto},
-    types::extra::U32,
-    FixedU32,
-};
+use substrate_fixed::{FixedU32, traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed}, types::extra::U32};
 
 use super::TimestampedVolume;
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
-pub struct RikiddoConfig<F: Fixed> {
-    pub initial_fee: F,
-    pub minimal_revenue_coefficient: F,
+pub struct RikiddoConfig<FI: Fixed> {
+    pub initial_fee: FI,
 }
 
-impl<F: FixedUnsigned + LossyFrom<FixedU32<U32>>> RikiddoConfig<F> {
-    pub fn new(initial_fee: F, minimal_revenue_coefficient: F) -> Self {
-        Self { initial_fee, minimal_revenue_coefficient }
+impl<FU: FixedUnsigned + LossyFrom<FixedU32<U32>>> RikiddoConfig<FU> {
+    pub fn new(initial_fee: FU) -> Self {
+        Self { initial_fee }
     }
 }
 
-impl<F: FixedUnsigned + LossyFrom<FixedU32<U32>>> Default for RikiddoConfig<F> {
+impl<FU: FixedUnsigned + LossyFrom<FixedU32<U32>>> Default for RikiddoConfig<FU> {
     fn default() -> Self {
-        Self::new(INITIAL_FEE.lossy_into(), MINIMAL_REVENUE.lossy_into())
+        Self::new(INITIAL_FEE.lossy_into())
     }
 }
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
-pub struct RikiddoSigmoidMV<FU: FixedUnsigned, FS: FixedSigned, FE: Sigmoid, MA: MarketAverage>
+#[derive(Clone, Debug, Decode, Default, Encode, Eq, PartialEq)]
+pub struct RikiddoSigmoidMV<FU, FS, FE, MA>
 where
-    FU: FixedUnsigned,
+    FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,
     FS: FixedSigned,
     FE: Sigmoid<FIN = FS, FOUT = FU>,
-    MA: MarketAverage<F = FU>,
+    MA: MarketAverage<FU = FU>,
 {
     pub config: RikiddoConfig<FU>,
     pub fees: FE,
@@ -42,51 +37,76 @@ where
     pub ma_long: MA,
 }
 
-impl<FU, FS, FE, MA> Lmsr for RikiddoSigmoidMV<FU, FS, FE, MA>
+impl<FU, FS, FE, MA> RikiddoSigmoidMV<FU, FS, FE, MA>
 where
-    FU: FixedUnsigned,
+    FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,
     FS: FixedSigned,
     FE: Sigmoid<FIN = FS, FOUT = FU>,
-    MA: MarketAverage<F = FU>,
+    MA: MarketAverage<FU = FU>,
 {
-    type F = FU;
+    pub fn new(config: RikiddoConfig<FU>, fees: FE, ma_short: MA, ma_long: MA) -> Self {
+        Self { config, fees, ma_short, ma_long }
+    }
+}
+
+impl<FU, FS, FE, MA> Lmsr for RikiddoSigmoidMV<FU, FS, FE, MA>
+where
+    FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,
+    FS: FixedSigned,
+    FE: Sigmoid<FIN = FS, FOUT = FU>,
+    MA: MarketAverage<FU = FU>,
+{
+    type FU = FU;
 
     /// Return price P_i(q) for all assets in q
-    fn all_prices(asset_balances: Vec<Self::F>) -> Result<Vec<Self::F>, &'static str> {
+    fn all_prices(asset_balances: Vec<Self::FU>) -> Result<Vec<Self::FU>, &'static str> {
         Err("Unimplemented")
     }
 
     /// Return cost C(q) for all assets in q
-    fn cost(asset_balances: Vec<Self::F>) -> Result<Self::F, &'static str> {
+    fn cost(asset_balances: Vec<Self::FU>) -> Result<Self::FU, &'static str> {
         Err("Unimplemented")
     }
 
     /// Return price P_i(q) for asset q_i in q
     fn price(
-        asset_in_question_balance: Self::F,
-        asset_balances: Vec<Self::F>,
-    ) -> Result<Self::F, &'static str> {
+        asset_in_question_balance: Self::FU,
+        asset_balances: Vec<Self::FU>,
+    ) -> Result<Self::FU, &'static str> {
         Err("Unimplemented")
     }
 }
 
 impl<FU, FS, FE, MA> RikiddoMV for RikiddoSigmoidMV<FU, FS, FE, MA>
 where
-    FU: FixedUnsigned,
+    FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,
     FS: FixedSigned,
     FE: Sigmoid<FIN = FS, FOUT = FU>,
-    MA: MarketAverage<F = FU>,
+    MA: MarketAverage<FU = FU>,
 {
     /// Clear market data
     fn clear(&mut self) {
-        // TODO
+        self.ma_short.clear();
+        self.ma_long.clear();
     }
 
     /// Update market data
+    /// Returns volume ratio short / long or None
     fn update(
         &mut self,
-        volume: TimestampedVolume<Self::F>,
-    ) -> Result<Option<Self::F>, &'static str> {
-        Err("Unimplemented")
+        volume: &TimestampedVolume<Self::FU>,
+    ) -> Result<Option<Self::FU>, &'static str> {
+        let mas = self.ma_short.update(volume)?;
+        let mal = self.ma_long.update(volume)?;
+        
+        if let Some(mas_unwrapped) = mas {
+            if let Some(mal_unwrapped) = mal {
+                if mal_unwrapped != 0u32.to_fixed::<FU>() {
+                    return Ok(Some(mas_unwrapped.saturating_div(mal_unwrapped)));
+                }
+            };
+        };
+
+        Ok(None)
     }
 }

--- a/zrml/rikiddo/src/types/rikiddo.rs
+++ b/zrml/rikiddo/src/types/rikiddo.rs
@@ -1,0 +1,38 @@
+use sp_std::marker::PhantomData;
+
+use crate::{
+    constants::{INITIAL_FEE, MINIMAL_REVENUE},
+    traits::{MarketAverage, Sigmoid},
+};
+use frame_support::dispatch::{fmt::Debug, Decode, Encode};
+use substrate_fixed::{
+    traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto},
+    types::extra::U32,
+    FixedU32,
+};
+
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+pub struct RikiddoConfig<F: Fixed> {
+    pub initial_fee: F,
+    pub minimal_revenue_coefficient: F,
+}
+
+impl<F: FixedUnsigned + LossyFrom<FixedU32<U32>>> RikiddoConfig<F> {
+    pub fn new(initial_fee: F, minimal_revenue_coefficient: F) -> Self {
+        Self { initial_fee, minimal_revenue_coefficient }
+    }
+}
+
+impl<F: FixedUnsigned + LossyFrom<FixedU32<U32>>> Default for RikiddoConfig<F> {
+    fn default() -> Self {
+        Self::new(INITIAL_FEE.lossy_into(), MINIMAL_REVENUE.lossy_into())
+    }
+}
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+pub struct RikiddoSigmoidMV<FS: FixedSigned, FU: FixedUnsigned, FE: Sigmoid, MA: MarketAverage> {
+    pub config: RikiddoConfig<FU>,
+    pub fees: FE,
+    pub ma_short: MA,
+    pub ma_long: MA,
+    pub _market: PhantomData<FS>,
+}

--- a/zrml/rikiddo/src/types/rikiddo.rs
+++ b/zrml/rikiddo/src/types/rikiddo.rs
@@ -2,7 +2,7 @@ use sp_std::marker::PhantomData;
 
 use crate::{
     constants::{INITIAL_FEE, MINIMAL_REVENUE},
-    traits::{MarketAverage, Sigmoid},
+    traits::{Lmsr, MarketAverage, RikiddoMV, Sigmoid},
 };
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
 use substrate_fixed::{
@@ -10,6 +10,8 @@ use substrate_fixed::{
     types::extra::U32,
     FixedU32,
 };
+
+use super::TimestampedVolume;
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub struct RikiddoConfig<F: Fixed> {
@@ -29,10 +31,64 @@ impl<F: FixedUnsigned + LossyFrom<FixedU32<U32>>> Default for RikiddoConfig<F> {
     }
 }
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
-pub struct RikiddoSigmoidMV<FS: FixedSigned, FU: FixedUnsigned, FE: Sigmoid, MA: MarketAverage> {
+pub struct RikiddoSigmoidMV<FU: FixedUnsigned, FS: FixedSigned, FE: Sigmoid, MA: MarketAverage>
+where
+    FU: FixedUnsigned,
+    FS: FixedSigned,
+    FE: Sigmoid<F = FS>,
+    MA: MarketAverage<F = FU>,
+{
     pub config: RikiddoConfig<FU>,
     pub fees: FE,
     pub ma_short: MA,
     pub ma_long: MA,
-    pub _market: PhantomData<FS>,
+}
+
+impl<FU, FS, FE, MA> Lmsr for RikiddoSigmoidMV<FU, FS, FE, MA>
+where
+    FU: FixedUnsigned,
+    FS: FixedSigned,
+    FE: Sigmoid<F = FS>,
+    MA: MarketAverage<F = FU>,
+{
+    type F = FU;
+
+    /// Return price P_i(q) for all assets in q
+    fn all_prices(asset_balances: Vec<Self::F>) -> Result<Vec<Self::F>, &'static str> {
+        Err("Unimplemented")
+    }
+
+    /// Return cost C(q) for all assets in q
+    fn cost(asset_balances: Vec<Self::F>) -> Result<Self::F, &'static str> {
+        Err("Unimplemented")
+    }
+
+    /// Return price P_i(q) for asset q_i in q
+    fn price(
+        asset_in_question_balance: Self::F,
+        asset_balances: Vec<Self::F>,
+    ) -> Result<Self::F, &'static str> {
+        Err("Unimplemented")
+    }
+}
+
+impl<FU, FS, FE, MA> RikiddoMV for RikiddoSigmoidMV<FU, FS, FE, MA>
+where
+    FU: FixedUnsigned,
+    FS: FixedSigned,
+    FE: Sigmoid<F = FS>,
+    MA: MarketAverage<F = FU>,
+{
+    /// Clear market data
+    fn clear(&mut self) {
+        // TODO
+    }
+
+    /// Update market data
+    fn update(
+        &mut self,
+        volume: TimestampedVolume<Self::F>,
+    ) -> Result<Option<Self::F>, &'static str> {
+        Err("Unimplemented")
+    }
 }

--- a/zrml/rikiddo/src/types/rikiddo.rs
+++ b/zrml/rikiddo/src/types/rikiddo.rs
@@ -1,5 +1,3 @@
-use sp_std::marker::PhantomData;
-
 use crate::{
     constants::{INITIAL_FEE, MINIMAL_REVENUE},
     traits::{Lmsr, MarketAverage, RikiddoMV, Sigmoid},
@@ -35,7 +33,7 @@ pub struct RikiddoSigmoidMV<FU: FixedUnsigned, FS: FixedSigned, FE: Sigmoid, MA:
 where
     FU: FixedUnsigned,
     FS: FixedSigned,
-    FE: Sigmoid<F = FS>,
+    FE: Sigmoid<FIN = FS, FOUT = FU>,
     MA: MarketAverage<F = FU>,
 {
     pub config: RikiddoConfig<FU>,
@@ -48,7 +46,7 @@ impl<FU, FS, FE, MA> Lmsr for RikiddoSigmoidMV<FU, FS, FE, MA>
 where
     FU: FixedUnsigned,
     FS: FixedSigned,
-    FE: Sigmoid<F = FS>,
+    FE: Sigmoid<FIN = FS, FOUT = FU>,
     MA: MarketAverage<F = FU>,
 {
     type F = FU;
@@ -76,7 +74,7 @@ impl<FU, FS, FE, MA> RikiddoMV for RikiddoSigmoidMV<FU, FS, FE, MA>
 where
     FU: FixedUnsigned,
     FS: FixedSigned,
-    FE: Sigmoid<F = FS>,
+    FE: Sigmoid<FIN = FS, FOUT = FU>,
     MA: MarketAverage<F = FU>,
 {
     /// Clear market data

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -23,7 +23,6 @@ pub struct RikiddoConfig<FI: Fixed> {
     pub(crate) log2_e: FI,
 }
 
-// TODO: use initial_fee from fee_sigmoid struct.
 impl<FS: FixedSigned + LossyFrom<FixedI32<U31>> + LossyFrom<U1F127>> RikiddoConfig<FS> {
     pub fn new(initial_fee: FS) -> Self {
         Self { initial_fee, log2_e: FS::lossy_from(LOG2_E) }
@@ -32,8 +31,8 @@ impl<FS: FixedSigned + LossyFrom<FixedI32<U31>> + LossyFrom<U1F127>> RikiddoConf
 
 impl<FS: FixedSigned + LossyFrom<FixedI32<U31>> + LossyFrom<U1F127>> Default for RikiddoConfig<FS> {
     fn default() -> Self {
-        let converted = convert_to_signed::<FixedU32<U32>, FixedI32<U31>>(INITIAL_FEE).unwrap();
         // Potentially dangerous unwrap(), should be impossible to fail (tested).
+        let converted = convert_to_signed::<FixedU32<U32>, FixedI32<U31>>(INITIAL_FEE).unwrap();
         Self::new(converted.lossy_into())
     }
 }

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -3,11 +3,7 @@ use crate::{
     traits::{Lmsr, MarketAverage, RikiddoMV, Sigmoid},
 };
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
-use substrate_fixed::{
-    traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
-    types::extra::U32,
-    FixedU32,
-};
+use substrate_fixed::{FixedI128, FixedU32, traits::{Fixed, FixedSigned, FixedUnsigned, FromFixed, LossyFrom, LossyInto, ToFixed}, types::extra::{U128, U32}};
 
 use super::TimestampedVolume;
 
@@ -44,12 +40,56 @@ where
 impl<FU, FS, FE, MA> RikiddoSigmoidMV<FU, FS, FE, MA>
 where
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,
-    FS: FixedSigned,
+    FS: FixedSigned + PartialOrd<FU> + LossyFrom<FixedI128<U128>>,
     FE: Sigmoid<FIN = FS, FOUT = FU>,
     MA: MarketAverage<FU = FU>,
 {
     pub fn new(config: RikiddoConfig<FU>, fees: FE, ma_short: MA, ma_long: MA) -> Self {
         Self { config, fees, ma_short, ma_long }
+    }
+
+    pub fn get_fee(&self) -> Result<FU, &'static str> {
+        let mas = self.ma_short.get();
+        let mas_unwrapped = if let Some(res) = mas {
+            res
+        } else {
+            return Ok(self.config.initial_fee);
+        };
+
+        let mal = self.ma_long.get();
+        let mal_unwrapped = if let Some(res) = mal {
+            res
+        } else {
+            return Ok(self.config.initial_fee);
+        };
+
+        if mal_unwrapped.to_num::<u128>() == 0u128 {
+            return Err("[RikiddoSigmoidMV] Zero division error during calculation: ma_short / ma_long");
+        }
+
+        let ratio = if let Some(res) = mas_unwrapped.checked_div(mal_unwrapped) {
+            res
+        } else {
+            // In most cases this is impossible (divisor always >= 1 if not 0)
+            return Err("[RikiddoSigmoidMV] Overflow during calculation: ma_short / ma_long")
+        };
+
+        if FS::max_value() < ratio.int() {
+            // On most configurations, this does not happen.
+            return Err("[RikiddoSigmoidMV] Overflow during conversion from ratio into type FS")
+        }
+
+        let integer_part_unsigned = i128::from_fixed(ratio.int());
+        // We can safely cast because until here we know that the sign bit is not set
+        let integer_part: FS = (integer_part_unsigned as i128).to_fixed();
+        let fractional_part: FixedI128<U128> = ratio.frac().to_fixed();
+
+        if let Some(res) = integer_part.checked_add(fractional_part.lossy_into()) {
+            return self.fees.calculate(res);
+        }
+        
+        // This error should be impossible to reach.
+        return Err("[RikiddoSigmoidMV] Something went wrong during ratio to FS type conversion.");
     }
 }
 
@@ -70,6 +110,13 @@ where
     /// Return cost C(q) for all assets in q
     fn cost(asset_balances: Vec<Self::FU>) -> Result<Self::FU, &'static str> {
         Err("Unimplemented")
+        // get fee (write helper functions) (min(w, (f+n(r))))
+        // sum over every element
+            // qi = current
+            // sum over every element to calculate exponents (helper function)
+            // Decide strategy (normal (faster) or overflow-failsafe)
+            // total_result += ln(sum(e^results))
+        // total_result *= fee
     }
 
     /// Return price P_i(q) for asset q_i in q

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -9,7 +9,7 @@ use substrate_fixed::{
     traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
     transcendental::{exp, ln, log2},
     types::{
-        extra::{U119, U127, U128, U31, U32},
+        extra::{U127, U128, U31, U32},
         I9F23, U1F127,
     },
     FixedI128, FixedI32, FixedU128, FixedU32,
@@ -208,9 +208,7 @@ where
         if asset_balances.len() == 0 {
             return Err("[RikiddoSigmoidMV] No asset balances provided");
         };
-
-        // get fee (write helper functions) (min(w, (f+n(r))))
-        // TODO: add initial fee to get_fee result (or incorporate it in get_fee)
+        
         let fee = self.get_fee()?;
         let mut total_balance = FU::from_num(0u8);
 

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -279,7 +279,8 @@ where
                 res
             } else {
                 // Highly unlikely
-                return Err("[RikiddoSigmoidMV] Overflow during calculation: biggest_exp * log2(e) + log2(num_assets)");
+                return Err("[RikiddoSigmoidMV] Overflow during calculation: biggest_exp * \
+                            log2(e) + log2(num_assets)");
             };
 
         let required_bits_minus_one: u128 =
@@ -295,7 +296,9 @@ where
             res
         } else {
             // Overflow impossible
-            return Err("[RikiddoSigmoidMV] Overflow during calculation: required_bits_minus_one + 1");
+            return Err(
+                "[RikiddoSigmoidMV] Overflow during calculation: required_bits_minus_one + 1"
+            );
         };
 
         let ln_sum_e: FS;

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -96,7 +96,7 @@ where
         convert_to_unsigned::<FS, FU>(self.fees.calculate(ratio_signed)?)
     }
 
-    pub(crate) fn default_cost_strategy(&self, exponents: &Vec<FS>) -> Result<FS, &'static str> {
+    pub(crate) fn default_cost_strategy(&self, exponents: &[FS]) -> Result<FS, &'static str> {
         let mut acc: FS = FS::from_num(0u8);
 
         for elem in exponents {
@@ -117,16 +117,16 @@ where
         }
 
         if let Ok(res) = ln::<FS, FS>(acc) {
-            return Ok(res);
+            Ok(res)
         } else {
             // Impossible to reach, unless the "exponents" vector is empty
-            return Err("[RikiddoSigmoidMV] ln(exp_sum), exp_sum <= 0");
-        };
+            Err("[RikiddoSigmoidMV] ln(exp_sum), exp_sum <= 0")
+        }
     }
 
     pub(crate) fn optimized_cost_strategy(
         &self,
-        exponents: &Vec<FS>,
+        exponents: &[FS],
         biggest_exponent: &FS,
     ) -> Result<FS, &'static str> {
         let mut biggest_exponent_used = false;
@@ -177,12 +177,12 @@ where
         };
 
         if let Some(res) = result.checked_add(ln_exp_sum) {
-            return Ok(res);
+            Ok(res)
         } else {
             // Highly unlikely
-            return Err("[RikiddoSigmoidMV] Overflow during calculation: biggest_exponent + \
-                        ln(exp_sum) (optimized)");
-        };
+            Err("[RikiddoSigmoidMV] Overflow during calculation: biggest_exponent + ln(exp_sum) \
+                 (optimized)")
+        }
     }
 }
 
@@ -202,13 +202,13 @@ where
     type FU = FU;
 
     /// Return price P_i(q) for all assets in q
-    fn all_prices(&self, asset_balances: &Vec<Self::FU>) -> Result<Vec<Self::FU>, &'static str> {
+    fn all_prices(&self, _asset_balances: &[Self::FU]) -> Result<Vec<Self::FU>, &'static str> {
         Err("Unimplemented")
     }
 
     /// Return cost C(q) for all assets in q
-    fn cost(&self, asset_balances: &Vec<Self::FU>) -> Result<Self::FU, &'static str> {
-        if asset_balances.len() == 0 {
+    fn cost(&self, asset_balances: &[Self::FU]) -> Result<Self::FU, &'static str> {
+        if asset_balances.is_empty() {
             return Err("[RikiddoSigmoidMV] No asset balances provided");
         };
 
@@ -310,18 +310,18 @@ where
         }
 
         if let Some(res) = denominator.checked_mul(convert_to_unsigned(ln_sum_e)?) {
-            return Ok(res);
+            Ok(res)
         } else {
-            return Err("[RikiddoSigmoidMV] Overflow during calculation: fee * \
-                        total_asset_balance * ln(sum_i(e^i))");
+            Err("[RikiddoSigmoidMV] Overflow during calculation: fee * total_asset_balance * \
+                 ln(sum_i(e^i))")
         }
     }
 
     /// Return price P_i(q) for asset q_i in q
     fn price(
         &self,
-        asset_in_question_balance: &Self::FU,
-        asset_balances: &Vec<Self::FU>,
+        _asset_in_question_balance: &Self::FU,
+        _asset_balances: &[Self::FU],
     ) -> Result<Self::FU, &'static str> {
         Err("Unimplemented")
     }

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -132,7 +132,7 @@ where
         let mut biggest_exponent_used = false;
 
         if FS::max_value().int().to_num::<u128>() < 1u128 {
-            // Highly unlikely (requires that balances only have fractional bits)
+            // Impossible due to trait bounds (at least 1 sign bit and 8 integer bits)
             return Err("[RikiddoSigmoidMV] Error, cannot initialize FS with one");
         }
 
@@ -148,6 +148,7 @@ where
             let exponent = if let Some(res) = elem.checked_sub(*biggest_exponent) {
                 res
             } else {
+                // Should be impossible
                 return Err("[RikiddoSigmoidFee] Overflow during calculation: current_exponent - \
                             biggest_exponent");
             };

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -3,7 +3,11 @@ use crate::{
     traits::{Lmsr, MarketAverage, RikiddoMV, Sigmoid},
 };
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
-use substrate_fixed::{FixedU32, traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed}, types::extra::U32};
+use substrate_fixed::{
+    traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
+    types::extra::U32,
+    FixedU32,
+};
 
 use super::TimestampedVolume;
 
@@ -98,7 +102,7 @@ where
     ) -> Result<Option<Self::FU>, &'static str> {
         let mas = self.ma_short.update(volume)?;
         let mal = self.ma_long.update(volume)?;
-        
+
         if let Some(mas_unwrapped) = mas {
             if let Some(mal_unwrapped) = mal {
                 if mal_unwrapped != 0u32.to_fixed::<FU>() {

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -41,7 +41,7 @@ pub struct RikiddoSigmoidMV<FU, FS, FE, MA>
 where
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,
     FS: FixedSigned + LossyFrom<FixedI32<U31>> + LossyFrom<U1F127>,
-    FE: Sigmoid<FIN = FS, FOUT = FU>,
+    FE: Sigmoid<FS = FS>,
     MA: MarketAverage<FU = FU>,
 {
     pub config: RikiddoConfig<FS>,
@@ -60,7 +60,7 @@ where
         + LossyFrom<FixedI128<U127>>
         + PartialOrd<I9F23>,
     FS::Bits: Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign,
-    FE: Sigmoid<FIN = FS, FOUT = FU>,
+    FE: Sigmoid<FS = FS>,
     MA: MarketAverage<FU = FU>,
 {
     pub fn new(config: RikiddoConfig<FS>, fees: FE, ma_short: MA, ma_long: MA) -> Self {
@@ -93,7 +93,7 @@ where
         };
 
         let ratio_signed = convert_to_signed(ratio)?;
-        self.fees.calculate(ratio_signed)
+        convert_to_unsigned::<FS, FU>(self.fees.calculate(ratio_signed)?)
     }
 
     pub(crate) fn default_cost_strategy(&self, exponents: &Vec<FS>) -> Result<FS, &'static str> {
@@ -196,7 +196,7 @@ where
         + LossyFrom<FixedI128<U127>>
         + PartialOrd<I9F23>,
     FS::Bits: Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign,
-    FE: Sigmoid<FIN = FS, FOUT = FU>,
+    FE: Sigmoid<FS = FS>,
     MA: MarketAverage<FU = FU>,
 {
     type FU = FU;
@@ -337,7 +337,7 @@ where
         + LossyFrom<FixedI128<U127>>
         + PartialOrd<I9F23>,
     FS::Bits: Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign,
-    FE: Sigmoid<FIN = FS, FOUT = FU>,
+    FE: Sigmoid<FS = FS>,
     MA: MarketAverage<FU = FU>,
 {
     /// Clear market data

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -279,7 +279,7 @@ where
                 res
             } else {
                 // Highly unlikely
-                return Err("Overflow during calculation: biggest_exp * log2(e) + log2(num_assets)");
+                return Err("[RikiddoSigmoidMV] Overflow during calculation: biggest_exp * log2(e) + log2(num_assets)");
             };
 
         let required_bits_minus_one: u128 =
@@ -294,8 +294,8 @@ where
         let required_bits = if let Some(res) = required_bits_minus_one.checked_add(1) {
             res
         } else {
-            // Highly unlikely
-            return Err("Overflow during calculation: required_bits_minus_one + 1");
+            // Overflow impossible
+            return Err("[RikiddoSigmoidMV] Overflow during calculation: required_bits_minus_one + 1");
         };
 
         let ln_sum_e: FS;

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -208,7 +208,7 @@ where
         if asset_balances.len() == 0 {
             return Err("[RikiddoSigmoidMV] No asset balances provided");
         };
-        
+
         let fee = self.get_fee()?;
         let mut total_balance = FU::from_num(0u8);
 

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -81,7 +81,7 @@ where
 
         // PartialOrd is bugged, therefore the workaround
         // https://github.com/encointer/substrate-fixed/issues/9
-        if FS::max_value().int().to_num::<u128>() < FU::max_value().int().to_num::<u128>() {
+        if FS::max_value().int().to_num::<u128>() < ratio.int().to_num::<u128>() {
             return Err("[RikiddoSigmoidMV] Overflow during conversion from ma. ratio into type FS");
         }
 

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -4,7 +4,15 @@ use crate::{
     types::convert_to_unsigned,
 };
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
-use substrate_fixed::{FixedI128, FixedI32, FixedU128, FixedU32, traits::{FixedSigned, FixedUnsigned, LossyFrom, LossyInto}, transcendental::sqrt, types::{I9F23, extra::{U127, U128, U24, U32}}};
+use substrate_fixed::{
+    traits::{FixedSigned, FixedUnsigned, LossyFrom, LossyInto},
+    transcendental::sqrt,
+    types::{
+        extra::{U127, U128, U24, U32},
+        I9F23,
+    },
+    FixedI128, FixedI32, FixedU128, FixedU32,
+};
 
 use super::convert_to_signed;
 

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -107,7 +107,9 @@ where
             return Ok(self.config.min_revenue);
         }
 
-        if Self::FOUT::max_value() < sigmoid_result.int() {
+        // PartialOrd is bugged, therefore the workaround
+        // https://github.com/encointer/substrate-fixed/issues/9
+        if Self::FOUT::max_value().int().to_num::<u128>() < sigmoid_result.int().to_num::<u128>() {
             return Err("[FeeSigmoid] Overflow during conversion: Result does not fit in \
                         specified output type");
         }

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -10,7 +10,7 @@ use substrate_fixed::{
         extra::{U128, U24, U32},
         I9F23,
     },
-    FixedI128, FixedI32, FixedU128, FixedU32,
+    FixedI32, FixedU128, FixedU32,
 };
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -30,12 +30,14 @@ pub struct FeeSigmoid<FI: Fixed + LossyFrom<FixedI32<U24>>> {
     pub config: FeeSigmoidConfig<FI>,
 }
 
-impl<F> Sigmoid<F> for FeeSigmoid<F>
+impl<F> Sigmoid for FeeSigmoid<F>
 where
     F: FixedSigned + LossyFrom<FixedI32<U24>> + PartialOrd<I9F23>,
 {
+    type F = F;
+
     // z(r) in https://files.kyber.network/DMM-Feb21.pdf
-    fn calculate(&self, r: F) -> Result<F, &'static str> {
+    fn calculate(&self, r: Self::F) -> Result<F, &'static str> {
         let r_minus_n = if let Some(res) = r.checked_sub(self.config.n) {
             res
         } else {

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -1,11 +1,11 @@
 use crate::{
     constants::{M, MINIMAL_REVENUE, N, P},
     traits::Sigmoid,
-    types::{convert_to_signed, convert_to_unsigned},
+    types::{convert_to_unsigned},
 };
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
 use substrate_fixed::{
-    traits::{FixedSigned, FixedUnsigned, FromFixed, LossyFrom, LossyInto, ToFixed},
+    traits::{FixedSigned, FixedUnsigned, LossyFrom, LossyInto},
     transcendental::sqrt,
     types::{
         extra::{U128, U24, U32},

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -3,7 +3,15 @@ use crate::{
     traits::Sigmoid,
 };
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
-use substrate_fixed::{FixedI128, FixedI32, FixedU32, traits::{FixedSigned, LossyFrom, LossyInto}, transcendental::sqrt, types::{I9F23, extra::{U127, U24, U32}}};
+use substrate_fixed::{
+    traits::{FixedSigned, LossyFrom, LossyInto},
+    transcendental::sqrt,
+    types::{
+        extra::{U127, U24, U32},
+        I9F23,
+    },
+    FixedI128, FixedI32, FixedU32,
+};
 
 use super::convert_to_signed;
 
@@ -28,7 +36,8 @@ where
             // Only case this can panic is, when INITIAL_FEE is >= 1.0 and FS integer bits < 2
             initial_fee: convert_to_signed::<FixedU32<U32>, FS>(INITIAL_FEE.lossy_into()).unwrap(),
             // Only case this can panic is, when MIN_REVENUE is >= 1.0 and FS integer bits < 2
-            min_revenue: convert_to_signed::<FixedU32<U32>, FS>(MINIMAL_REVENUE.lossy_into()).unwrap(),
+            min_revenue: convert_to_signed::<FixedU32<U32>, FS>(MINIMAL_REVENUE.lossy_into())
+                .unwrap(),
         }
     }
 }

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -30,6 +30,12 @@ pub struct FeeSigmoid<FI: Fixed + LossyFrom<FixedI32<U24>>> {
     pub config: FeeSigmoidConfig<FI>,
 }
 
+impl<F: FixedSigned + LossyFrom<FixedI32<U24>>> FeeSigmoid<F> {
+    pub fn new(config: FeeSigmoidConfig<F>) -> Self {
+        Self { config }
+    }
+}
+
 impl<F> Sigmoid for FeeSigmoid<F>
 where
     F: FixedSigned + LossyFrom<FixedI32<U24>> + PartialOrd<I9F23>,

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -123,7 +123,7 @@ where
             return Ok(res);
         } else {
             // This error should be impossible to reach.
-            return Err("[FeeSigmoid] Something went wrong during FIN to FOUT type conversion.");
+            return Err("[FeeSigmoid] Something went wrong during FIN to FOUT type conversion");
         };
     }
 }

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -3,10 +3,15 @@ use crate::{
     traits::Sigmoid,
 };
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
-use substrate_fixed::{FixedI128, FixedI32, FixedU128, FixedU32, traits::{FixedSigned, FixedUnsigned, FromFixed, LossyFrom, LossyInto, ToFixed}, transcendental::sqrt, types::{
-        extra::{U24, U32, U128},
+use substrate_fixed::{
+    traits::{FixedSigned, FixedUnsigned, FromFixed, LossyFrom, LossyInto, ToFixed},
+    transcendental::sqrt,
+    types::{
+        extra::{U128, U24, U32},
         I9F23,
-    }};
+    },
+    FixedI128, FixedI32, FixedU128, FixedU32,
+};
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
 pub struct FeeSigmoidConfig<FS: FixedSigned, FU: FixedUnsigned> {
@@ -20,7 +25,7 @@ impl<FS, FU> Default for FeeSigmoidConfig<FS, FU>
 where
     FS: FixedSigned + LossyFrom<FixedI32<U24>>,
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,
-    i128: From<FS::Bits>
+    i128: From<FS::Bits>,
 {
     fn default() -> Self {
         Self {
@@ -37,7 +42,7 @@ pub struct FeeSigmoid<FS, FU>
 where
     FS: FixedSigned + LossyFrom<FixedI32<U24>>,
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,
-    i128: From<FS::Bits>
+    i128: From<FS::Bits>,
 {
     pub config: FeeSigmoidConfig<FS, FU>,
 }
@@ -47,7 +52,7 @@ where
     FS: FixedSigned + LossyFrom<FixedI32<U24>>,
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,
     i128: From<FS::Bits>,
-    u128: ToFixed
+    u128: ToFixed,
 {
     pub fn new(config: FeeSigmoidConfig<FS, FU>) -> Self {
         Self { config }
@@ -103,7 +108,8 @@ where
         }
 
         if Self::FOUT::max_value() < sigmoid_result.int() {
-            return Err("[FeeSigmoid] Overflow during conversion: Result does not fit in specified output type");
+            return Err("[FeeSigmoid] Overflow during conversion: Result does not fit in \
+                        specified output type");
         }
 
         let integer_part_signed = i128::from_fixed(sigmoid_result.int());
@@ -115,7 +121,7 @@ where
             return Ok(res);
         } else {
             // This error should be impossible to reach.
-            return Err("[FeeSigmoid] Something went wrong during FIN to FOUT type conversion.")
+            return Err("[FeeSigmoid] Something went wrong during FIN to FOUT type conversion.");
         };
     }
 }

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{M, MINIMAL_REVENUE, N, P},
     traits::Sigmoid,
-    types::{convert_to_unsigned},
+    types::convert_to_unsigned,
 };
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
 use substrate_fixed::{


### PR DESCRIPTION
This PR contains a partial implementation of the Rikiddo core functionallity and tests for it. Since the PR became too big already, it was split into two parts. 
This part contains the implementation of the `RikiddoMV` trait, the trait that exposes functions to add market data and clear it. It also contains the implementation of the Rikiddo cost function (which is exposed through the LMSR trait). The cost functions uses two strategies to calculate the result: One strategy simply calculates the cost function based on the unmodified cost formula (function `default_cost_strategy`). It requires some less operations than the other variant, but it can't calculate the result in many cases (due to overflow of intermediate exponential function results). If the Fixed point number type used to store the intermediate results of the exponential functions within the cost function does not offer enough bits to store the intermediate result, an alternative function (`optimized_cost_strategy`) is used that is able to calculate the result in any (relevant) case.
The next part of this split PR will offer an implementation of the price function.