### PR TITLE
Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12024,6 +12024,7 @@ dependencies = [
  "frame-system",
  "pallet-balances",
  "pallet-randomness-collective-flip",
+ "pallet-timestamp",
  "parity-scale-codec",
  "rand 0.8.4",
  "sp-io",
@@ -12040,11 +12041,13 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-timestamp",
  "parity-scale-codec",
  "serde",
  "sp-io",
  "sp-runtime",
  "zeitgeist-primitives",
+ "zrml-market-commons",
 ]
 
 [[package]]
@@ -12174,12 +12177,14 @@ dependencies = [
  "orml-tokens",
  "orml-traits",
  "pallet-balances",
+ "pallet-timestamp",
  "parity-scale-codec",
  "sp-api",
  "sp-io",
  "sp-runtime",
  "zeitgeist-primitives",
  "zrml-liquidity-mining",
+ "zrml-market-commons",
  "zrml-swaps",
  "zrml-swaps-runtime-api",
 ]

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -29,7 +29,7 @@ use {
 const DEFAULT_COLLATOR_INFLATION_INFO: parachain_staking::InflationInfo<Balance> = {
     let hours_per_year = 8766;
     let millisecs_per_year = hours_per_year * 60 * 60 * 1000;
-    let round_millisecs = DefaultBlocksPerRound::get() as u64 * MILLISECS_PER_BLOCK;
+    let round_millisecs = DefaultBlocksPerRound::get() as u64 * MILLISECS_PER_BLOCK as u64;
     let rounds_per_year = millisecs_per_year / round_millisecs;
 
     let annual_inflation = ztg::STAKING_PTD;

--- a/node/src/cli/cli_parachain.rs
+++ b/node/src/cli/cli_parachain.rs
@@ -235,7 +235,7 @@ pub struct RunCmd {
     pub parachain_id: u32,
 }
 
-impl std::ops::Deref for RunCmd {
+impl core::ops::Deref for RunCmd {
     type Target = sc_cli::RunCmd;
 
     #[inline]

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -6,7 +6,7 @@ use sp_runtime::Permill;
 
 // Definitions for time
 pub const BLOCKS_PER_DAY: BlockNumber = BLOCKS_PER_HOUR * 24;
-pub const MILLISECS_PER_BLOCK: u64 = 6000;
+pub const MILLISECS_PER_BLOCK: u32 = 12000;
 pub const BLOCKS_PER_MINUTE: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 pub const BLOCKS_PER_HOUR: BlockNumber = BLOCKS_PER_MINUTE * 60;
 
@@ -50,7 +50,7 @@ parameter_types! {
     pub const MinCategories: u16 = 2;
     pub const OracleBond: Balance = 50 * CENT;
     pub const PmPalletId: PalletId = PalletId(*b"zge/pred");
-    pub const ReportingPeriod: BlockNumber = BLOCKS_PER_DAY;
+    pub const ReportingPeriod: u32 = BLOCKS_PER_DAY as _;
     pub const ValidityBond: Balance = 50 * CENT;
 }
 
@@ -75,6 +75,11 @@ parameter_types! {
     pub const MinLiquidity: Balance = 100 * BASE;
     pub const MinWeight: Balance = BASE;
     pub const SwapsPalletId: PalletId = PalletId(*b"zge/swap");
+}
+
+// Time
+parameter_types! {
+    pub const MinimumPeriod: u64 = MILLISECS_PER_BLOCK as u64 / 2;
 }
 
 // Treasury

--- a/primitives/src/traits/dispute_api.rs
+++ b/primitives/src/traits/dispute_api.rs
@@ -8,6 +8,7 @@ pub trait DisputeApi {
     type Balance;
     type BlockNumber;
     type MarketId;
+    type Moment;
     type Origin;
 
     /// Disputes a reported outcome.
@@ -21,7 +22,7 @@ pub trait DisputeApi {
         dispute_bound: &D,
         disputes: &[MarketDispute<Self::AccountId, Self::BlockNumber>],
         market_id: &Self::MarketId,
-        market: &Market<Self::AccountId, Self::BlockNumber>,
+        market: &Market<Self::AccountId, Self::BlockNumber, Self::Moment>,
     ) -> Result<OutcomeReport, DispatchError>
     where
         D: Fn(usize) -> Self::Balance;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -65,7 +65,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND / 2;
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
 
 pub type AdaptedBasicCurrency =
     orml_currencies::BasicCurrencyAdapter<Runtime, Balances, Amount, Balance>;
@@ -104,7 +103,6 @@ parameter_types! {
   pub const MaxNominatorsPerCollator: u32 = 32;
   pub const MinBlocksPerRound: u32 = (BLOCKS_PER_DAY / 6) as _;
   pub const MinCollatorStake: u128 = 64 * BASE;
-  pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
   pub const MinNominatorStake: u128 = BASE / 2;
   pub const MinSelectedCandidates: u32 = 1;
   pub const SS58Prefix: u8 = 73;
@@ -446,6 +444,7 @@ impl parachain_info::Config for Runtime {}
 impl zrml_liquidity_mining::Config for Runtime {
     type Currency = Balances;
     type Event = Event;
+    type MarketCommons = MarketCommons;
     type MarketId = MarketId;
     type PalletId = LiquidityMiningPalletId;
     type WeightInfo = zrml_liquidity_mining::weights::WeightInfo<Runtime>;
@@ -454,6 +453,7 @@ impl zrml_liquidity_mining::Config for Runtime {
 impl zrml_market_commons::Config for Runtime {
     type Currency = Balances;
     type MarketId = MarketId;
+    type Timestamp = Timestamp;
 }
 
 impl zrml_orderbook_v1::Config for Runtime {
@@ -483,7 +483,6 @@ impl zrml_prediction_markets::Config for Runtime {
     type SimpleDisputes = SimpleDisputes;
     type Slash = ();
     type Swaps = Swaps;
-    type Timestamp = Timestamp;
     type ValidityBond = ValidityBond;
     type WeightInfo = zrml_prediction_markets::weights::WeightInfo<Runtime>;
 }

--- a/zrml/court/Cargo.toml
+++ b/zrml/court/Cargo.toml
@@ -11,6 +11,7 @@ zrml-market-commons = { default-features = false, path = "../market-commons" }
 [dev-dependencies]
 pallet-balances = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate" }
 pallet-randomness-collective-flip = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate" }
+pallet-timestamp = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate"}
 sp-io = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate" }
 
 [features]

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -46,6 +46,7 @@ mod pallet {
         <<T as Config>::MarketCommons as MarketCommonsPalletApi>::Currency;
     pub(crate) type MarketIdOf<T> =
         <<T as Config>::MarketCommons as MarketCommonsPalletApi>::MarketId;
+    type MomentOf<T> = <<T as Config>::MarketCommons as MarketCommonsPalletApi>::Moment;
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
@@ -202,8 +203,9 @@ mod pallet {
         type AccountId = T::AccountId;
         type Balance = BalanceOf<T>;
         type BlockNumber = T::BlockNumber;
-        type Origin = T::Origin;
         type MarketId = MarketIdOf<T>;
+        type Moment = MomentOf<T>;
+        type Origin = T::Origin;
 
         fn on_dispute(
             disputes: &[MarketDispute<Self::AccountId, Self::BlockNumber>],
@@ -225,7 +227,7 @@ mod pallet {
             _: &D,
             _: &[MarketDispute<Self::AccountId, Self::BlockNumber>],
             _: &Self::MarketId,
-            _: &Market<Self::AccountId, Self::BlockNumber>,
+            _: &Market<Self::AccountId, Self::BlockNumber, Self::Moment>,
         ) -> Result<OutcomeReport, DispatchError>
         where
             D: Fn(usize) -> Self::Balance,

--- a/zrml/court/src/mock.rs
+++ b/zrml/court/src/mock.rs
@@ -7,9 +7,9 @@ use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup},
 };
 use zeitgeist_primitives::{
-    constants::{BlockHashCount, CourtCaseDuration, MaxReserves, StakeWeight, BASE},
+    constants::{BlockHashCount, CourtCaseDuration, MaxReserves, MinimumPeriod, StakeWeight, BASE},
     types::{
-        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, MarketId,
+        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, MarketId, Moment,
         UncheckedExtrinsicTest,
     },
 };
@@ -36,6 +36,7 @@ construct_runtime!(
         MarketCommons: zrml_market_commons::{Pallet, Storage},
         RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
         System: frame_system::{Call, Config, Event<T>, Pallet, Storage},
+        Timestamp: pallet_timestamp::{Pallet},
     }
 );
 
@@ -90,6 +91,14 @@ impl pallet_randomness_collective_flip::Config for Runtime {}
 impl zrml_market_commons::Config for Runtime {
     type Currency = Balances;
     type MarketId = MarketId;
+    type Timestamp = Timestamp;
+}
+
+impl pallet_timestamp::Config for Runtime {
+    type MinimumPeriod = MinimumPeriod;
+    type Moment = Moment;
+    type OnTimestampSet = ();
+    type WeightInfo = ();
 }
 
 pub struct ExtBuilder {

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -9,14 +9,7 @@ use crate::{
 use core::ops::Range;
 use frame_support::{assert_noop, assert_ok, traits::Hooks};
 use sp_runtime::traits::Header;
-use zeitgeist_primitives::{
-    constants::BASE,
-    traits::DisputeApi,
-    types::{
-        Market, MarketCreation, MarketDisputeMechanism, MarketEnd, MarketStatus, MarketType,
-        OutcomeReport,
-    },
-};
+use zeitgeist_primitives::{constants::BASE, traits::DisputeApi, types::OutcomeReport};
 
 const DEFAULT_SET_OF_JURORS: &[(u128, Juror<u128>)] = &[
     (7, Juror { staked: 1, status: JurorStatus::Ok }),

--- a/zrml/liquidity-mining/Cargo.toml
+++ b/zrml/liquidity-mining/Cargo.toml
@@ -6,9 +6,11 @@ parity-scale-codec = { default-features = false, features = ["derive"], version 
 serde = { default-features = false, optional = true, version = "1.0" }
 sp-runtime = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 zeitgeist-primitives = { default-features = false, path = "../../primitives" }
+zrml-market-commons = { default-features = false, path = "../market-commons" }
 
 [dev-dependencies]
 pallet-balances = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate" }
+pallet-timestamp = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate" }
 sp-io = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate" }
 
 [features]
@@ -26,6 +28,7 @@ std = [
     'serde/std',
     'sp-runtime/std',
     'zeitgeist-primitives/std',
+    "zrml-market-commons/std",
 ]
 
 [package]

--- a/zrml/liquidity-mining/src/liquidity_mining_pallet_api.rs
+++ b/zrml/liquidity-mining/src/liquidity_mining_pallet_api.rs
@@ -7,12 +7,6 @@ pub trait LiquidityMiningPalletApi {
     type BlockNumber;
     type MarketId;
 
-    /// Adds a market period to calculate incentives.
-    ///
-    /// Before calling any other function of this interface, it is important to first
-    /// register a market period through this method.
-    fn add_market_period(market_id: Self::MarketId, period: [Self::BlockNumber; 2]);
-
     /// Increases the number of stored pool shares of an account for a given market.
     ///
     /// It is up to the caller to synchronize the amount of shares between different pallets

--- a/zrml/liquidity-mining/src/mock.rs
+++ b/zrml/liquidity-mining/src/mock.rs
@@ -7,9 +7,9 @@ use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup},
 };
 use zeitgeist_primitives::{
-    constants::{BlockHashCount, ExistentialDeposit, MaxLocks, MaxReserves, BASE},
+    constants::{BlockHashCount, ExistentialDeposit, MaxLocks, MaxReserves, MinimumPeriod, BASE},
     types::{
-        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, MarketId,
+        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, MarketId, Moment,
         UncheckedExtrinsicTest,
     },
 };
@@ -32,14 +32,17 @@ construct_runtime!(
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
         Balances: pallet_balances::{Call, Config<T>, Event<T>, Pallet, Storage},
-        System: frame_system::{Call, Config, Event<T>, Pallet, Storage},
         LiquidityMining: zrml_liquidity_mining::{Config<T>, Event<T>, Pallet},
+        MarketCommons: zrml_market_commons::{Pallet, Storage},
+        System: frame_system::{Call, Config, Event<T>, Pallet, Storage},
+        Timestamp: pallet_timestamp::{Pallet},
     }
 );
 
 impl crate::Config for Runtime {
     type Currency = Balances;
     type Event = ();
+    type MarketCommons = MarketCommons;
     type MarketId = MarketId;
     type PalletId = LmPalletId;
     type WeightInfo = crate::weights::WeightInfo<Runtime>;
@@ -80,6 +83,19 @@ impl pallet_balances::Config for Runtime {
     type ExistentialDeposit = ExistentialDeposit;
     type MaxLocks = MaxLocks;
     type MaxReserves = MaxReserves;
+    type WeightInfo = ();
+}
+
+impl zrml_market_commons::Config for Runtime {
+    type Currency = Balances;
+    type MarketId = MarketId;
+    type Timestamp = Timestamp;
+}
+
+impl pallet_timestamp::Config for Runtime {
+    type MinimumPeriod = MinimumPeriod;
+    type Moment = Moment;
+    type OnTimestampSet = ();
     type WeightInfo = ();
 }
 

--- a/zrml/liquidity-mining/src/owned_values_params.rs
+++ b/zrml/liquidity-mining/src/owned_values_params.rs
@@ -2,8 +2,8 @@
 ///
 /// # Types
 ///
-/// * `BAL`: BALance
-/// * `BNR`: Block NumbeR
+/// * `BA`: BAlance
+/// * `BN`: Block Number
 #[cfg_attr(feature = "std", derive(serde::Deserialize, serde::Serialize))]
 #[derive(
     Clone,
@@ -16,14 +16,14 @@
     parity_scale_codec::Decode,
     parity_scale_codec::Encode,
 )]
-pub struct OwnedValuesParams<BAL, BNR> {
+pub struct OwnedValuesParams<BA, BN> {
     /// The number of blocks an account participated in a market period.
-    pub participated_blocks: BNR,
+    pub participated_blocks: BN,
     /// Owned amount of perpetual incentives. Won't go away when accounts exist early and is not
     /// attached to any share
-    pub perpetual_incentives: BAL,
+    pub perpetual_incentives: BA,
     /// Owned incentives. Related to the total number of shares.
-    pub total_incentives: BAL,
+    pub total_incentives: BA,
     /// Owned quantity of shares. Related to the total amount of incentives.
-    pub total_shares: BAL,
+    pub total_shares: BA,
 }

--- a/zrml/liquidity-mining/src/track_incentives_based_on_sold_shares.rs
+++ b/zrml/liquidity-mining/src/track_incentives_based_on_sold_shares.rs
@@ -23,7 +23,7 @@ where
             };
 
             let ptd = if let Some(el) = calculate_perthousand(sold_shares, &values.total_shares) {
-                el
+                el.into()
             } else {
                 // `total_shares` is zero
                 continue;

--- a/zrml/liquidity-mining/src/utils.rs
+++ b/zrml/liquidity-mining/src/utils.rs
@@ -1,16 +1,40 @@
-use core::ops::Div;
-use sp_runtime::traits::{CheckedDiv, Saturating, UniqueSaturatedInto};
+use crate::MomentOf;
+use core::ops::{Div, Range};
+use sp_runtime::{
+    traits::{CheckedDiv, Saturating, UniqueSaturatedInto},
+    SaturatedConversion,
+};
+use zeitgeist_primitives::constants::MILLISECS_PER_BLOCK;
+
+// Calculates the **average** number of blocks occurred between the starting and ending time period
+// of a market.
+//
+// To convert the block number type to the moment type, is is necessary to first convert the
+// block number value to `u32`, which caps the maximum output to `u32::MAX`. Since this function
+// is only used to evaluate perpetual balances, such limitation shouldn't be a problem.
+pub fn calculate_average_blocks_of_a_time_period<T>(range: &Range<MomentOf<T>>) -> T::BlockNumber
+where
+    T: crate::Config,
+{
+    let total_value_time = range.end.saturating_sub(range.start);
+    let mpb_balance = MILLISECS_PER_BLOCK.into();
+    // The following won't overflow because `MILLISECS_PER_BLOCK` is not zero.
+    let total_value_blocks = total_value_time / mpb_balance;
+    let total_value_blocks_u32: u32 = total_value_blocks.saturated_into();
+    total_value_blocks_u32.into()
+}
 
 // Per-thousand compared to `total_value` and a given `value`. For example, if total is 200,
 // then 6 is 3% of 200.
 //
 // Results currently can't have more than 00.0% accuracy.
-pub fn calculate_perthousand<T>(value: T, total_value: &T) -> Option<T>
+pub fn calculate_perthousand<T>(value: T, total_value: &T) -> Option<u16>
 where
-    T: CheckedDiv + From<u16> + Saturating,
+    T: CheckedDiv + From<u16> + Saturating + UniqueSaturatedInto<u16>,
 {
     let _1000_balance = T::from(1000u16);
-    value.saturating_mul(_1000_balance).checked_div(total_value)
+    let opaque = value.saturating_mul(_1000_balance).checked_div(total_value)?;
+    Some(opaque.unique_saturated_into())
 }
 
 // The value compared to `total_value` and a given `perthousand`. For example, 3% of 200 is 6.
@@ -22,14 +46,4 @@ where
 {
     let _1000_balance = T::from(1000u16);
     total_value.saturating_mul(perthousand) / _1000_balance
-}
-
-// Perthousand ranges from 0 to 1000 so this function will never overflow.
-pub fn perthousand_to_balance<B, T>(perthousand: T) -> B
-where
-    B: From<u16>,
-    T: UniqueSaturatedInto<u16>,
-{
-    let ptd_u16: u16 = perthousand.unique_saturated_into();
-    B::from(ptd_u16)
 }

--- a/zrml/market-commons/src/market_commons_pallet_api.rs
+++ b/zrml/market-commons/src/market_commons_pallet_api.rs
@@ -10,9 +10,10 @@ use zeitgeist_primitives::types::{Market, PoolId};
 /// Simple disputes - Pallet Api
 pub trait MarketCommonsPalletApi {
     type AccountId;
-    type BlockNumber;
+    type BlockNumber: AtLeast32Bit;
     type Currency: ReservableCurrency<Self::AccountId>;
     type MarketId: AtLeast32Bit + Copy + Default + MaybeSerializeDeserialize + Member + Parameter;
+    type Moment: AtLeast32Bit + Copy + Default + Parameter;
 
     // Market
 
@@ -24,16 +25,16 @@ pub trait MarketCommonsPalletApi {
     /// Gets a market from the storage.
     fn market(
         market_id: &Self::MarketId,
-    ) -> Result<Market<Self::AccountId, Self::BlockNumber>, DispatchError>;
+    ) -> Result<Market<Self::AccountId, Self::BlockNumber, Self::Moment>, DispatchError>;
 
     /// Mutates a given market storage
     fn mutate_market<F>(market_id: &Self::MarketId, cb: F) -> DispatchResult
     where
-        F: FnOnce(&mut Market<Self::AccountId, Self::BlockNumber>) -> DispatchResult;
+        F: FnOnce(&mut Market<Self::AccountId, Self::BlockNumber, Self::Moment>) -> DispatchResult;
 
     /// Pushes a new market into the storage, returning its related auto-incremented ID.
     fn push_market(
-        market: Market<Self::AccountId, Self::BlockNumber>,
+        market: Market<Self::AccountId, Self::BlockNumber, Self::Moment>,
     ) -> Result<Self::MarketId, DispatchError>;
 
     /// Removes a market from the storage.
@@ -47,9 +48,15 @@ pub trait MarketCommonsPalletApi {
     /// Fetches the pool id associated with a given `market_id`.
     fn market_pool(market_id: &Self::MarketId) -> Result<PoolId, DispatchError>;
 
+    /// Returns the current UTC time (milliseconds)
+    fn now() -> Self::Moment;
+
     // Migrations (Temporary)
 
-    fn insert_market(market_id: Self::MarketId, market: Market<Self::AccountId, Self::BlockNumber>);
+    fn insert_market(
+        market_id: Self::MarketId,
+        market: Market<Self::AccountId, Self::BlockNumber, Self::Moment>,
+    );
 
     fn set_market_counter(counter: Self::MarketId);
 }

--- a/zrml/prediction-markets/fuzz/pm_full_workflow.rs
+++ b/zrml/prediction-markets/fuzz/pm_full_workflow.rs
@@ -1,11 +1,12 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
+use core::ops::{Range, RangeInclusive};
 use frame_support::traits::Hooks;
 use libfuzzer_sys::fuzz_target;
 use zeitgeist_primitives::{
     traits::DisputeApi,
-    types::{MarketCreation, MarketDisputeMechanism, MarketEnd, MultiHash, OutcomeReport},
+    types::{MarketCreation, MarketDisputeMechanism, MarketPeriod, MultiHash, OutcomeReport},
 };
 use zrml_prediction_markets::mock::{
     ExtBuilder, Origin, PredictionMarkets, Runtime, SimpleDisputes, System,
@@ -20,7 +21,7 @@ fuzz_target!(|data: Data| {
         let _ = PredictionMarkets::create_scalar_market(
             Origin::signed(data.create_scalar_market_origin.into()),
             data.create_scalar_market_oracle.into(),
-            MarketEnd::Timestamp(data.create_scalar_market_timestamp),
+            MarketPeriod::Block(data.create_scalar_market_period),
             data.create_scalar_market_metadata,
             market_creation(data.create_scalar_market_creation),
             data.create_scalar_market_outcome_range,
@@ -70,10 +71,10 @@ fuzz_target!(|data: Data| {
 struct Data {
     create_scalar_market_origin: u8,
     create_scalar_market_oracle: u8,
-    create_scalar_market_timestamp: u64,
+    create_scalar_market_period: Range<u64>,
     create_scalar_market_metadata: MultiHash,
     create_scalar_market_creation: u8,
-    create_scalar_market_outcome_range: (u128, u128),
+    create_scalar_market_outcome_range: RangeInclusive<u128>,
     create_scalar_market_mdm: u8,
 
     buy_complete_set_origin: u8,

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -22,7 +22,7 @@ use zeitgeist_primitives::{
     },
     types::{
         AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
-        MarketId, SerdeWrapper, UncheckedExtrinsicTest,
+        MarketId, Moment, SerdeWrapper, UncheckedExtrinsicTest,
     },
 };
 
@@ -40,7 +40,7 @@ pub type AdaptedBasicCurrency =
     orml_currencies::BasicCurrencyAdapter<Runtime, Balances, Amount, Balance>;
 
 ord_parameter_types! {
-    pub const Sudo: AccountIdTest = 69;
+    pub const Sudo: AccountIdTest = SUDO;
 }
 
 parameter_types! {
@@ -56,7 +56,7 @@ parameter_types! {
     pub const MaximumBlockWeight: Weight = 1024;
     pub const MinimumPeriod: u64 = 0;
     pub const OracleBond: Balance = 100;
-    pub const ReportingPeriod: BlockNumber = 10;
+    pub const ReportingPeriod: u32 = 10;
     pub const ValidityBond: Balance = 200;
     pub DustAccount: AccountIdTest = PalletId(*b"orml/dst").into_account();
 }
@@ -106,7 +106,6 @@ impl crate::Config for Runtime {
     type SimpleDisputes = SimpleDisputes;
     type Slash = ();
     type Swaps = Swaps;
-    type Timestamp = Timestamp;
     type ValidityBond = ValidityBond;
     type WeightInfo = prediction_markets::weights::WeightInfo<Runtime>;
 }
@@ -170,7 +169,7 @@ impl pallet_balances::Config for Runtime {
 
 impl pallet_timestamp::Config for Runtime {
     type MinimumPeriod = MinimumPeriod;
-    type Moment = u64;
+    type Moment = Moment;
     type OnTimestampSet = ();
     type WeightInfo = ();
 }
@@ -178,6 +177,7 @@ impl pallet_timestamp::Config for Runtime {
 impl zrml_liquidity_mining::Config for Runtime {
     type Currency = Balances;
     type Event = Event;
+    type MarketCommons = MarketCommons;
     type MarketId = MarketId;
     type PalletId = LiquidityMiningPalletId;
     type WeightInfo = zrml_liquidity_mining::weights::WeightInfo<Runtime>;
@@ -186,6 +186,7 @@ impl zrml_liquidity_mining::Config for Runtime {
 impl zrml_market_commons::Config for Runtime {
     type Currency = Balances;
     type MarketId = MarketId;
+    type Timestamp = Timestamp;
 }
 
 impl zrml_simple_disputes::Config for Runtime {

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -1,14 +1,16 @@
 #![cfg(test)]
 use crate as zrml_rikiddo;
-use frame_support::{construct_runtime, parameter_types};
+use frame_support::construct_runtime;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
 };
 use substrate_fixed::types::extra::U34;
 use zeitgeist_primitives::{
-    constants::{BlockHashCount, ExistentialDeposit, MaxReserves, BASE},
-    types::{AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, UncheckedExtrinsicTest},
+    constants::{BlockHashCount, ExistentialDeposit, MaxReserves, MinimumPeriod, BASE},
+    types::{
+        AccountIdTest, Balance, BlockNumber, BlockTest, Hash, Index, Moment, UncheckedExtrinsicTest,
+    },
 };
 
 pub const ALICE: AccountIdTest = 0;
@@ -20,10 +22,6 @@ pub const FRED: AccountIdTest = 5;
 
 pub type Block = BlockTest<Runtime>;
 pub type UncheckedExtrinsic = UncheckedExtrinsicTest<Runtime>;
-
-parameter_types! {
-    pub const MinimumPeriod: u64 = 0;
-}
 
 construct_runtime!(
     pub enum Runtime
@@ -85,7 +83,7 @@ impl pallet_balances::Config for Runtime {
 
 impl pallet_timestamp::Config for Runtime {
     type MinimumPeriod = MinimumPeriod;
-    type Moment = u64;
+    type Moment = Moment;
     type OnTimestampSet = ();
     type WeightInfo = ();
 }

--- a/zrml/simple-disputes/src/lib.rs
+++ b/zrml/simple-disputes/src/lib.rs
@@ -31,6 +31,7 @@ mod pallet {
         <<T as Config>::MarketCommons as MarketCommonsPalletApi>::Currency;
     pub(crate) type MarketIdOf<T> =
         <<T as Config>::MarketCommons as MarketCommonsPalletApi>::MarketId;
+    pub(crate) type MomentOf<T> = <<T as Config>::MarketCommons as MarketCommonsPalletApi>::Moment;
     type NegativeImbalanceOf<T> =
         <CurrencyOf<T> as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance;
 
@@ -102,8 +103,9 @@ mod pallet {
         type AccountId = T::AccountId;
         type Balance = BalanceOf<T>;
         type BlockNumber = T::BlockNumber;
-        type Origin = T::Origin;
         type MarketId = MarketIdOf<T>;
+        type Moment = MomentOf<T>;
+        type Origin = T::Origin;
 
         fn on_dispute(
             _: &[MarketDispute<Self::AccountId, Self::BlockNumber>],
@@ -116,7 +118,7 @@ mod pallet {
             dispute_bound: &D,
             disputes: &[MarketDispute<Self::AccountId, Self::BlockNumber>],
             _: &Self::MarketId,
-            market: &Market<Self::AccountId, Self::BlockNumber>,
+            market: &Market<Self::AccountId, Self::BlockNumber, MomentOf<T>>,
         ) -> Result<OutcomeReport, DispatchError>
         where
             D: Fn(usize) -> Self::Balance,

--- a/zrml/swaps/Cargo.toml
+++ b/zrml/swaps/Cargo.toml
@@ -13,8 +13,10 @@ zrml-liquidity-mining = { default-features = false, path = "../liquidity-mining"
 orml-currencies = { branch = "master", git = "https://github.com/open-web3-stack/open-runtime-module-library", optional = true }
 orml-tokens = { branch = "master", git = "https://github.com/open-web3-stack/open-runtime-module-library", optional = true }
 pallet-balances = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate", optional = true }
+pallet-timestamp = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate", optional = true }
 sp-api = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate", optional = true }
 sp-io = { branch = "polkadot-v0.9.8", git = "https://github.com/paritytech/substrate", optional = true }
+zrml-market-commons = { optional = true, path = "../market-commons" }
 zrml-swaps-runtime-api = { optional = true, path = "./runtime-api" }
 
 [dev-dependencies]
@@ -26,8 +28,10 @@ mock = [
     "orml-currencies",
     "orml-tokens",
     "pallet-balances",
+    "pallet-timestamp",
     "sp-api",
     "sp-io",
+    "zrml-market-commons",
     "zrml-swaps-runtime-api",
 ]
 runtime-benchmarks = [

--- a/zrml/swaps/src/mock.rs
+++ b/zrml/swaps/src/mock.rs
@@ -12,11 +12,11 @@ use zeitgeist_primitives::{
     constants::{
         BlockHashCount, ExitFee, LiquidityMiningPalletId, MaxAssets, MaxInRatio, MaxLocks,
         MaxOutRatio, MaxReserves, MaxTotalWeight, MaxWeight, MinLiquidity, MinWeight,
-        SwapsPalletId,
+        MinimumPeriod, SwapsPalletId,
     },
     types::{
         AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
-        MarketId, PoolId, SerdeWrapper, UncheckedExtrinsicTest,
+        MarketId, Moment, PoolId, SerdeWrapper, UncheckedExtrinsicTest,
     },
 };
 
@@ -53,8 +53,10 @@ construct_runtime!(
         Balances: pallet_balances::{Call, Config<T>, Event<T>, Pallet, Storage},
         Currencies: orml_currencies::{Event<T>, Pallet},
         LiquidityMining: zrml_liquidity_mining::{Config<T>, Event<T>, Pallet},
+        MarketCommons: zrml_market_commons::{Pallet, Storage},
         Swaps: zrml_swaps::{Call, Event<T>, Pallet},
         System: frame_system::{Call, Config, Event<T>, Pallet, Storage},
+        Timestamp: pallet_timestamp::{Pallet},
         Tokens: orml_tokens::{Config<T>, Event<T>, Pallet, Storage},
     }
 );
@@ -136,9 +138,23 @@ impl pallet_balances::Config for Runtime {
 impl zrml_liquidity_mining::Config for Runtime {
     type Currency = Balances;
     type Event = Event;
+    type MarketCommons = MarketCommons;
     type MarketId = MarketId;
     type PalletId = LiquidityMiningPalletId;
     type WeightInfo = zrml_liquidity_mining::weights::WeightInfo<Runtime>;
+}
+
+impl zrml_market_commons::Config for Runtime {
+    type Currency = Balances;
+    type MarketId = MarketId;
+    type Timestamp = Timestamp;
+}
+
+impl pallet_timestamp::Config for Runtime {
+    type MinimumPeriod = MinimumPeriod;
+    type Moment = Moment;
+    type OnTimestampSet = ();
+    type WeightInfo = ();
 }
 
 pub struct ExtBuilder {

--- a/zrml/swaps/src/tests.rs
+++ b/zrml/swaps/src/tests.rs
@@ -232,7 +232,7 @@ fn only_root_can_call_admin_set_pool_as_stale() {
         assert_noop!(
             Swaps::admin_set_pool_as_stale(
                 alice_signed(),
-                MarketType::Scalar((0, 0)),
+                MarketType::Scalar(0..=0),
                 0,
                 OutcomeReport::Scalar(1)
             ),
@@ -243,7 +243,7 @@ fn only_root_can_call_admin_set_pool_as_stale() {
         assert_ok!(Swaps::pool_join(alice_signed(), 0, _1, vec!(_1, _1, _1, _1),));
         assert_ok!(Swaps::admin_set_pool_as_stale(
             Origin::root(),
-            MarketType::Scalar((0, 0)),
+            MarketType::Scalar(0..=0),
             0,
             OutcomeReport::Scalar(1)
         ),);


### PR DESCRIPTION
Fixes #220 and #251

Taking into consideration that the majority of the block construction have a stable and fixed duration, it is then possible to replace `MarketEnd::Period` with an ending block. For example, in a network with ~6 seconds block construction, ~30 minutes in the future means 300 additional blocks.
This `MarketEnd::Period` removal was motivated due to the fact that the liquidity mining pallet currently only works with block-based times to calculate rewards and the inclusion of actual time evaluation would take more time.
