### PR TITLE
Remove unnecessary usage of `sp-std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11977,7 +11977,6 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
@@ -12071,7 +12070,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "zeitgeist-primitives",
 ]
 
@@ -12092,7 +12090,6 @@ dependencies = [
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "zeitgeist-primitives",
  "zrml-liquidity-mining",
  "zrml-market-commons",
@@ -12134,7 +12131,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "substrate-fixed",
  "zeitgeist-primitives",
 ]
@@ -12169,7 +12165,6 @@ dependencies = [
  "sp-api",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "zeitgeist-primitives",
  "zrml-liquidity-mining",
  "zrml-swaps",

--- a/misc/weight_template.hbs
+++ b/misc/weight_template.hbs
@@ -14,7 +14,7 @@
 #![allow(unused_imports)]
 
 use frame_support::{traits::Get, weights::Weight};
-use sp_std::marker::PhantomData;
+use core::marker::PhantomData;
 
 ///  Trait containing the required functions for weight retrival within
 /// {{pallet}} (automatically generated)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,7 +24,6 @@ sp-inherents = { branch = "polkadot-v0.9.8", default-features = false, git = "ht
 sp-offchain = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-runtime = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-session = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
-sp-std = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-transaction-pool = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-version = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 
@@ -152,7 +151,6 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
-	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]
 
+extern crate alloc;
+
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
@@ -15,6 +17,7 @@ mod xcmp_message;
 #[cfg(feature = "parachain")]
 pub use xcmp_message::XCMPMessage;
 
+use alloc::{boxed::Box, vec::Vec};
 use frame_support::{
     construct_runtime, parameter_types,
     weights::{
@@ -36,7 +39,6 @@ use sp_runtime::{
     transaction_validity::{TransactionSource, TransactionValidity},
     ApplyExtrinsicResult, Perbill, Percent,
 };
-use sp_std::{boxed::Box, vec::Vec};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
@@ -734,7 +736,7 @@ impl cumulus_pallet_parachain_system::CheckInherents<Block> for CheckInherents {
         let inherent_data =
             cumulus_primitives_timestamp::InherentDataProvider::from_relay_chain_slot_and_duration(
                 relay_chain_slot,
-                sp_std::time::Duration::from_secs(6),
+                core::time::Duration::from_secs(6),
             )
             .create_inherent_data()
             .expect("Could not create the timestamp inherent data");

--- a/runtime/src/opaque.rs
+++ b/runtime/src/opaque.rs
@@ -6,8 +6,8 @@
 pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
 
 use crate::Header;
+use alloc::vec::Vec;
 use sp_runtime::{generic, impl_opaque_keys};
-use sp_std::vec::Vec;
 
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type SessionHandlers = ();

--- a/runtime/src/parachain_params.rs
+++ b/runtime/src/parachain_params.rs
@@ -1,13 +1,13 @@
 use crate::{
     AccountId, Balances, Origin, ParachainInfo, ParachainSystem, XcmpQueue, MAXIMUM_BLOCK_WEIGHT,
 };
+use alloc::{vec, vec::Vec};
 use frame_support::{
     parameter_types,
     traits::{All, IsInVec},
     weights::Weight,
 };
 use polkadot_parachain::primitives::Sibling;
-use sp_std::{vec, vec::Vec};
 use xcm::v0::{Junction, MultiLocation, NetworkId};
 use xcm_builder::{
     AccountId32Aliases, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, CurrencyAdapter,

--- a/zrml/orderbook-v1/Cargo.toml
+++ b/zrml/orderbook-v1/Cargo.toml
@@ -6,7 +6,6 @@ frame-system = { branch = "polkadot-v0.9.8", default-features = false, git = "ht
 orml-traits = { branch = "master", default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library" }
 parity-scale-codec = { default-features = false, features = ["derive"], version = "2.0" }
 sp-runtime = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
-sp-std = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 zeitgeist-primitives = { default-features = false, path = "../../primitives" }
 
 [dev-dependencies]
@@ -28,7 +27,6 @@ std = [
     'orml-traits/std',
     'parity-scale-codec/std',
     'sp-runtime/std',
-    'sp-std/std',
     'zeitgeist-primitives/std',
 ]
 

--- a/zrml/orderbook-v1/src/weights.rs
+++ b/zrml/orderbook-v1/src/weights.rs
@@ -29,8 +29,8 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
+use core::marker::PhantomData;
 use frame_support::{traits::Get, weights::Weight};
-use sp_std::marker::PhantomData;
 
 ///  Trait containing the required functions for weight retrival within
 /// zrml_orderbook_v1 (automatically generated)

--- a/zrml/prediction-markets/Cargo.toml
+++ b/zrml/prediction-markets/Cargo.toml
@@ -6,7 +6,6 @@ orml-traits = { branch = "master", default-features = false, git = "https://gith
 parity-scale-codec = { default-features = false, features = ["derive"], version = "2.0" }
 sp-arithmetic = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-runtime = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
-sp-std = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 zeitgeist-primitives = { default-features = false, path = "../../primitives" }
 zrml-liquidity-mining = { default-features = false, path = "../liquidity-mining" }
 zrml-market-commons = { default-features = false, path = "../market-commons" }
@@ -51,7 +50,6 @@ std = [
     'parity-scale-codec/std',
     'sp-arithmetic/std',
     'sp-runtime/std',
-    'sp-std/std',
     'zeitgeist-primitives/std',
     'zrml-liquidity-mining/std',
     'zrml-market-commons/std',

--- a/zrml/prediction-markets/src/weights.rs
+++ b/zrml/prediction-markets/src/weights.rs
@@ -29,8 +29,8 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
+use core::marker::PhantomData;
 use frame_support::{traits::Get, weights::Weight};
-use sp_std::marker::PhantomData;
 
 ///  Trait containing the required functions for weight retrival within
 /// zrml_prediction_markets (automatically generated)

--- a/zrml/rikiddo/Cargo.toml
+++ b/zrml/rikiddo/Cargo.toml
@@ -3,7 +3,6 @@ frame-support = { branch = "polkadot-v0.9.8", default-features = false, git = "h
 frame-system = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 parity-scale-codec = { default-features = false, features = ["derive"], version = "2.0" }
 sp-runtime = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
-sp-std = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 substrate-fixed = { default-features = false, features = ["serde"], git = "https://github.com/encointer/substrate-fixed" }
 zeitgeist-primitives = { default-features = false, path = "../../primitives" }
 
@@ -19,7 +18,6 @@ std = [
     "frame-system/std",
     "parity-scale-codec/std",
     "sp-runtime/std",
-    "sp-std/std",
     "substrate-fixed/std",
     "zeitgeist-primitives/std",
 ]

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -15,7 +15,7 @@ pub use pallet::*;
 
 #[frame_support::pallet]
 mod pallet {
-    use core::marker::PhantomData;
+    use core::{fmt::Debug, marker::PhantomData};
     use frame_support::{
         pallet_prelude::{MaybeSerializeDeserialize, Member},
         traits::{Hooks, Time},
@@ -23,7 +23,6 @@ mod pallet {
     };
     use parity_scale_codec::Codec;
     use sp_runtime::traits::AtLeast32BitUnsigned;
-    use sp_std::fmt::Debug;
     use substrate_fixed::types::extra::LeEqU128;
 
     #[pallet::config]

--- a/zrml/rikiddo/src/traits.rs
+++ b/zrml/rikiddo/src/traits.rs
@@ -1,11 +1,11 @@
 use crate::types::{EmaConfig, FeeSigmoidConfig, TimestampedVolume};
+use core::fmt::Debug;
 use frame_support::{
     pallet_prelude::{MaybeSerializeDeserialize, Member},
     Parameter,
 };
 use parity_scale_codec::Codec;
 use sp_runtime::traits::AtLeast32BitUnsigned;
-use sp_std::fmt::Debug;
 use substrate_fixed::traits::{Fixed, FixedSigned, FixedUnsigned};
 
 pub trait Sigmoid {

--- a/zrml/swaps/Cargo.toml
+++ b/zrml/swaps/Cargo.toml
@@ -5,7 +5,6 @@ frame-system = { branch = "polkadot-v0.9.8", default-features = false, git = "ht
 orml-traits = { branch = "master", default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library" }
 parity-scale-codec = { default-features = false, features = ["derive"], version = "2.0" }
 sp-runtime = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
-sp-std = { branch = "polkadot-v0.9.8", default-features = false, git = "https://github.com/paritytech/substrate" }
 zeitgeist-primitives = { default-features = false, path = "../../primitives" }
 zrml-liquidity-mining = { default-features = false, path = "../liquidity-mining" }
 
@@ -43,7 +42,6 @@ std = [
     "orml-traits/std",
     "parity-scale-codec/std",
     "sp-runtime/std",
-    "sp-std/std",
     "zeitgeist-primitives/std",
     "zrml-liquidity-mining/std",
 ]

--- a/zrml/swaps/src/weights.rs
+++ b/zrml/swaps/src/weights.rs
@@ -29,8 +29,8 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
+use core::marker::PhantomData;
 use frame_support::{traits::Get, weights::Weight};
-use sp_std::marker::PhantomData;
 
 ///  Trait containing the required functions for weight retrival within
 /// zrml_swaps (automatically generated)


### PR DESCRIPTION
`sp-std` is just a shortcut for the `alloc` or `core` crates and is not necessary at all.