### PR TITLE
[Rikiddo] Implement Rikiddo pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12146,6 +12146,7 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "substrate-fixed",

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -15,7 +15,10 @@ use sc_telemetry::TelemetryEndpoints;
 use sp_core::{crypto::UncheckedInto, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use zeitgeist_primitives::{
-    constants::{BALANCE_FRACTIONAL_DECIMAL_PLACES, ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD}},
+    constants::{
+        ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD},
+        BALANCE_FRACTIONAL_DECIMAL_PLACES,
+    },
     types::{AccountId, Balance, Signature},
 };
 use zeitgeist_runtime::{SS58Prefix, TokensConfig};

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -15,7 +15,7 @@ use sc_telemetry::TelemetryEndpoints;
 use sp_core::{crypto::UncheckedInto, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use zeitgeist_primitives::{
-    constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD},
+    constants::{BALANCE_FRACTIONAL_DECIMAL_PLACES, ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD}},
     types::{AccountId, Balance, Signature},
 };
 use zeitgeist_runtime::{SS58Prefix, TokensConfig};
@@ -227,7 +227,7 @@ fn token_properties() -> Map<String, Value> {
     let mut properties = Map::new();
     properties.insert("ss58Format".into(), SS58Prefix::get().into());
     properties.insert("tokenSymbol".into(), "ZBP".into());
-    properties.insert("tokenDecimals".into(), 10.into());
+    properties.insert("tokenDecimals".into(), BALANCE_FRACTIONAL_DECIMAL_PLACES.into());
     properties
 }
 

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -16,6 +16,18 @@ pub const CENT: Balance = BASE / 100; // 100_000_000
 pub const MILLI: Balance = CENT / 10; //  10_000_000
 pub const MICRO: Balance = MILLI / 1000; // 10_000
 
+pub const BALANCE_FRACTIONAL_DECIMAL_PLACES: u8 = {
+    let mut base = BASE;
+    let mut counter: u8 = 0;
+
+    while base >= 10 {
+        base /= 10;
+        counter += 1;
+    }
+
+    counter
+};
+
 // Balance
 parameter_types! {
     pub const ExistentialDeposit: u128 = CENT;

--- a/zrml/rikiddo/Cargo.toml
+++ b/zrml/rikiddo/Cargo.toml
@@ -2,6 +2,7 @@
 frame-support = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 frame-system = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 parity-scale-codec = { default-features = false, features = ["derive"], version = "2.0" }
+sp-core = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-runtime = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 substrate-fixed = { default-features = false, features = ["serde"], git = "https://github.com/encointer/substrate-fixed" }
 zeitgeist-primitives = { default-features = false, path = "../../primitives" }

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -18,8 +18,9 @@ mod pallet {
     use frame_support::{Twox64Concat, debug, dispatch::DispatchResult, pallet_prelude::StorageMap, traits::{Get, Hooks, Time}};
     use parity_scale_codec::{Decode, Encode, FullCodec, FullEncode};
     use sp_runtime::DispatchError;
-    use sp_std::{
+    use core::{
         convert::TryFrom,
+        fmt::Debug,
         marker::PhantomData,
         ops::{AddAssign, BitOrAssign, ShlAssign},
     };
@@ -43,7 +44,7 @@ mod pallet {
     #[pallet::config]
     pub trait Config<I: 'static = ()>: frame_system::Config {
         /// Defines the type of traded amounts
-        type Balance: Copy + Into<u128> + TryFrom<u128> + sp_std::fmt::Debug;
+        type Balance: Copy + Into<u128> + TryFrom<u128> + Debug;
 
         /// Offers timestamping functionality
         type Timestamp: Time;

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -40,9 +40,7 @@ mod pallet {
 
     use crate::{
         traits::{Lmsr, RikiddoMV, RikiddoSigmoidMVPallet},
-        types::{
-            FromFixedToDecimal, FromFixedDecimal, TimestampedVolume, UnixTimestamp,
-        },
+        types::{FromFixedDecimal, FromFixedToDecimal, TimestampedVolume, UnixTimestamp},
     };
     use parity_scale_codec::Codec;
     use sp_runtime::traits::AtLeast32BitUnsigned;
@@ -119,13 +117,8 @@ mod pallet {
             }
         }
 
-        fn convert_balance_to_fixed(
-            balance: &T::Balance,
-        ) -> Result<T::FixedTypeU, DispatchError> {
-            match T::FixedTypeU::from_fixed_decimal(
-                *balance,
-                T::BalanceFractionalDecimals::get(),
-            ) {
+        fn convert_balance_to_fixed(balance: &T::Balance) -> Result<T::FixedTypeU, DispatchError> {
+            match T::FixedTypeU::from_fixed_decimal(*balance, T::BalanceFractionalDecimals::get()) {
                 Ok(res) => return Ok(res),
                 Err(err) => {
                     debug(&err);
@@ -134,10 +127,11 @@ mod pallet {
             };
         }
 
-        fn convert_fixed_to_balance(
-            fixed: &T::FixedTypeU,
-        ) -> Result<T::Balance, DispatchError> {
-            match T::Balance::from_fixed_to_fixed_decimal(*fixed, T::BalanceFractionalDecimals::get()) {
+        fn convert_fixed_to_balance(fixed: &T::FixedTypeU) -> Result<T::Balance, DispatchError> {
+            match T::Balance::from_fixed_to_fixed_decimal(
+                *fixed,
+                T::BalanceFractionalDecimals::get(),
+            ) {
                 Ok(res) => return Ok(res),
                 Err(err) => {
                     debug(&err);
@@ -150,18 +144,18 @@ mod pallet {
             balance: &[T::Balance],
         ) -> Result<Vec<T::FixedTypeU>, DispatchError> {
             balance
-            .iter()
-            .map(|e| Self::convert_balance_to_fixed(e))
-            .collect::<Result<Vec<T::FixedTypeU>, DispatchError>>()
+                .iter()
+                .map(|e| Self::convert_balance_to_fixed(e))
+                .collect::<Result<Vec<T::FixedTypeU>, DispatchError>>()
         }
 
         fn convert_fixed_to_balance_vector(
             fixed: &[T::FixedTypeU],
         ) -> Result<Vec<T::Balance>, DispatchError> {
             fixed
-            .iter()
-            .map(|e| Self::convert_fixed_to_balance(e))
-            .collect::<Result<Vec<T::Balance>, DispatchError>>()
+                .iter()
+                .map(|e| Self::convert_fixed_to_balance(e))
+                .collect::<Result<Vec<T::Balance>, DispatchError>>()
         }
     }
 
@@ -234,11 +228,9 @@ mod pallet {
         }
 
         /// Fetch the current fee
-        fn fee(
-            poolid: Self::PoolId
-        ) -> Result<Self::Balance, DispatchError> {
+        fn fee(poolid: Self::PoolId) -> Result<Self::Balance, DispatchError> {
             let rikiddo = Self::get_rikiddo(&poolid)?;
-            
+
             match rikiddo.fee() {
                 Ok(fee) => return Ok(Self::convert_fixed_to_balance(&fee)?),
                 Err(err) => {

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -39,10 +39,9 @@ mod pallet {
     };
 
     use crate::{
-        traits::{Lmsr, MarketAverage, RikiddoMV, RikiddoSigmoidMVPallet, Sigmoid},
+        traits::{Lmsr, RikiddoMV, RikiddoSigmoidMVPallet},
         types::{
-            EmaConfig, FeeSigmoidConfig, FromFixedToDecimal, FromFixedDecimal, IntoFixedDecimal, IntoFixedFromDecimal,
-            RikiddoConfig, RikiddoSigmoidMV, TimestampedVolume, UnixTimestamp,
+            FromFixedToDecimal, FromFixedDecimal, TimestampedVolume, UnixTimestamp,
         },
     };
     use parity_scale_codec::Codec;

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -268,7 +268,7 @@ mod pallet {
         }
 
         /// Update market data
-        fn update(
+        fn update_volume(
             poolid: Self::PoolId,
             volume: Self::Balance,
         ) -> Result<Option<Self::Balance>, DispatchError> {
@@ -281,7 +281,7 @@ mod pallet {
             let mut rikiddo = Self::get_rikiddo(&poolid)?;
 
             // Update rikiddo market data by adding the TimestampedVolume
-            let balance_fixed = match rikiddo.update(&timestamped_volume) {
+            let balance_fixed = match rikiddo.update_volume(&timestamped_volume) {
                 Ok(res) => {
                     if let Some(inner) = res {
                         inner

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -37,9 +37,6 @@ mod pallet {
         traits::{Lmsr, RikiddoMV, RikiddoSigmoidMVPallet},
         types::{FromFixedDecimal, FromFixedToDecimal, TimestampedVolume, UnixTimestamp},
     };
-    use parity_scale_codec::Codec;
-    use sp_runtime::traits::AtLeast32BitUnsigned;
-    use substrate_fixed::types::extra::LeEqU128;
 
     #[pallet::config]
     pub trait Config<I: 'static = ()>: frame_system::Config {

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -48,6 +48,8 @@ mod pallet {
         type Timestamp: Time;
 
         /// Will be used for the fractional part of the fixed point numbers
+        /// Calculation: Select FixedTYPE, such that TYPE = the type of Balance (i.e. FixedU128)
+        /// Select the generic UWIDTH, such that WIDTH = floor(log2(fractional_decimals))
         type FixedTypeU: Decode
             + Encode
             + FixedUnsigned
@@ -55,6 +57,10 @@ mod pallet {
             + LossyFrom<FixedU128<U128>>;
 
         /// Will be used for the fractional part of the fixed point numbers
+        /// Calculation: Select FixedTYPE, such that it is the signed variant of FixedTypeU
+        /// It is possible to reduce the fractional bit count by one, effectively eliminating
+        /// conversion overflows when the MSB of the unsigned fixed type is set, but in exchange
+        /// Reducing the fractional precision by one bit.
         type FixedTypeS: Decode
             + Encode
             + FixedSigned
@@ -63,6 +69,9 @@ mod pallet {
             + LossyFrom<U1F127>
             + LossyFrom<FixedI128<U127>>
             + PartialOrd<I9F23>;
+
+        // Number of fractional decimal places for one unit of currency
+        type BalanceFractionalDecimals: Into<u8>;
 
         /// Type that's used as an id for pools
         type PoolId: Decode + FullEncode;

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -143,10 +143,7 @@ mod pallet {
         }
 
         /// Create Rikiddo instance for specifc asset pool
-        fn create(
-            poolid: Self::PoolId,
-            rikiddo: Self::Rikiddo,
-        ) -> DispatchResult {
+        fn create(poolid: Self::PoolId, rikiddo: Self::Rikiddo) -> DispatchResult {
             if Self::get_lmsr(poolid).is_ok() {
                 return Err(Error::<T>::RikiddoAlreadyExistsForPool.into());
             }

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -18,7 +18,7 @@ mod pallet {
     use core::{fmt::Debug, marker::PhantomData};
     use frame_support::{
         pallet_prelude::StorageMap,
-        traits::{Hooks, Time},
+        traits::{Get, Hooks, Time},
         Twox64Concat,
     };
     use parity_scale_codec::{Decode, Encode, FullCodec, FullEncode};
@@ -48,8 +48,8 @@ mod pallet {
         type Timestamp: Time;
 
         /// Will be used for the fractional part of the fixed point numbers
-        /// Calculation: Select FixedTYPE, such that TYPE = the type of Balance (i.e. FixedU128)
-        /// Select the generic UWIDTH, such that WIDTH = floor(log2(fractional_decimals))
+        /// Calculation: Select FixedTYPE<UWIDTH>, such that TYPE = the type of Balance (i.e. FixedU128)
+        /// Select the generic UWIDTH = floor(log2(fractional_decimals))
         type FixedTypeU: Decode
             + Encode
             + FixedUnsigned
@@ -71,7 +71,7 @@ mod pallet {
             + PartialOrd<I9F23>;
 
         // Number of fractional decimal places for one unit of currency
-        type BalanceFractionalDecimals: Into<u8>;
+        type BalanceFractionalDecimals: Get<u8>;
 
         /// Type that's used as an id for pools
         type PoolId: Decode + FullEncode;

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -211,6 +211,7 @@ mod pallet {
                     if let Some(inner) = res {
                         inner
                     } else  {
+                        <RikiddoPerPool<T>>::insert(poolid, rikiddo);
                         return Ok(None);
                     }
                 }
@@ -231,6 +232,7 @@ mod pallet {
             
             match converted {
                 Ok(res) => {
+                    <RikiddoPerPool<T>>::insert(poolid, rikiddo);
                     return Ok(Some(res));
                 },
                 Err(err) => {

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -154,8 +154,9 @@ mod pallet {
 
         /// Destroy Rikiddo instance
         fn destroy(poolid: Self::PoolId) -> DispatchResult {
-            // TODO
-            Err("Unimplemented!".into())
+            let _ = Self::get_lmsr(poolid)?;
+            <RikiddoPerPool<T>>::remove(poolid);
+            Ok(())
         }
 
         /// Return price P_i(q) for asset q_i in q

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -218,6 +218,7 @@ mod pallet {
                     debug(&err);
 
                     if err == "[EmaMarketVolume] Incoming volume timestamp is older than previous timestamp" {
+                        // Using the default Timestamp pallet makes this branch unreachable
                         return Err(Error::<T>::TransactionIsOlderThanPrevious.into());
                     } else {
                         return Err(Error::<T>::ArithmeticOverflow.into());

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -17,9 +17,23 @@ pub use pallet::*;
 mod pallet {
     use core::{fmt::Debug, marker::PhantomData};
     use frame_support::{
-        pallet_prelude::{MaybeSerializeDeserialize, Member},
+        pallet_prelude::StorageMap,
         traits::{Hooks, Time},
-        Parameter,
+        Twox64Concat,
+    };
+    use parity_scale_codec::{Decode, Encode, FullCodec, FullEncode};
+    use substrate_fixed::{
+        traits::{FixedSigned, FixedUnsigned, LossyFrom},
+        types::{
+            extra::{U127, U128, U31, U32},
+            I9F23, U1F127,
+        },
+        FixedI128, FixedI32, FixedU128, FixedU32,
+    };
+
+    use crate::{
+        traits::{MarketAverage, RikiddoSigmoidMVPallet, Sigmoid},
+        types::{EmaConfig, FeeSigmoidConfig, RikiddoSigmoidMV},
     };
     use parity_scale_codec::Codec;
     use sp_runtime::traits::AtLeast32BitUnsigned;
@@ -27,49 +41,125 @@ mod pallet {
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
-        /// Balance type: Defines the type of traded amounts
-        type Balance: Parameter
-            + Member
-            + AtLeast32BitUnsigned
-            + Codec
-            + Default
-            + Copy
-            + MaybeSerializeDeserialize
-            + Debug;
+        /// Defines the type of traded amounts
+        type Balance;
 
-        /// The type that offers timestamping functionality
+        /// Offers timestamping functionality
         type Timestamp: Time;
 
-        /// The type that will be used for the fractional part of the fixed point numbers
-        type FractionalType: LeEqU128;
+        /// Will be used for the fractional part of the fixed point numbers
+        type FixedTypeU: Decode
+            + Encode
+            + FixedUnsigned
+            + LossyFrom<FixedU32<U32>>
+            + LossyFrom<FixedU128<U128>>;
+
+        /// Will be used for the fractional part of the fixed point numbers
+        type FixedTypeS: Decode
+            + Encode
+            + FixedSigned
+            + From<I9F23>
+            + LossyFrom<FixedI32<U31>>
+            + LossyFrom<U1F127>
+            + LossyFrom<FixedI128<U127>>
+            + PartialOrd<I9F23>;
+
+        /// Type that's used as an id for pools
+        type PoolId: Decode + FullEncode;
+
+        /// Type that's used to gather market data
+        type MarketData: MarketAverage<FU = Self::FixedTypeU> + Decode + Encode;
+
+        /// Type that's used to calculate fees
+        type Fees: Sigmoid<FS = Self::FixedTypeS> + Decode + FullCodec;
     }
 
     #[pallet::error]
-    pub enum Error<T> {}
-
-    #[pallet::call]
-    impl<T: Config> Pallet<T> {}
-
-    impl<T: Config> Pallet<T> {}
+    pub enum Error<T> {
+        ArithmeticOverflow,
+        FixedConversionImpossible,
+    }
 
     // This is the storage containing the Rikiddo instances per pool.
-    /*
     #[pallet::storage]
     pub type LmsrPerPool<T: Config> = StorageMap<
         _,
         Twox64Concat,
-        u128,
-        RikiddoMV<
-            FixedU128<T::FractionalType>,
-            FeeSigmoid,
-            EmaMarketVolume<FixedU128<T::FractionalType>>,
-        >,
+        T::PoolId,
+        RikiddoSigmoidMV<T::FixedTypeU, T::FixedTypeS, T::Fees, T::MarketData>,
     >;
-    */
 
     #[pallet::hooks]
     impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
 
     #[pallet::pallet]
     pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {}
+
+    impl<T: Config> RikiddoSigmoidMVPallet for Pallet<T> {
+        type Balance = T::Balance;
+        type PoolId = T::PoolId;
+        type FS = T::FixedTypeS;
+        type FU = T::FixedTypeU;
+
+        /// Clear market data for specific asset pool
+        fn clear(poolid: Self::PoolId) {
+            // TODO
+        }
+
+        /// Return cost C(q) for all assets in q
+        fn cost(
+            poolid: Self::PoolId,
+            asset_balances: Vec<Self::Balance>,
+        ) -> Result<Self::Balance, &'static str> {
+            // TODO
+            Err("Unimplemented!")
+        }
+
+        /// Create Rikiddo instance for specifc asset pool
+        fn create(
+            poolid: Self::PoolId,
+            fee_config: FeeSigmoidConfig<Self::FS>,
+            ema_config_short: EmaConfig<Self::FU>,
+            ema_config_long: EmaConfig<Self::FU>,
+            balance_one_unit: Self::Balance,
+        ) {
+            // TODO
+        }
+
+        /// Destroy Rikiddo instance
+        fn destroy(poolid: Self::PoolId) {
+            // TODO
+        }
+
+        /// Return price P_i(q) for asset q_i in q
+        fn price(
+            poolid: Self::PoolId,
+            asset_in_question: Self::Balance,
+            asset_balances: Vec<Self::Balance>,
+        ) -> Result<Self::Balance, &'static str> {
+            // TODO
+            Err("Unimplemented!")
+        }
+
+        /// Return price P_i(q) for all assets in q
+        fn all_prices(
+            poolid: Self::PoolId,
+            asset_balances: Vec<Self::Balance>,
+        ) -> Result<Vec<Self::Balance>, &'static str> {
+            // TODO
+            Err("Unimplemented!")
+        }
+
+        /// Update market data
+        fn update(
+            poolid: Self::PoolId,
+            volume: Self::Balance,
+        ) -> Result<Option<Self::Balance>, &'static str> {
+            // TODO
+            Err("Unimplemented!")
+        }
+    }
 }

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -1,6 +1,6 @@
-//! # Court
+//! # Rikiddo
 //!
-//! Manages market disputes and resolutions.
+//! Manages prices of event assets within a pool
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -15,13 +15,10 @@ pub use pallet::*;
 
 #[frame_support::pallet]
 mod pallet {
-    use core::{fmt::Debug, marker::PhantomData};
-    use frame_support::{
-        pallet_prelude::StorageMap,
-        traits::{Get, Hooks, Time},
-        Twox64Concat,
-    };
+    use core::marker::PhantomData;
+    use frame_support::{Twox64Concat, dispatch::DispatchResult, fail, pallet_prelude::StorageMap, traits::{Get, Hooks, Time}};
     use parity_scale_codec::{Decode, Encode, FullCodec, FullEncode};
+    use sp_runtime::DispatchError;
     use substrate_fixed::{
         traits::{FixedSigned, FixedUnsigned, LossyFrom},
         types::{
@@ -32,7 +29,7 @@ mod pallet {
     };
 
     use crate::{
-        traits::{MarketAverage, RikiddoSigmoidMVPallet, Sigmoid},
+        traits::{MarketAverage, RikiddoMV, RikiddoSigmoidMVPallet, Sigmoid},
         types::{EmaConfig, FeeSigmoidConfig, RikiddoSigmoidMV},
     };
     use parity_scale_codec::Codec;
@@ -87,6 +84,7 @@ mod pallet {
     pub enum Error<T> {
         ArithmeticOverflow,
         FixedConversionImpossible,
+        PoolNotFound,
     }
 
     // This is the storage containing the Rikiddo instances per pool.
@@ -114,17 +112,22 @@ mod pallet {
         type FU = T::FixedTypeU;
 
         /// Clear market data for specific asset pool
-        fn clear(poolid: Self::PoolId) {
-            // TODO
+        fn clear(poolid: Self::PoolId) -> Result<(), DispatchError> {
+            if let Ok(lmsr) = <LmsrPerPool<T>>::try_get(poolid) {
+                lmsr.clear();
+                Ok(())
+            } else {
+                Err(Error::<T>::PoolNotFound.into())
+            }
         }
 
         /// Return cost C(q) for all assets in q
         fn cost(
             poolid: Self::PoolId,
             asset_balances: Vec<Self::Balance>,
-        ) -> Result<Self::Balance, &'static str> {
+        ) -> Result<Self::Balance, DispatchError> {
             // TODO
-            Err("Unimplemented!")
+            Err("Unimplemented!".into())
         }
 
         /// Create Rikiddo instance for specifc asset pool
@@ -134,13 +137,15 @@ mod pallet {
             ema_config_short: EmaConfig<Self::FU>,
             ema_config_long: EmaConfig<Self::FU>,
             balance_one_unit: Self::Balance,
-        ) {
+        ) -> DispatchResult {
             // TODO
+            Err("Unimplemented!".into())
         }
 
         /// Destroy Rikiddo instance
-        fn destroy(poolid: Self::PoolId) {
+        fn destroy(poolid: Self::PoolId) -> DispatchResult {
             // TODO
+            Err("Unimplemented!".into())
         }
 
         /// Return price P_i(q) for asset q_i in q
@@ -148,27 +153,27 @@ mod pallet {
             poolid: Self::PoolId,
             asset_in_question: Self::Balance,
             asset_balances: Vec<Self::Balance>,
-        ) -> Result<Self::Balance, &'static str> {
+        ) -> Result<Self::Balance, DispatchError> {
             // TODO
-            Err("Unimplemented!")
+            Err("Unimplemented!".into())
         }
 
         /// Return price P_i(q) for all assets in q
         fn all_prices(
             poolid: Self::PoolId,
             asset_balances: Vec<Self::Balance>,
-        ) -> Result<Vec<Self::Balance>, &'static str> {
+        ) -> Result<Vec<Self::Balance>, DispatchError> {
             // TODO
-            Err("Unimplemented!")
+            Err("Unimplemented!".into())
         }
 
         /// Update market data
         fn update(
             poolid: Self::PoolId,
             volume: Self::Balance,
-        ) -> Result<Option<Self::Balance>, &'static str> {
+        ) -> Result<Option<Self::Balance>, DispatchError> {
             // TODO
-            Err("Unimplemented!")
+            Err("Unimplemented!".into())
         }
     }
 }

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -7,9 +7,7 @@ use sp_runtime::{
 };
 use substrate_fixed::{types::extra::U33, FixedI128, FixedU128};
 use zeitgeist_primitives::{
-    constants::{
-        ExistentialDeposit, MaxReserves, BASE, BLOCK_HASH_COUNT,
-    },
+    constants::{ExistentialDeposit, MaxReserves, BASE, BLOCK_HASH_COUNT},
     types::{
         AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, PoolId, UncheckedExtrinsicTest,
     },

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -28,7 +28,7 @@ pub type UncheckedExtrinsic = UncheckedExtrinsicTest<Runtime>;
 parameter_types! {
     pub const BlockHashCount: u64 = BLOCK_HASH_COUNT;
     pub const MinimumPeriod: u64 = 0;
-    pub const FractionalDecimalPlaces: u8 = BALANCE_FRACTIONAL_DECIMAL_PLACES;
+    pub const FractionalDecimalPlaces: u8 = 10;
 }
 
 construct_runtime!(
@@ -52,8 +52,6 @@ impl crate::Config for Runtime {
     type FixedTypeS = FixedI128<U33>;
     type BalanceFractionalDecimals = FractionalDecimalPlaces;
     type PoolId = PoolId;
-    // type MarketData = EmaMarketVolume<Self::FixedTypeU>;
-    // type Fees = FeeSigmoid<Self::FixedTypeS>;
     type Rikiddo = RikiddoSigmoidMV<
         Self::FixedTypeU,
         Self::FixedTypeS,

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -1,18 +1,15 @@
 #![cfg(test)]
-use crate::{
-    types::{EmaMarketVolume, FeeSigmoid, RikiddoSigmoidMV},
-};
+use crate::types::{EmaMarketVolume, FeeSigmoid, RikiddoSigmoidMV};
 use frame_support::{construct_runtime, parameter_types};
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
 };
-use substrate_fixed::{
-    types::extra::{U33},
-    FixedI128, FixedU128,
-};
+use substrate_fixed::{types::extra::U33, FixedI128, FixedU128};
 use zeitgeist_primitives::{
-    constants::{ExistentialDeposit, MaxReserves, BASE, BLOCK_HASH_COUNT, BALANCE_FRACTIONAL_DECIMAL_PLACES},
+    constants::{
+        ExistentialDeposit, MaxReserves, BALANCE_FRACTIONAL_DECIMAL_PLACES, BASE, BLOCK_HASH_COUNT,
+    },
     types::{
         AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, PoolId, UncheckedExtrinsicTest,
     },

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -1,7 +1,5 @@
 #![cfg(test)]
 use crate::{
-    self as zrml_rikiddo,
-    traits::RikiddoMV,
     types::{EmaMarketVolume, FeeSigmoid, RikiddoSigmoidMV},
 };
 use frame_support::{construct_runtime, parameter_types};
@@ -10,11 +8,11 @@ use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup},
 };
 use substrate_fixed::{
-    types::extra::{U33, U34},
+    types::extra::{U33},
     FixedI128, FixedU128,
 };
 use zeitgeist_primitives::{
-    constants::{ExistentialDeposit, MaxReserves, BASE, BLOCK_HASH_COUNT},
+    constants::{ExistentialDeposit, MaxReserves, BASE, BLOCK_HASH_COUNT, BALANCE_FRACTIONAL_DECIMAL_PLACES},
     types::{
         AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, PoolId, UncheckedExtrinsicTest,
     },
@@ -33,7 +31,7 @@ pub type UncheckedExtrinsic = UncheckedExtrinsicTest<Runtime>;
 parameter_types! {
     pub const BlockHashCount: u64 = BLOCK_HASH_COUNT;
     pub const MinimumPeriod: u64 = 0;
-    pub const FractionalDecimalPlaces: u8 = 10;
+    pub const FractionalDecimalPlaces: u8 = BALANCE_FRACTIONAL_DECIMAL_PLACES;
 }
 
 construct_runtime!(

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -8,7 +8,7 @@ use sp_runtime::{
 use substrate_fixed::{types::extra::U33, FixedI128, FixedU128};
 use zeitgeist_primitives::{
     constants::{
-        ExistentialDeposit, MaxReserves, BALANCE_FRACTIONAL_DECIMAL_PLACES, BASE, BLOCK_HASH_COUNT,
+        ExistentialDeposit, MaxReserves, BASE, BLOCK_HASH_COUNT,
     },
     types::{
         AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, PoolId, UncheckedExtrinsicTest,

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -7,9 +7,9 @@ use sp_runtime::{
 };
 use substrate_fixed::{types::extra::U33, FixedI128, FixedU128};
 use zeitgeist_primitives::{
-    constants::{ExistentialDeposit, MaxReserves, BASE, BLOCK_HASH_COUNT},
+    constants::{BlockHashCount, ExistentialDeposit, MaxReserves, BASE},
     types::{
-        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, PoolId, UncheckedExtrinsicTest,
+        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, Moment, PoolId, UncheckedExtrinsicTest,
     },
 };
 
@@ -24,7 +24,6 @@ pub type Block = BlockTest<Runtime>;
 pub type UncheckedExtrinsic = UncheckedExtrinsicTest<Runtime>;
 
 parameter_types! {
-    pub const BlockHashCount: u64 = BLOCK_HASH_COUNT;
     pub const MinimumPeriod: u64 = 0;
     pub const FractionalDecimalPlaces: u8 = 10;
 }

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -1,15 +1,21 @@
 #![cfg(test)]
-use crate as zrml_rikiddo;
-use frame_support::construct_runtime;
+use crate::{
+    self as zrml_rikiddo,
+    types::{EmaMarketVolume, FeeSigmoid},
+};
+use frame_support::{construct_runtime, parameter_types};
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
 };
-use substrate_fixed::types::extra::U34;
+use substrate_fixed::{
+    types::extra::{U33, U34},
+    FixedI128, FixedU128,
+};
 use zeitgeist_primitives::{
-    constants::{BlockHashCount, ExistentialDeposit, MaxReserves, MinimumPeriod, BASE},
+    constants::{ExistentialDeposit, MaxReserves, BASE, BLOCK_HASH_COUNT},
     types::{
-        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, Moment, UncheckedExtrinsicTest,
+        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, PoolId, UncheckedExtrinsicTest,
     },
 };
 
@@ -22,6 +28,12 @@ pub const FRED: AccountIdTest = 5;
 
 pub type Block = BlockTest<Runtime>;
 pub type UncheckedExtrinsic = UncheckedExtrinsicTest<Runtime>;
+
+parameter_types! {
+    pub const BlockHashCount: u64 = BLOCK_HASH_COUNT;
+    pub const MinimumPeriod: u64 = 0;
+    pub const FractionalDecimalPlaces: u8 = 10;
+}
 
 construct_runtime!(
     pub enum Runtime
@@ -40,7 +52,12 @@ construct_runtime!(
 impl crate::Config for Runtime {
     type Timestamp = Timestamp;
     type Balance = Balance;
-    type FractionalType = U34;
+    type FixedTypeU = FixedU128<U33>;
+    type FixedTypeS = FixedI128<U33>;
+    type BalanceFractionalDecimals = FractionalDecimalPlaces;
+    type PoolId = PoolId;
+    type MarketData = EmaMarketVolume<Self::FixedTypeU>;
+    type Fees = FeeSigmoid<Self::FixedTypeS>;
 }
 
 impl frame_system::Config for Runtime {

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -1,5 +1,9 @@
 #![cfg(test)]
-use crate::{self as zrml_rikiddo, traits::RikiddoMV, types::{EmaMarketVolume, FeeSigmoid, RikiddoSigmoidMV}};
+use crate::{
+    self as zrml_rikiddo,
+    traits::RikiddoMV,
+    types::{EmaMarketVolume, FeeSigmoid, RikiddoSigmoidMV},
+};
 use frame_support::{construct_runtime, parameter_types};
 use sp_runtime::{
     testing::Header,
@@ -40,7 +44,7 @@ construct_runtime!(
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
         Balances: pallet_balances::{Call, Config<T>, Event<T>, Pallet, Storage},
-        Rikiddo: zrml_rikiddo::{Pallet, Storage},
+        Rikiddo: crate::{Pallet, Storage},
         System: frame_system::{Config, Event<T>, Pallet, Storage},
         Timestamp: pallet_timestamp::{Call, Pallet, Storage, Inherent},
     }
@@ -55,7 +59,12 @@ impl crate::Config for Runtime {
     type PoolId = PoolId;
     // type MarketData = EmaMarketVolume<Self::FixedTypeU>;
     // type Fees = FeeSigmoid<Self::FixedTypeS>;
-    type Rikiddo = RikiddoSigmoidMV<Self::FixedTypeU, Self::FixedTypeS, FeeSigmoid<Self::FixedTypeS>, EmaMarketVolume<Self::FixedTypeU>>; 
+    type Rikiddo = RikiddoSigmoidMV<
+        Self::FixedTypeU,
+        Self::FixedTypeS,
+        FeeSigmoid<Self::FixedTypeS>,
+        EmaMarketVolume<Self::FixedTypeU>,
+    >;
 }
 
 impl frame_system::Config for Runtime {

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -1,8 +1,5 @@
 #![cfg(test)]
-use crate::{
-    self as zrml_rikiddo,
-    types::{EmaMarketVolume, FeeSigmoid},
-};
+use crate::{self as zrml_rikiddo, traits::RikiddoMV, types::{EmaMarketVolume, FeeSigmoid, RikiddoSigmoidMV}};
 use frame_support::{construct_runtime, parameter_types};
 use sp_runtime::{
     testing::Header,
@@ -56,8 +53,9 @@ impl crate::Config for Runtime {
     type FixedTypeS = FixedI128<U33>;
     type BalanceFractionalDecimals = FractionalDecimalPlaces;
     type PoolId = PoolId;
-    type MarketData = EmaMarketVolume<Self::FixedTypeU>;
-    type Fees = FeeSigmoid<Self::FixedTypeS>;
+    // type MarketData = EmaMarketVolume<Self::FixedTypeU>;
+    // type Fees = FeeSigmoid<Self::FixedTypeS>;
+    type Rikiddo = RikiddoSigmoidMV<Self::FixedTypeU, Self::FixedTypeS, FeeSigmoid<Self::FixedTypeS>, EmaMarketVolume<Self::FixedTypeU>>; 
 }
 
 impl frame_system::Config for Runtime {

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -9,7 +9,8 @@ use substrate_fixed::{types::extra::U33, FixedI128, FixedU128};
 use zeitgeist_primitives::{
     constants::{BlockHashCount, ExistentialDeposit, MaxReserves, BASE},
     types::{
-        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, Moment, PoolId, UncheckedExtrinsicTest,
+        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, Moment, PoolId,
+        UncheckedExtrinsicTest,
     },
 };
 

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -81,7 +81,7 @@ fn fixed_point_decimal_to_fixed_type_returns_correct_result() {
         vec![0.0, 1.0, 0.0_000_000_001, 0.0_123_456_789, 99.99, 7_361.01, 1_337.33_333_333];
 
     for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
-        let converted: FixedU128<U33> = tv.0.to_fixed_as_fixed_decimal(tv.1).unwrap();
+        let converted: FixedU128<U33> = tv.0.to_fixed_from_fixed_decimal(tv.1).unwrap();
         assert_eq!(converted, <FixedU128<U33>>::from_num(tvc));
     }
 }
@@ -101,7 +101,7 @@ fn fixed_point_decimal_from_fixed_type_returns_correct_result() {
     let test_vector_correct_number: Vec<u128> = vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013];
 
     for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
-        let converted: u128 = u128::from_fixed_as_fixed_decimal(tv.0, tv.1).unwrap();
+        let converted: u128 = u128::from_fixed_to_fixed_decimal(tv.0, tv.1).unwrap();
         assert_eq!(converted, tvc);
     }
 }

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -2,6 +2,7 @@
 
 use frame_support::assert_err;
 use substrate_fixed::{
+    traits::ToFixed,
     types::extra::{U1, U2, U3, U33, U7, U8},
     FixedI8, FixedU128, FixedU8,
 };
@@ -85,23 +86,44 @@ fn fixed_point_decimal_to_fixed_type_returns_correct_result() {
     }
 }
 
-/*
 #[test]
 fn fixed_point_decimal_from_fixed_type_returns_correct_result() {
-    // This vector contains tuples of (fixed_point_decimal, fractional_decimal_places)
-    let test_vector: Vec<u64> = vec![(0, 10_000_000_000, 5, 123_456_789, 9_999, 736_101, 133_733_333_333];
-    let test_vector_correct_number = vec![(0, 10_000_000_000, 5, 123_456_789, 9_999, 736_101, 133_733_333_333];
+    // This vector contains tuples of (Fixed type, places)
+    // The tuples tests every logical path
+    let test_vector: Vec<(FixedU128<U33>, u8)> = vec![
+        (32.5f64.to_fixed(), 0),
+        (32.25f64.to_fixed(), 0),
+        (200.to_fixed(), 8),
+        (200.1234f64.to_fixed(), 8),
+        (200.1234f64.to_fixed(), 2),
+        (200.1254f64.to_fixed(), 2),
+    ];
+    let test_vector_correct_number: Vec<u128> = vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013];
 
     for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
-        let converted = <FixedU128<U33>>::from_fixed_decimal(tv.0, tv.1).unwrap();
-        assert_eq!(converted, <FixedU128<U33>>::from_num(tvc));
+        let converted: u128 = u128::from_fixed_as_fixed_decimal(tv.0, tv.1).unwrap();
+        assert_eq!(converted, tvc);
     }
 }
-*/
 
 #[test]
 fn fixed_type_to_fixed_point_decimal_returns_correct_result() {
-    assert!(false, "Unimplemented!");
+        // This vector contains tuples of (Fixed type, places)
+    // The tuples tests every logical path
+    let test_vector: Vec<(FixedU128<U33>, u8)> = vec![
+        (32.5f64.to_fixed(), 0),
+        (32.25f64.to_fixed(), 0),
+        (200.to_fixed(), 8),
+        (200.1234f64.to_fixed(), 8),
+        (200.1234f64.to_fixed(), 2),
+        (200.1254f64.to_fixed(), 2),
+    ];
+    let test_vector_correct_number: Vec<u128> = vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013];
+
+    for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
+        let converted: u128 = tv.0.to_fixed_decimal(tv.1).unwrap();
+        assert_eq!(converted, tvc);
+    }
 }
 
 #[test]

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -98,7 +98,8 @@ fn fixed_point_decimal_from_fixed_type_returns_correct_result() {
         (200.1234f64.to_fixed(), 2),
         (200.1254f64.to_fixed(), 2),
     ];
-    let test_vector_correct_number: Vec<u128> = vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013];
+    let test_vector_correct_number: Vec<u128> =
+        vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013];
 
     for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
         let converted: u128 = u128::from_fixed_to_fixed_decimal(tv.0, tv.1).unwrap();
@@ -108,7 +109,7 @@ fn fixed_point_decimal_from_fixed_type_returns_correct_result() {
 
 #[test]
 fn fixed_type_to_fixed_point_decimal_returns_correct_result() {
-        // This vector contains tuples of (Fixed type, places)
+    // This vector contains tuples of (Fixed type, places)
     // The tuples tests every logical path
     let test_vector: Vec<(FixedU128<U33>, u8)> = vec![
         (32.5f64.to_fixed(), 0),
@@ -118,7 +119,8 @@ fn fixed_type_to_fixed_point_decimal_returns_correct_result() {
         (200.1234f64.to_fixed(), 2),
         (200.1254f64.to_fixed(), 2),
     ];
-    let test_vector_correct_number: Vec<u128> = vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013];
+    let test_vector_correct_number: Vec<u128> =
+        vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013];
 
     for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
         let converted: u128 = tv.0.to_fixed_decimal(tv.1).unwrap();

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -8,8 +8,8 @@ use substrate_fixed::{
 };
 
 use crate::types::{
-    convert_to_signed, convert_to_unsigned, FromFixedDecimal, FromFixedToDecimal,
-    IntoFixedAsDecimal, IntoFixedDecimal,
+    convert_to_signed, convert_to_unsigned, FromFixedDecimal, FromFixedToDecimal, IntoFixedDecimal,
+    IntoFixedFromDecimal,
 };
 
 mod ema_market_volume;

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -2,16 +2,17 @@
 
 use frame_support::assert_err;
 use substrate_fixed::{
-    types::extra::{U1, U2, U3, U7, U8},
-    FixedI8, FixedU8,
+    types::extra::{U1, U2, U3, U33, U7, U8},
+    FixedI8, FixedU128, FixedU8,
 };
 
-use crate::{
-    mock::ExtBuilder,
-    types::{convert_to_signed, convert_to_unsigned},
+use crate::types::{
+    convert_to_signed, convert_to_unsigned, FromFixedDecimal, FromFixedToDecimal,
+    IntoFixedAsDecimal, IntoFixedDecimal,
 };
 
 mod ema_market_volume;
+mod pallet;
 mod rikiddo_sigmoid_mv;
 mod sigmoid_fee;
 
@@ -64,8 +65,62 @@ fn convert_signed_to_unsigned_returns_correct_result() -> Result<(), &'static st
 }
 
 #[test]
-fn it_is_a_dummy_test() {
-    ExtBuilder::default().build().execute_with(|| {
-        assert!(true);
-    });
+fn fixed_point_decimal_to_fixed_type_returns_correct_result() {
+    // This vector contains tuples of (fixed_point_decimal, fractional_decimal_places)
+    let test_vector: Vec<(u128, u8)> = vec![
+        (0, 0),
+        (10_000_000_000, 10),
+        (1, 10),
+        (123_456_789, 10),
+        (9_999, 2),
+        (736_101, 2),
+        (133_733_333_333, 8),
+    ];
+    let test_vector_correct_number: Vec<f64> =
+        vec![0.0, 1.0, 0.0_000_000_001, 0.0_123_456_789, 99.99, 7_361.01, 1_337.33_333_333];
+
+    for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
+        let converted: FixedU128<U33> = tv.0.to_fixed_as_fixed_decimal(tv.1).unwrap();
+        assert_eq!(converted, <FixedU128<U33>>::from_num(tvc));
+    }
+}
+
+/*
+#[test]
+fn fixed_point_decimal_from_fixed_type_returns_correct_result() {
+    // This vector contains tuples of (fixed_point_decimal, fractional_decimal_places)
+    let test_vector: Vec<u64> = vec![(0, 10_000_000_000, 5, 123_456_789, 9_999, 736_101, 133_733_333_333];
+    let test_vector_correct_number = vec![(0, 10_000_000_000, 5, 123_456_789, 9_999, 736_101, 133_733_333_333];
+
+    for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
+        let converted = <FixedU128<U33>>::from_fixed_decimal(tv.0, tv.1).unwrap();
+        assert_eq!(converted, <FixedU128<U33>>::from_num(tvc));
+    }
+}
+*/
+
+#[test]
+fn fixed_type_to_fixed_point_decimal_returns_correct_result() {
+    assert!(false, "Unimplemented!");
+}
+
+#[test]
+fn fixed_type_from_fixed_point_decimal_returns_correct_result() {
+    // This vector contains tuples of (fixed_point_decimal, fractional_decimal_places)
+    let test_vector: Vec<(u128, u8)> = vec![
+        (0, 0),
+        (10_000_000_000, 10),
+        (1, 10),
+        (123_456_789, 10),
+        (9_999, 2),
+        (736_101, 2),
+        (133_733_333_333, 8),
+    ];
+    let test_vector_correct_number: Vec<f64> =
+        vec![0.0, 1.0, 0.0_000_000_001, 0.0_123_456_789, 99.99, 7_361.01, 1_337.33_333_333];
+
+    for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
+        let converted = <FixedU128<U33>>::from_fixed_decimal(tv.0, tv.1).unwrap();
+        assert_eq!(converted, <FixedU128<U33>>::from_num(tvc));
+    }
 }

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -97,9 +97,10 @@ fn fixed_point_decimal_from_fixed_type_returns_correct_result() {
         (200.1234f64.to_fixed(), 8),
         (200.1234f64.to_fixed(), 2),
         (200.1254f64.to_fixed(), 2),
+        (123.456f64.to_fixed(), 3),
     ];
     let test_vector_correct_number: Vec<u128> =
-        vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013];
+        vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013, 123_456];
 
     for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
         let converted: u128 = u128::from_fixed_to_fixed_decimal(tv.0, tv.1).unwrap();
@@ -118,9 +119,10 @@ fn fixed_type_to_fixed_point_decimal_returns_correct_result() {
         (200.1234f64.to_fixed(), 8),
         (200.1234f64.to_fixed(), 2),
         (200.1254f64.to_fixed(), 2),
+        (123.456f64.to_fixed(), 3),
     ];
     let test_vector_correct_number: Vec<u128> =
-        vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013];
+        vec![33, 32, 20_000_000_000, 20_012_340_000, 20_012, 20_013, 123_456];
 
     for (tv, tvc) in test_vector.iter().zip(test_vector_correct_number) {
         let converted: u128 = tv.0.to_fixed_decimal(tv.1).unwrap();

--- a/zrml/rikiddo/src/tests/ema_market_volume.rs
+++ b/zrml/rikiddo/src/tests/ema_market_volume.rs
@@ -36,7 +36,7 @@ fn ema_state_transitions_work() {
     assert_eq!(emv.state(), &MarketVolumeState::Uninitialized);
     let _ = emv.update(&TimestampedVolume { timestamp: 0, volume: 1u32.into() }).unwrap();
     assert_eq!(emv.state(), &MarketVolumeState::DataCollectionStarted);
-    let abc = emv.update(&TimestampedVolume { timestamp: 3, volume: 1u32.into() }).unwrap();
+    let _ = emv.update(&TimestampedVolume { timestamp: 3, volume: 1u32.into() }).unwrap();
     assert_eq!(emv.state(), &MarketVolumeState::DataCollected);
 }
 

--- a/zrml/rikiddo/src/tests/ema_market_volume.rs
+++ b/zrml/rikiddo/src/tests/ema_market_volume.rs
@@ -36,7 +36,7 @@ fn ema_state_transitions_work() {
     assert_eq!(emv.state(), &MarketVolumeState::Uninitialized);
     let _ = emv.update(&TimestampedVolume { timestamp: 0, volume: 1u32.into() }).unwrap();
     assert_eq!(emv.state(), &MarketVolumeState::DataCollectionStarted);
-    let _ = emv.update(&TimestampedVolume { timestamp: 3, volume: 1u32.into() }).unwrap();
+    let abc = emv.update(&TimestampedVolume { timestamp: 3, volume: 1u32.into() }).unwrap();
     assert_eq!(emv.state(), &MarketVolumeState::DataCollected);
 }
 

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -1,3 +1,5 @@
+use sp_std::convert::TryInto;
+
 use frame_support::{
     assert_noop, assert_ok,
     traits::{OnFinalize, OnInitialize},
@@ -5,7 +7,12 @@ use frame_support::{
 use frame_system::RawOrigin;
 use zeitgeist_primitives::constants::BALANCE_FRACTIONAL_DECIMAL_PLACES;
 
-use crate::{mock::*, traits::RikiddoSigmoidMVPallet, types::Timespan, Config};
+use crate::{Config, mock::*, tests::rikiddo_sigmoid_mv::cost, traits::RikiddoSigmoidMVPallet, types::{FromFixedDecimal, IntoFixedDecimal, Timespan}};
+
+#[inline]
+fn max_balance_difference(frac_dec_places: u8, max_percent_places_wrong: f64) -> u128 {
+    10u128.pow((frac_dec_places as f64 * max_percent_places_wrong).floor() as u32)
+}
 
 fn run_to_block(n: u64) {
     while System::block_number() < n {
@@ -78,20 +85,99 @@ fn rikiddo_pallet_update_market_data_returns_correct_result() {
 }
 
 #[test]
-fn rikiddo_pallet_cost_returns_correct_result() {
+fn rikiddo_pallet_fee_return_correct_result() {
     ExtBuilder::default().build().execute_with(|| {
+        // First we check that the returned initial fee is correct
         let mut rikiddo = <Runtime as Config>::Rikiddo::default();
+        type FixedS = <Runtime as Config>::FixedTypeS;
+        type Balance = <Runtime as Config>::Balance;
+        let frac_dec_places = <Runtime as Config>::BalanceFractionalDecimals::get();
+        let initial_fee: f64 = rikiddo.config.initial_fee.to_num();
         rikiddo.ma_short.config.ema_period = Timespan::Seconds(1);
         rikiddo.ma_long.config.ema_period = Timespan::Seconds(1);
-        // TODO
-        /*
-        assert_noop!(Rikiddo::update(0, 10000000000), crate::Error::<Runtime>::RikiddoNotFoundForPool);
+        assert_noop!(
+            Rikiddo::fee(0),
+            crate::Error::<Runtime>::RikiddoNotFoundForPool
+        );
         let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 0).unwrap();
         assert_ok!(Rikiddo::create(0, rikiddo));
+        let fee_reference_balance: Balance = FixedS::from_num(initial_fee).to_fixed_decimal(frac_dec_places).unwrap();
+        let fee_pallet_balance = Rikiddo::fee(0).unwrap();
+        let difference_abs = (fee_pallet_balance as i128 - fee_reference_balance as i128).abs() as u128;
+        let max_difference = max_balance_difference(frac_dec_places, 0.3);
+        assert!(
+            difference_abs <= max_difference,
+            "\nReference fee result (Balance): {}\nRikiddo pallet fee result (Balance): {}\nDifference: \
+             {}\nMax_Allowed_Difference: {}",
+             fee_reference_balance,
+            fee_pallet_balance,
+            difference_abs,
+            max_difference,
+        );
+
+        // Now we check if the fee has changed, since enough volume data was collected
+        assert_ok!(Rikiddo::update(0, 10000000000));
+        run_to_block(1);
+        let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 2).unwrap();
+        assert_ok!(Rikiddo::update(0, 10000000000));
+        assert_ne!(
+            Rikiddo::fee(0).unwrap(),
+            fee_pallet_balance
+        );
+    });
+}
+
+#[test]
+fn rikiddo_pallet_cost_returns_correct_result() {
+    ExtBuilder::default().build().execute_with(|| {
+        // The first part compares the result from the f64 reference cost function with
+        // what the pallet returns. It uses the initial fee.
+        let mut rikiddo = <Runtime as Config>::Rikiddo::default();
+        type FixedS = <Runtime as Config>::FixedTypeS;
+        type Balance = <Runtime as Config>::Balance;
+        let frac_dec_places = <Runtime as Config>::BalanceFractionalDecimals::get();
+        let initial_fee: f64 = rikiddo.config.initial_fee.to_num();
+        rikiddo.ma_short.config.ema_period = Timespan::Seconds(1);
+        rikiddo.ma_long.config.ema_period = Timespan::Seconds(1);
+        assert_ok!(Rikiddo::create(0, rikiddo));
+        let asset_balance: <Runtime as Config>::Balance = (500u128 * 10u128.pow(frac_dec_places as u32)).try_into().unwrap();
+        let cost_pallet_balance = Rikiddo::cost(0, &[asset_balance, asset_balance]).unwrap();
+        let cost_reference = cost(initial_fee, &vec![500.0f64, 500.0f64]);
+        let cost_reference_balance: Balance = FixedS::from_num(cost_reference).to_fixed_decimal(frac_dec_places).unwrap();
+        let difference_abs = (cost_pallet_balance as i128 - cost_reference_balance as i128).abs() as u128;
+        let max_difference = max_balance_difference(frac_dec_places, 0.3);
+        assert!(
+            difference_abs <= max_difference,
+            "\nReference cost result (Balance): {}\nRikiddo pallet cost result (Balance): {}\nDifference: \
+             {}\nMax_Allowed_Difference: {}",
+            cost_reference_balance,
+            cost_pallet_balance,
+            difference_abs,
+            max_difference,
+        );
+
+        // The second part also compares the cost results, but uses the sigmoid fee.
+        let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 0).unwrap();
+        //let fee = Rikiddo::fee
         assert_ok!(Rikiddo::update(0, 10000000000));
         run_to_block(1);
         let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 2).unwrap();
         assert_eq!(Rikiddo::update(0, 10000000000).unwrap(), Some(10u128.pow(BALANCE_FRACTIONAL_DECIMAL_PLACES as u32)));
-        */
+        let cost_pallet_balance_with_fee = Rikiddo::cost(0, &[asset_balance, asset_balance]).unwrap();
+        let fee = Rikiddo::fee(0).unwrap();
+        let fee_f64: f64 = FixedS::from_fixed_decimal(fee, frac_dec_places).unwrap().to_num();
+        let cost_reference_with_fee = cost(fee_f64, &vec![500.0f64, 500.0f64]);
+        let cost_reference_balance_with_fee: Balance = FixedS::from_num(cost_reference_with_fee).to_fixed_decimal(frac_dec_places).unwrap();
+        let difference_abs_with_fee = (cost_pallet_balance_with_fee as i128 - cost_reference_balance_with_fee as i128).abs() as u128;
+        let max_difference_with_fee = max_balance_difference(frac_dec_places, 0.3);
+        assert!(
+            difference_abs_with_fee <= max_difference_with_fee,
+            "\nReference cost result (Balance): {}\nRikiddo pallet cost result (Balance): {}\nDifference: \
+             {}\nMax_Allowed_Difference: {}",
+            cost_reference_balance_with_fee,
+            cost_pallet_balance_with_fee,
+            difference_abs_with_fee,
+            max_difference_with_fee,
+        );
     });
 }

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -1,5 +1,4 @@
-use sp_std::convert::TryInto;
-
+use core::convert::TryInto;
 use frame_support::{
     assert_noop, assert_ok,
     traits::{OnFinalize, OnInitialize},

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -19,10 +19,7 @@ fn rikiddo_pallet_can_create_one_instance_per_pool() {
 fn rikiddo_pallet_can_only_clear_existing_rikiddo_instances() {
     ExtBuilder::default().build().execute_with(|| {
         let rikiddo = <Runtime as Config>::Rikiddo::default();
-        assert_noop!(
-            Rikiddo::clear(0),
-            crate::Error::<Runtime>::RikiddoNotFoundForPool
-        );
+        assert_noop!(Rikiddo::clear(0), crate::Error::<Runtime>::RikiddoNotFoundForPool);
         assert_ok!(Rikiddo::create(0, rikiddo));
         assert_ok!(Rikiddo::clear(0));
     });
@@ -32,15 +29,9 @@ fn rikiddo_pallet_can_only_clear_existing_rikiddo_instances() {
 fn rikiddo_pallet_can_only_destroy_existing_rikiddo_instances() {
     ExtBuilder::default().build().execute_with(|| {
         let rikiddo = <Runtime as Config>::Rikiddo::default();
-        assert_noop!(
-            Rikiddo::destroy(0),
-            crate::Error::<Runtime>::RikiddoNotFoundForPool
-        );
+        assert_noop!(Rikiddo::destroy(0), crate::Error::<Runtime>::RikiddoNotFoundForPool);
         assert_ok!(Rikiddo::create(0, rikiddo));
         assert_ok!(Rikiddo::destroy(0));
-        assert_noop!(
-            Rikiddo::clear(0),
-            crate::Error::<Runtime>::RikiddoNotFoundForPool
-        );
+        assert_noop!(Rikiddo::clear(0), crate::Error::<Runtime>::RikiddoNotFoundForPool);
     });
 }

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -1,8 +1,29 @@
-use crate::mock::ExtBuilder;
+use frame_support::{assert_noop, assert_ok};
+
+use crate::{mock::*, traits::RikiddoSigmoidMVPallet, Config};
 
 #[test]
-fn it_is_a_dummy_test() {
+fn rikiddo_pallet_can_create_one_instance_per_pool() {
     ExtBuilder::default().build().execute_with(|| {
-        assert!(true);
+        let rikiddo = <Runtime as Config>::Rikiddo::default();
+        assert_ok!(Rikiddo::create(0, rikiddo.clone()));
+        assert_noop!(
+            Rikiddo::create(0, rikiddo.clone()),
+            crate::Error::<Runtime>::RikiddoAlreadyExistsForPool
+        );
+        assert_ok!(Rikiddo::create(1, rikiddo));
+    });
+}
+
+#[test]
+fn rikiddo_pallet_can_only_clear_existing_rikiddo_instances() {
+    ExtBuilder::default().build().execute_with(|| {
+        let rikiddo = <Runtime as Config>::Rikiddo::default();
+        assert_noop!(
+            Rikiddo::clear(0),
+            crate::Error::<Runtime>::RikiddoNotFoundForPool
+        );
+        assert_ok!(Rikiddo::create(0, rikiddo));
+        assert_ok!(Rikiddo::clear(0));
     });
 }

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -58,13 +58,12 @@ fn rikiddo_pallet_update_market_data_returns_correct_result() {
         let mut rikiddo = <Runtime as Config>::Rikiddo::default();
         rikiddo.ma_short.config.ema_period = Timespan::Seconds(1);
         rikiddo.ma_long.config.ema_period = Timespan::Seconds(1);
-        assert_noop!(Rikiddo::update(0, 100), crate::Error::<Runtime>::RikiddoNotFoundForPool);
-        assert_ok!(Rikiddo::create(0, rikiddo));
+        assert_noop!(Rikiddo::update(0, 10000000000), crate::Error::<Runtime>::RikiddoNotFoundForPool);
         let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 0).unwrap();
-        assert_ok!(Rikiddo::update(0, 100));
+        assert_ok!(Rikiddo::create(0, rikiddo));
+        assert_ok!(Rikiddo::update(0, 10000000000));
         run_to_block(1);
         let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 2).unwrap();
-        assert_eq!(Rikiddo::update(0, 100).unwrap(), Some(10u128.pow(BALANCE_FRACTIONAL_DECIMAL_PLACES as u32)));
-        // TODO: Figure out why the previous assertion fails
+        assert_eq!(Rikiddo::update(0, 10000000000).unwrap(), Some(10u128.pow(BALANCE_FRACTIONAL_DECIMAL_PLACES as u32)));
     });
 }

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -75,16 +75,16 @@ fn rikiddo_pallet_update_market_data_returns_correct_result() {
         rikiddo.ma_short.config.ema_period = Timespan::Seconds(1);
         rikiddo.ma_long.config.ema_period = Timespan::Seconds(1);
         assert_noop!(
-            Rikiddo::update(0, 10000000000),
+            Rikiddo::update_volume(0, 10000000000),
             crate::Error::<Runtime>::RikiddoNotFoundForPool
         );
         let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 0).unwrap();
         assert_ok!(Rikiddo::create(0, rikiddo));
-        assert_ok!(Rikiddo::update(0, 10000000000));
+        assert_ok!(Rikiddo::update_volume(0, 10000000000));
         run_to_block(1);
         let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 2).unwrap();
         assert_eq!(
-            Rikiddo::update(0, 10000000000).unwrap(),
+            Rikiddo::update_volume(0, 10000000000).unwrap(),
             Some(10u128.pow(BALANCE_FRACTIONAL_DECIMAL_PLACES as u32))
         );
     });
@@ -121,10 +121,10 @@ fn rikiddo_pallet_fee_return_correct_result() {
         );
 
         // Now we check if the fee has changed, since enough volume data was collected
-        assert_ok!(Rikiddo::update(0, 10000000000));
+        assert_ok!(Rikiddo::update_volume(0, 10000000000));
         run_to_block(1);
         let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 2).unwrap();
-        assert_ok!(Rikiddo::update(0, 10000000000));
+        assert_ok!(Rikiddo::update_volume(0, 10000000000));
         assert_ne!(Rikiddo::fee(0).unwrap(), fee_pallet_balance);
     });
 }
@@ -163,11 +163,11 @@ fn rikiddo_pallet_cost_returns_correct_result() {
 
         // The second part also compares the cost results, but uses the sigmoid fee.
         let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 0).unwrap();
-        assert_ok!(Rikiddo::update(0, 10000000000));
+        assert_ok!(Rikiddo::update_volume(0, 10000000000));
         run_to_block(1);
         let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 2).unwrap();
         assert_eq!(
-            Rikiddo::update(0, 10000000000).unwrap(),
+            Rikiddo::update_volume(0, 10000000000).unwrap(),
             Some(10u128.pow(BALANCE_FRACTIONAL_DECIMAL_PLACES as u32))
         );
         let cost_pallet_balance_with_fee =

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -27,3 +27,20 @@ fn rikiddo_pallet_can_only_clear_existing_rikiddo_instances() {
         assert_ok!(Rikiddo::clear(0));
     });
 }
+
+#[test]
+fn rikiddo_pallet_can_only_destroy_existing_rikiddo_instances() {
+    ExtBuilder::default().build().execute_with(|| {
+        let rikiddo = <Runtime as Config>::Rikiddo::default();
+        assert_noop!(
+            Rikiddo::destroy(0),
+            crate::Error::<Runtime>::RikiddoNotFoundForPool
+        );
+        assert_ok!(Rikiddo::create(0, rikiddo));
+        assert_ok!(Rikiddo::destroy(0));
+        assert_noop!(
+            Rikiddo::clear(0),
+            crate::Error::<Runtime>::RikiddoNotFoundForPool
+        );
+    });
+}

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -1,0 +1,8 @@
+use crate::mock::ExtBuilder;
+
+#[test]
+fn it_is_a_dummy_test() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert!(true);
+    });
+}

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -1,6 +1,22 @@
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, traits::{OnFinalize, OnInitialize}};
+use frame_system::RawOrigin;
+use zeitgeist_primitives::constants::BALANCE_FRACTIONAL_DECIMAL_PLACES;
 
-use crate::{mock::*, traits::RikiddoSigmoidMVPallet, Config};
+use crate::{Config, mock::*, traits::RikiddoSigmoidMVPallet, types::Timespan};
+
+fn run_to_block(n: u64) {
+    while System::block_number() < n {
+        Timestamp::on_finalize(System::block_number());
+        Balances::on_finalize(System::block_number());
+        Rikiddo::on_finalize(System::block_number());
+        System::on_finalize(System::block_number());
+        System::set_block_number(System::block_number() + 1);
+        System::on_initialize(System::block_number());
+        Timestamp::on_initialize(System::block_number());
+        Balances::on_initialize(System::block_number());
+        Rikiddo::on_initialize(System::block_number());
+    }
+  }
 
 #[test]
 fn rikiddo_pallet_can_create_one_instance_per_pool() {
@@ -33,5 +49,22 @@ fn rikiddo_pallet_can_only_destroy_existing_rikiddo_instances() {
         assert_ok!(Rikiddo::create(0, rikiddo));
         assert_ok!(Rikiddo::destroy(0));
         assert_noop!(Rikiddo::clear(0), crate::Error::<Runtime>::RikiddoNotFoundForPool);
+    });
+}
+
+#[test]
+fn rikiddo_pallet_update_market_data_returns_correct_result() {
+    ExtBuilder::default().build().execute_with(|| {
+        let mut rikiddo = <Runtime as Config>::Rikiddo::default();
+        rikiddo.ma_short.config.ema_period = Timespan::Seconds(1);
+        rikiddo.ma_long.config.ema_period = Timespan::Seconds(1);
+        assert_noop!(Rikiddo::update(0, 100), crate::Error::<Runtime>::RikiddoNotFoundForPool);
+        assert_ok!(Rikiddo::create(0, rikiddo));
+        let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 0).unwrap();
+        assert_ok!(Rikiddo::update(0, 100));
+        run_to_block(1);
+        let _ = <Runtime as Config>::Timestamp::set(RawOrigin::None.into(), 2).unwrap();
+        assert_eq!(Rikiddo::update(0, 100).unwrap(), Some(10u128.pow(BALANCE_FRACTIONAL_DECIMAL_PLACES as u32)));
+        // TODO: Figure out why the previous assertion fails
     });
 }

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -192,3 +192,5 @@ fn rikiddo_pallet_cost_returns_correct_result() {
         );
     });
 }
+
+// TODO: Tests for price and all_prices

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -20,7 +20,7 @@ fn ln_exp_sum(exponents: &Vec<f64>) -> f64 {
     exponents.iter().fold(0f64, |acc, val| acc + val.exp()).ln()
 }
 
-fn cost(fee: f64, balances: &Vec<f64>) -> f64 {
+pub(super) fn cost(fee: f64, balances: &Vec<f64>) -> f64 {
     let fee_times_sum = fee * balances.iter().sum::<f64>();
     let exponents = balances.iter().map(|e| e / fee_times_sum).collect();
     fee_times_sum * ln_exp_sum(&exponents)

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -3,6 +3,12 @@ use substrate_fixed::{types::extra::U64, FixedI128, FixedU128};
 use super::{ema_market_volume::ema_create_test_struct, max_allowed_error};
 use crate::types::{EmaMarketVolume, FeeSigmoid, RikiddoSigmoidMV};
 
+mod cost;
+mod fee;
+mod market_volume;
+mod misc;
+mod price;
+
 type Rikiddo = RikiddoSigmoidMV<
     FixedU128<U64>,
     FixedI128<U64>,
@@ -56,9 +62,3 @@ fn price(fee: f64, balances: &Vec<f64>, balance_in_question: f64) -> f64 {
     let denominator: f64 = balance_exponential_results.iter().sum::<f64>() * balance_sum;
     left_from_addition + (numerator / denominator)
 }
-
-mod cost;
-mod fee;
-mod market_volume;
-mod misc;
-mod price;

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv.rs
@@ -49,7 +49,7 @@ fn price_second_quotient(fee: f64, balances: &Vec<f64>) -> f64 {
         / denominator
 }
 
-fn price(fee: f64, balances: &Vec<f64>, balance_in_question: f64) -> f64 {
+pub(super) fn price(fee: f64, balances: &Vec<f64>, balance_in_question: f64) -> f64 {
     let balance_sum = balances.iter().sum::<f64>();
     let fee_times_sum = fee * balance_sum;
     let balance_exponential_results: Vec<f64> =

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/cost.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/cost.rs
@@ -110,12 +110,7 @@ fn rikiddo_cost_helper_does_set_all_values() -> Result<(), &'static str> {
     let rikiddo = Rikiddo::default();
     let param = <FixedU128<U64>>::from_num(1);
     let mut formula_components = RikiddoFormulaComponents::default();
-    let _ = rikiddo.cost_with_forumla(
-        &vec![param, param],
-        &mut formula_components,
-        true,
-        true,
-    )?;
+    let _ = rikiddo.cost_with_forumla(&vec![param, param], &mut formula_components, true, true)?;
     let zero: FixedI128<U64> = 0.to_fixed();
     assert_ne!(formula_components.one, zero);
     assert_ne!(formula_components.fee, zero);

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/cost.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/cost.rs
@@ -50,45 +50,6 @@ fn rikiddo_cost_function_overflow_during_calculation_of_exponent() {
 }
 
 #[test]
-fn rikiddo_cost_function_overflow_during_log2e_times_biggest_exponent() {
-    let mut rikiddo = Rikiddo::default();
-    rikiddo.config.initial_fee =
-        <FixedI128<U64>>::from_bits(0x0000_0000_0000_0000_0000_0000_0000_0003);
-    rikiddo.config.log2_e = <FixedI128<U64>>::from_num(i64::MAX);
-    let param = <FixedU128<U64>>::from_num(i64::MAX as u64);
-    assert_err!(
-        rikiddo.cost(&vec![param]),
-        "[RikiddoSigmoidMV] Overflow during calculation: log2_e * biggest_exponent"
-    );
-}
-
-#[test]
-fn rikiddo_cost_function_overflow_during_calculation_of_required_bits_minus_one() {
-    let mut rikiddo = Rikiddo::default();
-    rikiddo.config.initial_fee = <FixedI128<U64>>::from_num(1);
-    rikiddo.config.log2_e = <FixedI128<U64>>::from_num(i64::MAX);
-    let param = <FixedU128<U64>>::from_num(i64::MAX as u64);
-    let zero = <FixedU128<U64>>::from_num(0);
-    assert_err!(
-        rikiddo.cost(&vec![param, zero]),
-        "[RikiddoSigmoidMV] Overflow during calculation: biggest_exp * log2(e) + log2(num_assets)"
-    );
-}
-
-#[test]
-fn rikiddo_cost_function_overflow_during_ceil_required_bits_minus_one() {
-    let mut rikiddo = Rikiddo::default();
-    rikiddo.config.initial_fee = <FixedI128<U64>>::from_num(1);
-    rikiddo.config.log2_e = <FixedI128<U64>>::from_num(i64::MAX) + <FixedI128<U64>>::from_num(0.1);
-    let param = <FixedU128<U64>>::from_num(i64::MAX as u64);
-    assert_err!(
-        rikiddo.cost(&vec![param]),
-        "[RikiddoSigmoidMV] Overflow during calculation: ceil(biggest_exp * log2(e) + \
-         log2(num_assets))"
-    );
-}
-
-#[test]
 fn rikiddo_cost_function_overflow_during_calculation_of_result() {
     let mut rikiddo = Rikiddo::default();
     rikiddo.config.initial_fee = <FixedI128<U64>>::from_num(1);
@@ -154,7 +115,6 @@ fn rikiddo_cost_helper_does_set_all_values() -> Result<(), &'static str> {
         &mut formula_components,
         true,
         true,
-        true,
     )?;
     let zero: FixedI128<U64> = 0.to_fixed();
     assert_ne!(formula_components.one, zero);
@@ -175,7 +135,7 @@ fn rikiddo_cost_helper_does_return_cost_minus_sum_quantities() -> Result<(), &'s
     let mut formula_components = RikiddoFormulaComponents::default();
     let quantities = &vec![param, param];
     let cost_without_sum_quantities =
-        rikiddo.cost_with_forumla(&quantities, &mut formula_components, true, false, false)?;
+        rikiddo.cost_with_forumla(&quantities, &mut formula_components, true, false)?;
     let cost_from_price_formula_times_sum_quantities =
         cost_without_sum_quantities * formula_components.sum_balances;
     let cost: FixedI128<U64> = convert_to_signed(rikiddo.cost(&quantities)?)?;

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/fee.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/fee.rs
@@ -3,7 +3,7 @@ use substrate_fixed::{types::extra::U64, FixedU128};
 
 use super::{ema_create_test_struct, Rikiddo};
 use crate::{
-    traits::{MarketAverage, RikiddoMV},
+    traits::{Lmsr, MarketAverage, RikiddoMV},
     types::{FeeSigmoid, RikiddoConfig, TimestampedVolume},
 };
 

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/fee.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/fee.rs
@@ -15,7 +15,7 @@ fn rikiddo_get_fee_catches_zero_divison() {
     let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
     let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
     assert_err!(
-        rikiddo.get_fee(),
+        rikiddo.fee(),
         "[RikiddoSigmoidMV] Zero division error during calculation: ma_short / ma_long"
     );
 }
@@ -30,7 +30,7 @@ fn rikiddo_get_fee_overflows_during_ratio_calculation() {
     rikiddo.ma_short.ema = <FixedU128<U64>>::from_num(u64::MAX);
     rikiddo.ma_long.ema = <FixedU128<U64>>::from_num(0.1f64);
     assert_err!(
-        rikiddo.get_fee(),
+        rikiddo.fee(),
         "[RikiddoSigmoidMV] Overflow during calculation: ma_short / ma_long"
     );
 }
@@ -45,7 +45,7 @@ fn rikiddo_get_fee_ratio_does_not_fit_in_type() {
     rikiddo.ma_short.ema = <FixedU128<U64>>::from_num(u64::MAX);
     rikiddo.ma_long.ema = <FixedU128<U64>>::from_num(1u64);
     assert_err!(
-        rikiddo.get_fee(),
+        rikiddo.fee(),
         "Fixed point conversion failed: FROM type does not fit in TO type"
     );
 }
@@ -58,16 +58,16 @@ fn rikiddo_get_fee_returns_the_correct_result() {
         Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv_short, emv_long);
     assert_eq!(rikiddo.ma_short.get(), None);
     assert_eq!(rikiddo.ma_long.get(), None);
-    assert_eq!(rikiddo.get_fee().unwrap(), rikiddo.config.initial_fee);
+    assert_eq!(rikiddo.fee().unwrap(), rikiddo.config.initial_fee);
     let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 100u32.into() });
     let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 100u32.into() });
     assert_ne!(rikiddo.ma_short.get(), None);
     assert_eq!(rikiddo.ma_long.get(), None);
-    assert_eq!(rikiddo.get_fee().unwrap(), rikiddo.config.initial_fee);
+    assert_eq!(rikiddo.fee().unwrap(), rikiddo.config.initial_fee);
     let _ = rikiddo.update(&TimestampedVolume { timestamp: 3, volume: 100u32.into() });
     assert_ne!(rikiddo.ma_short.get(), None);
     assert_ne!(rikiddo.ma_long.get(), None);
     // We don't want to test the exact result (that is the responsibility of the fee module),
     // but rather if rikiddo toggles properly between initial fee and the calculated fee
-    assert_ne!(rikiddo.get_fee().unwrap(), rikiddo.config.initial_fee);
+    assert_ne!(rikiddo.fee().unwrap(), rikiddo.config.initial_fee);
 }

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/fee.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/fee.rs
@@ -12,8 +12,8 @@ fn rikiddo_get_fee_catches_zero_divison() {
     let emv = ema_create_test_struct(1, 0.0);
     let mut rikiddo =
         Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
-    let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
-    let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
+    let _ = rikiddo.update_volume(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
+    let _ = rikiddo.update_volume(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
     assert_err!(
         rikiddo.fee(),
         "[RikiddoSigmoidMV] Zero division error during calculation: ma_short / ma_long"
@@ -25,8 +25,8 @@ fn rikiddo_get_fee_overflows_during_ratio_calculation() {
     let emv = ema_create_test_struct(1, 2.0);
     let mut rikiddo =
         Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
-    let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
-    let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
+    let _ = rikiddo.update_volume(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
+    let _ = rikiddo.update_volume(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
     rikiddo.ma_short.ema = <FixedU128<U64>>::from_num(u64::MAX);
     rikiddo.ma_long.ema = <FixedU128<U64>>::from_num(0.1f64);
     assert_err!(
@@ -40,8 +40,8 @@ fn rikiddo_get_fee_ratio_does_not_fit_in_type() {
     let emv = ema_create_test_struct(1, 2.0);
     let mut rikiddo =
         Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
-    let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
-    let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
+    let _ = rikiddo.update_volume(&TimestampedVolume { timestamp: 0, volume: 0u32.into() });
+    let _ = rikiddo.update_volume(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
     rikiddo.ma_short.ema = <FixedU128<U64>>::from_num(u64::MAX);
     rikiddo.ma_long.ema = <FixedU128<U64>>::from_num(1u64);
     assert_err!(rikiddo.fee(), "Fixed point conversion failed: FROM type does not fit in TO type");
@@ -56,12 +56,12 @@ fn rikiddo_get_fee_returns_the_correct_result() {
     assert_eq!(rikiddo.ma_short.get(), None);
     assert_eq!(rikiddo.ma_long.get(), None);
     assert_eq!(rikiddo.fee().unwrap(), rikiddo.config.initial_fee);
-    let _ = rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 100u32.into() });
-    let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 100u32.into() });
+    let _ = rikiddo.update_volume(&TimestampedVolume { timestamp: 0, volume: 100u32.into() });
+    let _ = rikiddo.update_volume(&TimestampedVolume { timestamp: 2, volume: 100u32.into() });
     assert_ne!(rikiddo.ma_short.get(), None);
     assert_eq!(rikiddo.ma_long.get(), None);
     assert_eq!(rikiddo.fee().unwrap(), rikiddo.config.initial_fee);
-    let _ = rikiddo.update(&TimestampedVolume { timestamp: 3, volume: 100u32.into() });
+    let _ = rikiddo.update_volume(&TimestampedVolume { timestamp: 3, volume: 100u32.into() });
     assert_ne!(rikiddo.ma_short.get(), None);
     assert_ne!(rikiddo.ma_long.get(), None);
     // We don't want to test the exact result (that is the responsibility of the fee module),

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/fee.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/fee.rs
@@ -44,10 +44,7 @@ fn rikiddo_get_fee_ratio_does_not_fit_in_type() {
     let _ = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 0u32.into() });
     rikiddo.ma_short.ema = <FixedU128<U64>>::from_num(u64::MAX);
     rikiddo.ma_long.ema = <FixedU128<U64>>::from_num(1u64);
-    assert_err!(
-        rikiddo.fee(),
-        "Fixed point conversion failed: FROM type does not fit in TO type"
-    );
+    assert_err!(rikiddo.fee(), "Fixed point conversion failed: FROM type does not fit in TO type");
 }
 
 #[test]

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/market_volume.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/market_volume.rs
@@ -11,8 +11,8 @@ fn rikiddo_updates_mv_and_returns_some() {
     let emv = ema_create_test_struct(1, 2.0);
     let mut rikiddo =
         Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
-    rikiddo.update(&TimestampedVolume { timestamp: 0, volume: 1u32.into() }).unwrap();
-    let res = rikiddo.update(&TimestampedVolume { timestamp: 2, volume: 2u32.into() }).unwrap();
+    rikiddo.update_volume(&TimestampedVolume { timestamp: 0, volume: 1u32.into() }).unwrap();
+    let res = rikiddo.update_volume(&TimestampedVolume { timestamp: 2, volume: 2u32.into() }).unwrap();
     assert_eq!(res, Some(1u32.into()));
 }
 
@@ -20,14 +20,14 @@ fn rikiddo_updates_mv_and_returns_some() {
 fn rikiddo_updates_mv_and_returns_none() {
     let mut rikiddo = Rikiddo::default();
     let vol = TimestampedVolume::default();
-    assert_eq!(rikiddo.update(&vol).unwrap(), None);
+    assert_eq!(rikiddo.update_volume(&vol).unwrap(), None);
 }
 
 #[test]
 fn rikiddo_clear_clears_market_data() {
     let mut rikiddo = Rikiddo::default();
     let rikiddo_clone = rikiddo.clone();
-    let _ = rikiddo.update(&<TimestampedVolume<FixedU128<U64>>>::default());
+    let _ = rikiddo.update_volume(&<TimestampedVolume<FixedU128<U64>>>::default());
     assert_ne!(rikiddo, rikiddo_clone);
     rikiddo.clear();
     assert_eq!(rikiddo, rikiddo_clone);

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/market_volume.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/market_volume.rs
@@ -12,7 +12,8 @@ fn rikiddo_updates_mv_and_returns_some() {
     let mut rikiddo =
         Rikiddo::new(RikiddoConfig::default(), FeeSigmoid::default(), emv.clone(), emv);
     rikiddo.update_volume(&TimestampedVolume { timestamp: 0, volume: 1u32.into() }).unwrap();
-    let res = rikiddo.update_volume(&TimestampedVolume { timestamp: 2, volume: 2u32.into() }).unwrap();
+    let res =
+        rikiddo.update_volume(&TimestampedVolume { timestamp: 2, volume: 2u32.into() }).unwrap();
     assert_eq!(res, Some(1u32.into()));
 }
 

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/misc.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/misc.rs
@@ -23,37 +23,6 @@ fn rikiddo_default_does_not_panic() -> Result<(), &'static str> {
 }
 
 #[test]
-fn rikiddo_default_ln_sum_exp_strategy_exp_i_overflow() {
-    let rikiddo = Rikiddo::default();
-    let param = vec![<FixedI128<U64>>::from_num(100u64)];
-    assert_err!(
-        rikiddo.default_cost_strategy(&param),
-        "[RikiddoSigmoidMV] Error during calculation: exp(i) in ln sum_i(exp^i)"
-    );
-}
-
-#[test]
-fn rikiddo_default_ln_sum_exp_strategy_sum_exp_i_overflow() {
-    let rikiddo = Rikiddo::default();
-    let exponent = <FixedI128<U64>>::from_num(42.7f64);
-    let param = vec![exponent, exponent, exponent];
-    assert_err!(
-        rikiddo.default_cost_strategy(&param),
-        "[RikiddoSigmoidMV] Overflow during calculation: sum_i(e^i)"
-    );
-}
-
-#[test]
-fn rikiddo_default_ln_sum_exp_strategy_ln_zero() {
-    let rikiddo = Rikiddo::default();
-    let param = vec![];
-    assert_err!(
-        rikiddo.default_cost_strategy(&param),
-        "[RikiddoSigmoidMV] ln(exp_sum), exp_sum <= 0"
-    );
-}
-
-#[test]
 fn rikiddo_optimized_ln_sum_exp_strategy_exponent_subtract_overflow() {
     let rikiddo = Rikiddo::default();
     let param = vec![<FixedI128<U64>>::from_num(1i64 << 63)];
@@ -114,32 +83,19 @@ fn rikiddo_ln_sum_exp_strategies_return_correct_results() -> Result<(), &'static
         <FixedI128<U64>>::from_num(exponent1),
         <FixedI128<U64>>::from_num(exponent2),
     ];
-    // Evaluate the result of the default cost strategy
-    let mut result_fixed = rikiddo.default_cost_strategy(&param_fixed)?;
-    let result_f64: f64 = ln_exp_sum(&param_f64);
-    let mut result_fixed_f64: f64 = result_fixed.to_num();
-    let mut difference_abs = (result_f64 - result_fixed_f64).abs();
-    // The fixed calculation seems to be quite errorneous: Difference = 0.00000007886511177446209
-    assert!(
-        difference_abs <= 0.000001f64,
-        "\nFixed result: {}\nFloat result: {}\nDifference: {}\nMax_Allowed_Difference: {}",
-        result_fixed_f64,
-        result_f64,
-        difference_abs,
-        max_allowed_error(64)
-    );
-
-    // Evaluate the result of the optimize cost strategy
-    result_fixed = rikiddo.optimized_cost_strategy(
+    // Evaluate the result of the opimized cost strategy
+    let result_fixed = rikiddo.optimized_cost_strategy(
         &param_fixed,
         &param_fixed[2],
         &mut RikiddoFormulaComponents::default(),
         false,
     )?;
-    result_fixed_f64 = result_fixed.to_num();
-    difference_abs = (result_f64 - result_fixed_f64).abs();
+    let result_f64: f64 = ln_exp_sum(&param_f64);
+    let result_fixed_f64: f64 = result_fixed.to_num();
+    let difference_abs = (result_f64 - result_fixed_f64).abs();
+    // The fixed calculation seems to be quite errorneous: Difference = 0.00000007886511177446209
     assert!(
-        difference_abs <= 0.00000001f64,
+        difference_abs <= 0.000001f64,
         "\nFixed result: {}\nFloat result: {}\nDifference: {}\nMax_Allowed_Difference: {}",
         result_fixed_f64,
         result_f64,

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/price.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/price.rs
@@ -38,7 +38,7 @@ fn check_price_helper_result(helper: u8) -> Result<(), &'static str> {
     let param_u =
         vec![<FixedU128<U64>>::from_num(param_f64[0]), <FixedU128<U64>>::from_num(param_f64[1])];
     // This fills the formula_components with the correct values
-    let _ = rikiddo.cost_with_forumla(&param_u, formula_components, true, true, true);
+    let _ = rikiddo.cost_with_forumla(&param_u, formula_components, true, true);
     let rikiddo_price;
     let rikiddo_price_f64;
     let error_msg_function;

--- a/zrml/rikiddo/src/tests/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/tests/sigmoid_fee.rs
@@ -34,7 +34,7 @@ fn fee_sigmoid_overflow_r_minus_n() {
     let (mut fee, _, _, _) = init_default_sigmoid_fee_struct();
     let r = <FixedI128<U64>>::from_num(i64::MIN);
     fee.config.n = <FixedI128<U64>>::from_num(i64::MAX);
-    assert_err!(fee.calculate(r), "[FeeSigmoid] Overflow during calculation: r - n");
+    assert_err!(fee.calculate_fee(r), "[FeeSigmoid] Overflow during calculation: r - n");
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn fee_sigmoid_overflow_m_times_r_minus_n() {
     let r = <FixedI128<U64>>::from_num(i64::MIN);
     fee.config.n = <FixedI128<U64>>::from_num(0);
     fee.config.m = <FixedI128<U64>>::from_num(i64::MAX);
-    assert_err!(fee.calculate(r), "[FeeSigmoid] Overflow during calculation: m * (r-n)");
+    assert_err!(fee.calculate_fee(r), "[FeeSigmoid] Overflow during calculation: m * (r-n)");
 }
 
 #[test]
@@ -51,7 +51,7 @@ fn fee_sigmoid_overflow_r_minus_n_squared() {
     let (mut fee, _, _, _) = init_default_sigmoid_fee_struct();
     let r = <FixedI128<U64>>::from_num(i64::MIN);
     fee.config.n = <FixedI128<U64>>::from_num(0);
-    assert_err!(fee.calculate(r), "[FeeSigmoid] Overflow during calculation: (r-n)^2");
+    assert_err!(fee.calculate_fee(r), "[FeeSigmoid] Overflow during calculation: (r-n)^2");
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn fee_sigmoid_overflow_p_plus_r_minus_n_squared() {
     fee.config.n = <FixedI128<U64>>::from_num(1);
     fee.config.m = <FixedI128<U64>>::from_num(0);
     fee.config.p = <FixedI128<U64>>::from_num(i64::MAX);
-    assert_err!(fee.calculate(r), "[FeeSigmoid] Overflow during calculation: p + (r-n)^2");
+    assert_err!(fee.calculate_fee(r), "[FeeSigmoid] Overflow during calculation: p + (r-n)^2");
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn fee_sigmoid_overflow_numerator_div_denominator() {
     fee.config.m = <FixedI128<U64>>::from_num(i64::MAX);
     fee.config.p = <FixedI128<U64>>::from_num(-0.0099);
     assert_err!(
-        fee.calculate(r),
+        fee.calculate_fee(r),
         "[FeeSigmoid] Overflow during calculation: numerator / denominator"
     );
 }
@@ -83,7 +83,7 @@ fn fee_sigmoid_correct_result() -> Result<(), &'static str> {
     let (mut fee, m, n, p) = init_default_sigmoid_fee_struct();
     let fee_f64 = fee.config.initial_fee.to_num::<f64>() + sigmoid_fee(m, n, p, r);
     let r_fixed = <FixedI128<U64>>::from_num(r);
-    let fee_fixed = fee.calculate(r_fixed)?;
+    let fee_fixed = fee.calculate_fee(r_fixed)?;
     let fee_fixed_f64: f64 = fee_fixed.to_num();
     let difference_abs = (fee_f64 - fee_fixed_f64).abs();
 
@@ -97,6 +97,6 @@ fn fee_sigmoid_correct_result() -> Result<(), &'static str> {
     );
 
     fee.config.min_revenue = <FixedI128<U64>>::from_num(1u64 << 62);
-    assert_eq!(fee.calculate(r_fixed)?, fee.config.min_revenue);
+    assert_eq!(fee.calculate_fee(r_fixed)?, fee.config.min_revenue);
     Ok(())
 }

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -7,7 +7,7 @@ pub trait Sigmoid {
     type FS: Fixed;
 
     /// Calculate fee
-    fn calculate(&self, r: Self::FS) -> Result<Self::FS, &'static str>;
+    fn calculate_fee(&self, r: Self::FS) -> Result<Self::FS, &'static str>;
 }
 
 pub trait MarketAverage {
@@ -20,7 +20,7 @@ pub trait MarketAverage {
     fn clear(&mut self);
 
     /// Update market volume
-    fn update(
+    fn update_volume(
         &mut self,
         volume: &TimestampedVolume<Self::FU>,
     ) -> Result<Option<Self::FU>, &'static str>;
@@ -48,7 +48,7 @@ pub trait RikiddoMV: Lmsr {
     fn clear(&mut self);
 
     /// Update market data
-    fn update(
+    fn update_volume(
         &mut self,
         volume: &TimestampedVolume<Self::FU>,
     ) -> Result<Option<Self::FU>, &'static str>;
@@ -95,7 +95,7 @@ pub trait RikiddoSigmoidMVPallet {
     ) -> Result<Self::Balance, DispatchError>;
 
     /// Update market data
-    fn update(
+    fn update_volume(
         poolid: Self::PoolId,
         volume: Self::Balance,
     ) -> Result<Option<Self::Balance>, DispatchError>;

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -1,11 +1,6 @@
 use crate::types::{EmaConfig, FeeSigmoidConfig, TimestampedVolume};
-use core::fmt::Debug;
-use frame_support::{
-    pallet_prelude::{MaybeSerializeDeserialize, Member},
-    Parameter,
-};
-use parity_scale_codec::Codec;
-use sp_runtime::traits::AtLeast32BitUnsigned;
+use frame_support::dispatch::DispatchResult;
+use sp_runtime::DispatchError;
 use substrate_fixed::traits::{Fixed, FixedSigned, FixedUnsigned};
 
 pub trait Sigmoid {
@@ -66,13 +61,13 @@ pub trait RikiddoSigmoidMVPallet {
     type FU: FixedUnsigned;
 
     /// Clear market data for specific asset pool
-    fn clear(poolid: Self::PoolId);
+    fn clear(poolid: Self::PoolId) -> DispatchResult;
 
     /// Return cost C(q) for all assets in q
     fn cost(
         poolid: Self::PoolId,
         asset_balances: Vec<Self::Balance>,
-    ) -> Result<Self::Balance, &'static str>;
+    ) -> Result<Self::Balance, DispatchError>;
 
     /// Create Rikiddo instance for specifc asset pool
     fn create(
@@ -81,27 +76,27 @@ pub trait RikiddoSigmoidMVPallet {
         ema_config_short: EmaConfig<Self::FU>,
         ema_config_long: EmaConfig<Self::FU>,
         balance_one_unit: Self::Balance,
-    );
+    ) -> DispatchResult;
 
     /// Destroy Rikiddo instance
-    fn destroy(poolid: Self::PoolId);
+    fn destroy(poolid: Self::PoolId) -> DispatchResult;
 
     /// Return price P_i(q) for asset q_i in q
     fn price(
         poolid: Self::PoolId,
         asset_in_question: Self::Balance,
         asset_balances: Vec<Self::Balance>,
-    ) -> Result<Self::Balance, &'static str>;
+    ) -> Result<Self::Balance, DispatchError>;
 
     /// Return price P_i(q) for all assets in q
     fn all_prices(
         poolid: Self::PoolId,
         asset_balances: Vec<Self::Balance>,
-    ) -> Result<Vec<Self::Balance>, &'static str>;
+    ) -> Result<Vec<Self::Balance>, DispatchError>;
 
     /// Update market data
     fn update(
         poolid: Self::PoolId,
         volume: Self::Balance,
-    ) -> Result<Option<Self::Balance>, &'static str>;
+    ) -> Result<Option<Self::Balance>, DispatchError>;
 }

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -1,7 +1,7 @@
-use crate::types::{EmaConfig, FeeSigmoidConfig, RikiddoConfig, TimestampedVolume};
+use crate::types::TimestampedVolume;
 use frame_support::dispatch::DispatchResult;
 use sp_runtime::DispatchError;
-use substrate_fixed::traits::{Fixed, FixedSigned, FixedUnsigned};
+use substrate_fixed::traits::{Fixed, FixedUnsigned};
 
 pub trait Sigmoid {
     type FS: Fixed;
@@ -66,7 +66,7 @@ pub trait RikiddoSigmoidMVPallet {
     /// Return cost C(q) for all assets in q
     fn cost(
         poolid: Self::PoolId,
-        asset_balances: Vec<Self::Balance>,
+        asset_balances: &[Self::Balance],
     ) -> Result<Self::Balance, DispatchError>;
 
     /// Create Rikiddo instance for specifc asset pool
@@ -87,13 +87,13 @@ pub trait RikiddoSigmoidMVPallet {
     fn price(
         poolid: Self::PoolId,
         asset_in_question: Self::Balance,
-        asset_balances: Vec<Self::Balance>,
+        asset_balances: &[Self::Balance],
     ) -> Result<Self::Balance, DispatchError>;
 
     /// Return price P_i(q) for all assets in q
     fn all_prices(
         poolid: Self::PoolId,
-        asset_balances: Vec<Self::Balance>,
+        asset_balances: &[Self::Balance],
     ) -> Result<Vec<Self::Balance>, DispatchError>;
 
     /// Update market data

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -52,6 +52,9 @@ pub trait RikiddoMV: Lmsr {
         &mut self,
         volume: &TimestampedVolume<Self::FU>,
     ) -> Result<Option<Self::FU>, &'static str>;
+
+    /// Fetch current fee
+    fn fee(&self) -> Result<Self::FU, &'static str>;
 }
 
 pub trait RikiddoSigmoidMVPallet {
@@ -59,6 +62,18 @@ pub trait RikiddoSigmoidMVPallet {
     type PoolId: Copy;
     type FU: FixedUnsigned;
     type Rikiddo: RikiddoMV;
+
+    /// Return price P_i(q) for all assets in q
+    fn all_prices(
+        poolid: Self::PoolId,
+        asset_balances: &[Self::Balance],
+    ) -> Result<Vec<Self::Balance>, DispatchError>;
+
+    /// Create Rikiddo instance for specifc asset pool
+    fn create(
+        poolid: Self::PoolId,
+        rikiddo: Self::Rikiddo,
+    ) -> DispatchResult;
 
     /// Clear market data for specific asset pool
     fn clear(poolid: Self::PoolId) -> DispatchResult;
@@ -69,19 +84,13 @@ pub trait RikiddoSigmoidMVPallet {
         asset_balances: &[Self::Balance],
     ) -> Result<Self::Balance, DispatchError>;
 
-    /// Create Rikiddo instance for specifc asset pool
-    fn create(
-        poolid: Self::PoolId,
-        /*rikiddo_config: RikiddoConfig<Self::FS>,
-        fee_config: FeeSigmoidConfig<Self::FS>,
-        ema_config_short: EmaConfig<Self::FU>,
-        ema_config_long: EmaConfig<Self::FU>,
-        */
-        rikiddo: Self::Rikiddo,
-    ) -> DispatchResult;
-
     /// Destroy Rikiddo instance
     fn destroy(poolid: Self::PoolId) -> DispatchResult;
+
+    /// Fetch the current fee
+    fn fee(
+        poolid: Self::PoolId
+    ) -> Result<Self::Balance, DispatchError>;
 
     /// Return price P_i(q) for asset q_i in q
     fn price(
@@ -89,12 +98,6 @@ pub trait RikiddoSigmoidMVPallet {
         asset_in_question: Self::Balance,
         asset_balances: &[Self::Balance],
     ) -> Result<Self::Balance, DispatchError>;
-
-    /// Return price P_i(q) for all assets in q
-    fn all_prices(
-        poolid: Self::PoolId,
-        asset_balances: &[Self::Balance],
-    ) -> Result<Vec<Self::Balance>, DispatchError>;
 
     /// Update market data
     fn update(

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -35,6 +35,9 @@ pub trait Lmsr {
     /// Return cost C(q) for all assets in q
     fn cost(&self, asset_balances: &[Self::FU]) -> Result<Self::FU, &'static str>;
 
+    /// Fetch the current fee
+    fn fee(&self) -> Result<Self::FU, &'static str>;
+
     /// Return price P_i(q) for asset q_i in q
     fn price(
         &self,
@@ -52,9 +55,6 @@ pub trait RikiddoMV: Lmsr {
         &mut self,
         volume: &TimestampedVolume<Self::FU>,
     ) -> Result<Option<Self::FU>, &'static str>;
-
-    /// Fetch the current fee
-    fn fee(&self) -> Result<Self::FU, &'static str>;
 }
 
 pub trait RikiddoSigmoidMVPallet {
@@ -69,11 +69,11 @@ pub trait RikiddoSigmoidMVPallet {
         asset_balances: &[Self::Balance],
     ) -> Result<Vec<Self::Balance>, DispatchError>;
 
-    /// Create Rikiddo instance for specifc asset pool
-    fn create(poolid: Self::PoolId, rikiddo: Self::Rikiddo) -> DispatchResult;
-
     /// Clear market data for specific asset pool
     fn clear(poolid: Self::PoolId) -> DispatchResult;
+
+    /// Create Rikiddo instance for specifc asset pool
+    fn create(poolid: Self::PoolId, rikiddo: Self::Rikiddo) -> DispatchResult;
 
     /// Return cost C(q) for all assets in q
     fn cost(

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::types::{EmaConfig, FeeSigmoidConfig, TimestampedVolume};
+use crate::types::{EmaConfig, FeeSigmoidConfig, RikiddoConfig, TimestampedVolume};
 use frame_support::dispatch::DispatchResult;
 use sp_runtime::DispatchError;
 use substrate_fixed::traits::{Fixed, FixedSigned, FixedUnsigned};
@@ -56,9 +56,9 @@ pub trait RikiddoMV: Lmsr {
 
 pub trait RikiddoSigmoidMVPallet {
     type Balance;
-    type PoolId;
-    type FS: FixedSigned;
+    type PoolId: Copy;
     type FU: FixedUnsigned;
+    type Rikiddo: RikiddoMV;
 
     /// Clear market data for specific asset pool
     fn clear(poolid: Self::PoolId) -> DispatchResult;
@@ -72,10 +72,12 @@ pub trait RikiddoSigmoidMVPallet {
     /// Create Rikiddo instance for specifc asset pool
     fn create(
         poolid: Self::PoolId,
+        /*rikiddo_config: RikiddoConfig<Self::FS>,
         fee_config: FeeSigmoidConfig<Self::FS>,
         ema_config_short: EmaConfig<Self::FU>,
         ema_config_long: EmaConfig<Self::FU>,
-        balance_one_unit: Self::Balance,
+        */
+        rikiddo: Self::Rikiddo
     ) -> DispatchResult;
 
     /// Destroy Rikiddo instance

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -53,7 +53,7 @@ pub trait RikiddoMV: Lmsr {
         volume: &TimestampedVolume<Self::FU>,
     ) -> Result<Option<Self::FU>, &'static str>;
 
-    /// Fetch current fee
+    /// Fetch the current fee
     fn fee(&self) -> Result<Self::FU, &'static str>;
 }
 
@@ -70,10 +70,7 @@ pub trait RikiddoSigmoidMVPallet {
     ) -> Result<Vec<Self::Balance>, DispatchError>;
 
     /// Create Rikiddo instance for specifc asset pool
-    fn create(
-        poolid: Self::PoolId,
-        rikiddo: Self::Rikiddo,
-    ) -> DispatchResult;
+    fn create(poolid: Self::PoolId, rikiddo: Self::Rikiddo) -> DispatchResult;
 
     /// Clear market data for specific asset pool
     fn clear(poolid: Self::PoolId) -> DispatchResult;
@@ -88,9 +85,7 @@ pub trait RikiddoSigmoidMVPallet {
     fn destroy(poolid: Self::PoolId) -> DispatchResult;
 
     /// Fetch the current fee
-    fn fee(
-        poolid: Self::PoolId
-    ) -> Result<Self::Balance, DispatchError>;
+    fn fee(poolid: Self::PoolId) -> Result<Self::Balance, DispatchError>;
 
     /// Return price P_i(q) for asset q_i in q
     fn price(

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -60,30 +60,23 @@ pub trait RikiddoMV: Lmsr {
 }
 
 pub trait RikiddoSigmoidMVPallet {
-    type Balance: Parameter
-        + Member
-        + AtLeast32BitUnsigned
-        + Codec
-        + Default
-        + Copy
-        + MaybeSerializeDeserialize
-        + Debug;
-
+    type Balance;
+    type PoolId;
     type FS: FixedSigned;
     type FU: FixedUnsigned;
 
     /// Clear market data for specific asset pool
-    fn clear(poolid: u128);
+    fn clear(poolid: Self::PoolId);
 
     /// Return cost C(q) for all assets in q
     fn cost(
-        poolid: u128,
+        poolid: Self::PoolId,
         asset_balances: Vec<Self::Balance>,
     ) -> Result<Self::Balance, &'static str>;
 
     /// Create Rikiddo instance for specifc asset pool
     fn create(
-        poolid: u128,
+        poolid: Self::PoolId,
         fee_config: FeeSigmoidConfig<Self::FS>,
         ema_config_short: EmaConfig<Self::FU>,
         ema_config_long: EmaConfig<Self::FU>,
@@ -91,21 +84,24 @@ pub trait RikiddoSigmoidMVPallet {
     );
 
     /// Destroy Rikiddo instance
-    fn destroy(poolid: u128);
+    fn destroy(poolid: Self::PoolId);
 
     /// Return price P_i(q) for asset q_i in q
     fn price(
-        poolid: u128,
+        poolid: Self::PoolId,
         asset_in_question: Self::Balance,
         asset_balances: Vec<Self::Balance>,
     ) -> Result<Self::Balance, &'static str>;
 
     /// Return price P_i(q) for all assets in q
     fn all_prices(
-        poolid: u128,
+        poolid: Self::PoolId,
         asset_balances: Vec<Self::Balance>,
     ) -> Result<Vec<Self::Balance>, &'static str>;
 
     /// Update market data
-    fn update(poolid: u128, volume: Self::Balance) -> Result<Option<Self::Balance>, &'static str>;
+    fn update(
+        poolid: Self::PoolId,
+        volume: Self::Balance,
+    ) -> Result<Option<Self::Balance>, &'static str>;
 }

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -77,7 +77,7 @@ pub trait RikiddoSigmoidMVPallet {
         ema_config_short: EmaConfig<Self::FU>,
         ema_config_long: EmaConfig<Self::FU>,
         */
-        rikiddo: Self::Rikiddo
+        rikiddo: Self::Rikiddo,
     ) -> DispatchResult;
 
     /// Destroy Rikiddo instance

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -1,6 +1,6 @@
 use frame_support::dispatch::{Decode, Encode};
 use sp_core::RuntimeDebug;
-use sp_std::convert::TryFrom;
+use core::convert::TryFrom;
 use substrate_fixed::{
     traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
     types::extra::{U127, U128},

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -114,7 +114,9 @@ impl<F: Fixed, N: Into<u128>> FromFixedDecimal<N> for F {
         let mut decimal_string = decimal_u128.to_string();
         // Can panic (check index)
         if decimal_string.len() <= places as usize {
-            decimal_string = "0.".to_owned() + &decimal_string;
+            decimal_string = "0.".to_owned()
+                + &"0".repeat(places as usize - decimal_string.len())
+                + &decimal_string;
         } else {
             decimal_string.insert(decimal_string.len() - places as usize, '.');
         }
@@ -123,7 +125,7 @@ impl<F: Fixed, N: Into<u128>> FromFixedDecimal<N> for F {
     }
 }
 
-/// Converts a fixed point decimal number into Fixed type
+/// Converts a fixed point decimal number into Fixed type (Balance -> Fixed)
 pub trait IntoFixedAsDecimal<F: Fixed> {
     fn to_fixed_as_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError>;
 }
@@ -139,7 +141,7 @@ where
     }
 }
 
-// Converts a type into fixed point decimal number
+// Converts a Fixed type into fixed point decimal number
 pub trait FromFixedToDecimal<F>
 where
     Self: Sized + TryFrom<u128>,
@@ -147,7 +149,7 @@ where
     fn from_fixed_as_fixed_decimal(fixed: F) -> Result<Self, &'static str>;
 }
 
-// Converts a Fixed type into a fixed point decimal number
+// Converts a Fixed type into a fixed point decimal number (Fixed -> Balance)
 impl<F: Fixed, N: TryFrom<u128>> FromFixedToDecimal<F> for N {
     fn from_fixed_as_fixed_decimal(fixed: F) -> Result<N, &'static str> {
         let mut fixed_str = fixed.to_string();

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -1,4 +1,5 @@
-use frame_support::dispatch::{fmt::Debug, Decode, Encode};
+use frame_support::dispatch::{Decode, Encode};
+use sp_core::RuntimeDebug;
 use sp_std::convert::TryFrom;
 use substrate_fixed::{
     traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
@@ -16,13 +17,13 @@ pub use sigmoid_fee::*;
 
 pub type UnixTimestamp = u64;
 
-#[derive(Clone, Debug, Decode, Default, Encode, Eq, PartialEq)]
+#[derive(Clone, RuntimeDebug, Decode, Default, Encode, Eq, PartialEq)]
 pub struct TimestampedVolume<F: Fixed> {
     pub timestamp: UnixTimestamp,
     pub volume: F,
 }
 
-#[derive(Copy, Clone, Debug, Decode, Encode, Eq, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, RuntimeDebug, Decode, Encode, Eq, PartialEq, PartialOrd)]
 pub enum Timespan {
     Seconds(u32),
     Minutes(u32),
@@ -127,7 +128,7 @@ impl<F: Fixed, N: Into<u128>> FromFixedDecimal<N> for F {
 
 /// Converts a fixed point decimal number into Fixed type (Balance -> Fixed)
 pub trait IntoFixedAsDecimal<F: Fixed> {
-    fn to_fixed_as_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError>;
+    fn to_fixed_from_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError>;
 }
 
 /// Converts a fixed point decimal number into Fixed type
@@ -136,22 +137,22 @@ where
     F: Fixed + FromFixedDecimal<Self>,
     N: Into<u128>,
 {
-    fn to_fixed_as_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError> {
+    fn to_fixed_from_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError> {
         F::from_fixed_decimal(self, places)
     }
 }
 
-// Converts a Fixed type into fixed point decimal number
+/// Converts a Fixed type into fixed point decimal number
 pub trait FromFixedToDecimal<F>
 where
     Self: Sized + TryFrom<u128>,
 {
-    fn from_fixed_as_fixed_decimal(fixed: F, places: u8) -> Result<Self, &'static str>;
+    fn from_fixed_to_fixed_decimal(fixed: F, places: u8) -> Result<Self, &'static str>;
 }
 
-// Converts a Fixed type into a fixed point decimal number (Fixed -> Balance)
+/// Converts a Fixed type into a fixed point decimal number (Fixed -> Balance)
 impl<F: Fixed, N: TryFrom<u128>> FromFixedToDecimal<F> for N {
-    fn from_fixed_as_fixed_decimal(fixed: F, places: u8) -> Result<N, &'static str> {
+    fn from_fixed_to_fixed_decimal(fixed: F, places: u8) -> Result<N, &'static str> {
         if places == 0 {
             let mut result = fixed.to_num::<u128>();
 
@@ -236,6 +237,6 @@ where
     N: TryFrom<u128> + FromFixedToDecimal<Self>,
 {
     fn to_fixed_decimal(self, places: u8) -> Result<N, &'static str> {
-        N::from_fixed_as_fixed_decimal(self, places)
+        N::from_fixed_to_fixed_decimal(self, places)
     }
 }

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -98,7 +98,6 @@ pub trait FromFixedDecimal<F: Fixed, N: Into<u128>> {
     fn from_fixed_decimal(decimal: N, places: u8) -> Result<F, ParseFixedError>;
 }
 
-
 impl<F: Fixed, N: Into<u128>> FromFixedDecimal<F, N> for F {
     fn from_fixed_decimal(decimal: N, places: u8) -> Result<F, ParseFixedError> {
         let decimal_u128 = decimal.into();
@@ -111,5 +110,19 @@ impl<F: Fixed, N: Into<u128>> FromFixedDecimal<F, N> for F {
 		}
 		
 		F::from_str(&decimal_string)
+    }
+}
+
+pub trait IntoFixedAsDecimal<F: Fixed> {
+    fn to_fixed_as_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError>;
+}
+
+impl<F, U> IntoFixedAsDecimal<F> for U
+where
+    F: Fixed + FromFixedDecimal<F, U>,
+    U: Into<u128>,
+{
+    fn to_fixed_as_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError> {
+        F::from_fixed_decimal(self, places)
     }
 }

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -2,8 +2,8 @@ use frame_support::dispatch::{fmt::Debug, Decode, Encode};
 use sp_std::convert::TryFrom;
 use substrate_fixed::{
     traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
-    types::extra::{U127, U128, U8},
-    FixedI128, FixedU128, FixedU8, ParseFixedError,
+    types::extra::{U127, U128},
+    FixedI128, FixedU128, ParseFixedError,
 };
 
 mod ema_market_volume;

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -127,12 +127,12 @@ impl<F: Fixed, N: Into<u128>> FromFixedDecimal<N> for F {
 }
 
 /// Converts a fixed point decimal number into Fixed type (Balance -> Fixed)
-pub trait IntoFixedAsDecimal<F: Fixed> {
+pub trait IntoFixedFromDecimal<F: Fixed> {
     fn to_fixed_from_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError>;
 }
 
 /// Converts a fixed point decimal number into Fixed type
-impl<F, N> IntoFixedAsDecimal<F> for N
+impl<F, N> IntoFixedFromDecimal<F> for N
 where
     F: Fixed + FromFixedDecimal<Self>,
     N: Into<u128>,
@@ -234,7 +234,7 @@ pub trait IntoFixedDecimal<N: TryFrom<u128>> {
 impl<F, N> IntoFixedDecimal<N> for F
 where
     F: Fixed,
-    N: TryFrom<u128> + FromFixedToDecimal<Self>,
+    N: FromFixedToDecimal<Self>,
 {
     fn to_fixed_decimal(self, places: u8) -> Result<N, &'static str> {
         N::from_fixed_to_fixed_decimal(self, places)

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -1,9 +1,5 @@
 use frame_support::dispatch::{fmt::Debug, Decode, Encode};
-use substrate_fixed::{
-    traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
-    types::extra::{U127, U128},
-    FixedI128, FixedU128,
-};
+use substrate_fixed::{FixedI128, FixedU128, ParseFixedError, traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed}, types::extra::{U127, U128}};
 
 mod ema_market_volume;
 mod rikiddo_sigmoid_mv;
@@ -98,47 +94,22 @@ pub fn convert_to_unsigned<FROM: FixedSigned, TO: FixedUnsigned + LossyFrom<Fixe
     }
 }
 
-pub trait DecimalConversion<F> {
-	fn from_decimal(decimal: u128, places: u8) -> F;
-	fn to_decimal(other: F, places: u8) -> u128;
+pub trait FromFixedDecimal<F: Fixed, N: Into<u128>> {
+    fn from_fixed_decimal(decimal: N, places: u8) -> Result<F, ParseFixedError>;
 }
 
-impl<F: Fixed> DecimalConversion<F> for F {
-	// can panic
-    fn from_decimal(decimal: u128, places: u8) -> F {
-		let decimal_string = decimal.to_string();
-		// Can panic (check index)
-		let parsed_integer = &decimal_string[..decimal_string.len() - places as usize];
-		let parsed_fraction = &decimal_string[decimal_string.len() - places as usize..];
-		// Panic impossible, it must contain a base 10 string, since it is the repr. of one
-		let integer = u128::from_str_radix(parsed_integer, 10).unwrap();
-		let fraction = u128::from_str_radix(parsed_fraction, 10).unwrap();
-	    
-		let base = 10u128.pow(places as u32);
-		// Can panic (needs checked variant)
-		let converted = F::from_num(integer);
-		let mut bits = String::from("0.");
-		let mut cmp_num = 0u128;
-		
-		for shift in 0..F::frac_nbits() {
-		    let shiftval = 2 << shift;
-		    //let addnum = base / (2 << shift);
-		    let addnum = base / shiftval + u128::from(base % shiftval == 0);
-		    cmp_num += addnum;
-		    
-		    if cmp_num > fraction {
-		        cmp_num -= addnum;
-		        bits.push('0');
-		    } else {
-		        bits.push('1');
-		    }
-        }
-		
-		// Can panic
-		converted + F::from_str_binary(&bits).unwrap()
-	}
 
-	fn to_decimal(other: F, places: u8) -> u128 {
-		42
-	}
+impl<F: Fixed, N: Into<u128>> FromFixedDecimal<F, N> for F {
+    fn from_fixed_decimal(decimal: N, places: u8) -> Result<F, ParseFixedError> {
+        let decimal_u128 = decimal.into();
+		let mut decimal_string = decimal_u128.to_string();
+		// Can panic (check index)
+		if decimal_string.len() <= places as usize {
+		    decimal_string = "0.".to_owned() + &decimal_string;
+		} else {
+    		decimal_string.insert(decimal_string.len() - places as usize, '.');
+		}
+		
+		F::from_str(&decimal_string)
+    }
 }

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -140,9 +140,9 @@ where
 }
 
 // Converts a type into fixed point decimal number
-pub trait FromFixedToDecimal<F> 
-    where 
-    Self: Sized + TryFrom<u128>
+pub trait FromFixedToDecimal<F>
+where
+    Self: Sized + TryFrom<u128>,
 {
     fn from_fixed_as_fixed_decimal(fixed: F) -> Result<Self, &'static str>;
 }
@@ -152,14 +152,14 @@ impl<F: Fixed, N: TryFrom<u128>> FromFixedToDecimal<F> for N {
     fn from_fixed_as_fixed_decimal(fixed: F) -> Result<N, &'static str> {
         let mut fixed_str = fixed.to_string();
         fixed_str.retain(|c| c != '.');
-        
+
         let result = if let Ok(res) = u128::from_str_radix(&fixed_str, 10) {
             res
         } else {
             // Impossible unless there is a bug in Fixed's to_string()
             return Err("Error parsing the string representation of the fixed point number");
         };
-        
+
         if let Ok(res) = N::try_from(result) {
             Ok(res)
         } else {

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -207,7 +207,9 @@ impl<F: Fixed, N: TryFrom<u128>> FromFixedToDecimal<F> for N {
                     // Impossible unless there is a bug in Fixed's to_string()
                     return Err("Error parsing the string representation of the fixed point number");
                 };
-            } // The other case requires no changes
+            } else {
+                fixed_str.retain(|c| c != '.');
+            }
         }
 
         let result = if let Ok(res) = u128::from_str_radix(&fixed_str, 10) {

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -192,7 +192,7 @@ impl<FU: FixedUnsigned + From<u32>> MarketAverage for EmaMarketVolume<FU> {
     }
 
     /// Update market volume
-    fn update(
+    fn update_volume(
         &mut self,
         volume: &TimestampedVolume<Self::FU>,
     ) -> Result<Option<Self::FU>, &'static str> {

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -3,8 +3,8 @@ use crate::{
     constants::{EMA_SHORT, SMOOTHING},
     traits::MarketAverage,
 };
-use sp_core::RuntimeDebug;
 use frame_support::dispatch::{Decode, Encode};
+use sp_core::RuntimeDebug;
 use substrate_fixed::{
     traits::{Fixed, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
     types::extra::{U24, U64},

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -3,14 +3,15 @@ use crate::{
     constants::{EMA_SHORT, SMOOTHING},
     traits::MarketAverage,
 };
-use frame_support::dispatch::{fmt::Debug, Decode, Encode};
+use sp_core::RuntimeDebug;
+use frame_support::dispatch::{Decode, Encode};
 use substrate_fixed::{
     traits::{Fixed, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
     types::extra::{U24, U64},
     FixedU128, FixedU32,
 };
 
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+#[derive(Clone, RuntimeDebug, Decode, Encode, Eq, PartialEq)]
 pub struct EmaConfig<FI: Fixed> {
     pub ema_period: Timespan,
     pub ema_period_estimate_after: Option<Timespan>,
@@ -37,14 +38,14 @@ impl<FU: FixedUnsigned + LossyFrom<FixedU32<U24>>> Default for EmaConfig<FU> {
     }
 }
 
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+#[derive(Clone, RuntimeDebug, Decode, Encode, Eq, PartialEq)]
 pub enum MarketVolumeState {
     Uninitialized,
     DataCollectionStarted,
     DataCollected,
 }
 
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+#[derive(Clone, RuntimeDebug, Decode, Encode, Eq, PartialEq)]
 pub struct EmaMarketVolume<FU: FixedUnsigned> {
     pub config: EmaConfig<FU>,
     pub ema: FU,

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -5,7 +5,7 @@ use crate::{
 use frame_support::dispatch::{Decode, Encode};
 use hashbrown::HashMap;
 use sp_core::RuntimeDebug;
-use sp_std::ops::{AddAssign, BitOrAssign, ShlAssign};
+use core::ops::{AddAssign, BitOrAssign, ShlAssign};
 use substrate_fixed::{
     consts::LOG2_E,
     traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -2,10 +2,10 @@ use crate::{
     constants::INITIAL_FEE,
     traits::{Lmsr, MarketAverage, RikiddoMV, Sigmoid},
 };
+use core::ops::{AddAssign, BitOrAssign, ShlAssign};
 use frame_support::dispatch::{Decode, Encode};
 use hashbrown::HashMap;
 use sp_core::RuntimeDebug;
-use core::ops::{AddAssign, BitOrAssign, ShlAssign};
 use substrate_fixed::{
     consts::LOG2_E,
     traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -2,8 +2,9 @@ use crate::{
     constants::INITIAL_FEE,
     traits::{Lmsr, MarketAverage, RikiddoMV, Sigmoid},
 };
-use core::ops::{AddAssign, BitOrAssign, ShlAssign};
-use frame_support::dispatch::{fmt::Debug, Decode, Encode};
+use sp_core::RuntimeDebug;
+use sp_std::ops::{AddAssign, BitOrAssign, ShlAssign};
+use frame_support::dispatch::{Decode, Encode};
 use hashbrown::HashMap;
 use substrate_fixed::{
     consts::LOG2_E,
@@ -18,7 +19,7 @@ use substrate_fixed::{
 
 use super::{convert_to_signed, convert_to_unsigned, TimestampedVolume};
 
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+#[derive(Clone, RuntimeDebug, Decode, Encode, Eq, PartialEq)]
 pub struct RikiddoConfig<FI: Fixed> {
     pub initial_fee: FI,
     pub(crate) log2_e: FI,
@@ -73,7 +74,7 @@ where
     }
 }
 
-#[derive(Clone, Debug, Decode, Default, Encode, Eq, PartialEq)]
+#[derive(Clone, RuntimeDebug, Decode, Default, Encode, Eq, PartialEq)]
 pub struct RikiddoSigmoidMV<FU, FS, FE, MA>
 where
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>>,

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -2,10 +2,10 @@ use crate::{
     constants::INITIAL_FEE,
     traits::{Lmsr, MarketAverage, RikiddoMV, Sigmoid},
 };
-use sp_core::RuntimeDebug;
-use sp_std::ops::{AddAssign, BitOrAssign, ShlAssign};
 use frame_support::dispatch::{Decode, Encode};
 use hashbrown::HashMap;
+use sp_core::RuntimeDebug;
+use sp_std::ops::{AddAssign, BitOrAssign, ShlAssign};
 use substrate_fixed::{
     consts::LOG2_E,
     traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -572,17 +572,17 @@ where
         };
 
         let ratio_signed = convert_to_signed(ratio)?;
-        convert_to_unsigned::<FS, FU>(self.fees.calculate(ratio_signed)?)
+        convert_to_unsigned::<FS, FU>(self.fees.calculate_fee(ratio_signed)?)
     }
 
     /// Update market data
     /// Returns volume ratio short / long or None
-    fn update(
+    fn update_volume(
         &mut self,
         volume: &TimestampedVolume<Self::FU>,
     ) -> Result<Option<Self::FU>, &'static str> {
-        let mas = self.ma_short.update(volume)?;
-        let mal = self.ma_long.update(volume)?;
+        let mas = self.ma_short.update_volume(volume)?;
+        let mal = self.ma_long.update_volume(volume)?;
 
         if let Some(mas) = mas {
             if let Some(mal) = mal {

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -2,7 +2,8 @@ use crate::{
     constants::{INITIAL_FEE, M, MINIMAL_REVENUE, N, P},
     traits::Sigmoid,
 };
-use frame_support::dispatch::{fmt::Debug, Decode, Encode};
+use sp_core::RuntimeDebug;
+use frame_support::dispatch::{Decode, Encode};
 use substrate_fixed::{
     traits::{FixedSigned, LossyFrom, LossyInto},
     transcendental::sqrt,
@@ -15,7 +16,7 @@ use substrate_fixed::{
 
 use super::convert_to_signed;
 
-#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq)]
+#[derive(Clone, RuntimeDebug, Decode, Encode, Eq, PartialEq)]
 pub struct FeeSigmoidConfig<FS: FixedSigned> {
     pub m: FS,
     pub p: FS,
@@ -42,7 +43,7 @@ where
     }
 }
 
-#[derive(Clone, Debug, Decode, Default, Encode, Eq, PartialEq)]
+#[derive(Clone, RuntimeDebug, Decode, Default, Encode, Eq, PartialEq)]
 pub struct FeeSigmoid<FS>
 where
     FS: FixedSigned + LossyFrom<FixedI32<U24>> + LossyFrom<FixedI128<U127>>,

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -67,7 +67,7 @@ where
     type FS = FS;
 
     // z(r) in https://files.kyber.network/DMM-Feb21.pdf
-    fn calculate(&self, r: Self::FS) -> Result<Self::FS, &'static str> {
+    fn calculate_fee(&self, r: Self::FS) -> Result<Self::FS, &'static str> {
         let r_minus_n = if let Some(res) = r.checked_sub(self.config.n) {
             res
         } else {

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -2,8 +2,8 @@ use crate::{
     constants::{INITIAL_FEE, M, MINIMAL_REVENUE, N, P},
     traits::Sigmoid,
 };
-use sp_core::RuntimeDebug;
 use frame_support::dispatch::{Decode, Encode};
+use sp_core::RuntimeDebug;
 use substrate_fixed::{
     traits::{FixedSigned, LossyFrom, LossyInto},
     transcendental::sqrt,


### PR DESCRIPTION
The Rikiddo pallet is solely a book keeper of `Rikiddo` instances per pool and a translator between the `Balance` type used within the pallets and the `Fixed` type. It exposes all the functions the Rikiddo core also offers in addition to a instantiation function `create`.
The basic procedure for most of the the pallet functions looks like this: Try to find the `Rikiddo` instance associated with the `poolid` that was passed, translate any `Balance` type to the configured `Fixed` type, execute the requested Rikiddo core function and convert the result back from the configured `Fixed` type to the `Balance` type. The pallet does not offer any dispatchable functions - it is ought to be used within another pallet to update the market data, fetch the fee and calculate the prices. In our case the swaps pallet will use the Rikiddo pallet for the previously mentioned functions.
The pallet followed the generic and modular approach of the Rikiddo core: Within it's `Config`, the maintainers can specify which variant of Rikiddo exactly should be used: How should the fee be calculated? How should the market volume be processed? Which exact implemention of Rikiddo should be used? All those properties can be configured within the pallet's `Config` trait. The pallet is instantiable, which enables a simultaneous usage of numerous Rikiddo implementations. Some example use-cases for this could be:

1. Introducing an improved Rikiddo variant and still being able to maintain old markets with the previous Rikiddo variant, while using the new Rikiddo variant for markets that are created after the new Rikiddo variant was introduced. Once all old markets that use the deprecated Rikiddo variant are closed, the old Rikiddo variant can be removed in an upcoming runtime upgrade.
2. Simultaneous usage of multiple Rikiddo variants, for example to gather data of multiple variants and compare this data for insights and improvements or to use different variants for different use-cases.

closes #216