### PR TITLE
[PM] Single extrinsic for creating and deploying a pool

### DIFF
--- a/primitives/src/traits/swaps.rs
+++ b/primitives/src/traits/swaps.rs
@@ -1,6 +1,6 @@
 use crate::types::{Asset, MarketType, OutcomeReport, Pool, PoolId};
 use alloc::vec::Vec;
-use frame_support::dispatch::{DispatchError, DispatchResult};
+use frame_support::dispatch::{DispatchError, DispatchResult, Weight};
 
 pub trait Swaps<AccountId> {
     type Balance;
@@ -22,6 +22,22 @@ pub trait Swaps<AccountId> {
         swap_fee: Self::Balance,
         weights: Vec<u128>,
     ) -> Result<PoolId, DispatchError>;
+
+    fn pool_exit_with_exact_asset_amount(
+        who: AccountId,
+        pool_id: PoolId,
+        asset: Asset<Self::MarketId>,
+        asset_amount: Self::Balance,
+        max_pool_amount: Self::Balance,
+    ) -> Result<Weight, DispatchError>;
+
+    fn pool_join_with_exact_asset_amount(
+        who: AccountId,
+        pool_id: PoolId,
+        asset_in: Asset<Self::MarketId>,
+        asset_amount: Self::Balance,
+        min_pool_amount: Self::Balance,
+    ) -> Result<Weight, DispatchError>;
 
     /// Returns the pool instance of a corresponding `pool_id`.
     fn pool(pool_id: PoolId) -> Result<Pool<Self::Balance, Self::MarketId>, DispatchError>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -56,10 +56,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("zeitgeist"),
     authoring_version: 1,
     // major_minor_patch_spec-version
-    spec_version: 20,
+    spec_version: 21,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 3,
+    transaction_version: 4,
 };
 
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -1,6 +1,9 @@
 #![cfg(all(feature = "mock", test))]
 
-use crate::{mock::*, BalanceOf, MarketIdOf, Config, Error, MarketIdsPerDisputeBlock, MarketIdsPerReportBlock};
+use crate::{
+    mock::*, BalanceOf, Config, Error, MarketIdOf, MarketIdsPerDisputeBlock,
+    MarketIdsPerReportBlock,
+};
 use core::cell::RefCell;
 use frame_support::{
     assert_noop, assert_ok,

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -168,48 +168,15 @@ mod pallet {
             asset_amount: BalanceOf<T>,
             max_pool_amount: BalanceOf<T>,
         ) -> DispatchResult {
-            let pool = Self::pool_by_id(pool_id)?;
-            let pool_ref = &pool;
             let who = ensure_signed(origin)?;
-            let who_clone = who.clone();
-
-            let params = PoolExitWithExactAmountParams {
-                asset,
-                asset_amount: |_, _| Ok(asset_amount),
-                bound: max_pool_amount,
-                ensure_balance: |asset_balance: BalanceOf<T>| {
-                    ensure!(
-                        asset_amount
-                            <= bmul(
-                                asset_balance.saturated_into(),
-                                T::MaxOutRatio::get().saturated_into()
-                            )?
-                            .saturated_into(),
-                        Error::<T>::MaxOutRatio
-                    );
-                    Ok(())
-                },
-                pool_amount: |asset_balance: BalanceOf<T>, total_supply: BalanceOf<T>| {
-                    let pool_amount: BalanceOf<T> = crate::math::calc_pool_in_given_single_out(
-                        asset_balance.saturated_into(),
-                        Self::pool_weight_rslt(pool_ref, &asset)?,
-                        total_supply.saturated_into(),
-                        pool_ref.total_weight,
-                        asset_amount.saturated_into(),
-                        pool_ref.swap_fee.saturated_into(),
-                    )?
-                    .saturated_into();
-                    ensure!(pool_amount != Zero::zero(), Error::<T>::MathApproximation);
-                    ensure!(pool_amount <= max_pool_amount, Error::<T>::LimitIn);
-                    T::LiquidityMining::remove_shares(&who, &pool_ref.market_id, asset_amount);
-                    Ok(pool_amount)
-                },
-                event: |evt| Self::deposit_event(Event::PoolExitWithExactAssetAmount(evt)),
-                who: who_clone,
+            <Self as Swaps<T::AccountId>>::pool_exit_with_exact_asset_amount(
+                who,
                 pool_id,
-                pool: pool_ref,
-            };
-            pool_exit_with_exact_amount::<_, _, _, _, T>(params)
+                asset,
+                asset_amount,
+                max_pool_amount,
+            )
+            .map(|_| ())
         }
 
         /// Pool - Exit with exact pool amount
@@ -340,43 +307,15 @@ mod pallet {
             asset_amount: BalanceOf<T>,
             min_pool_amount: BalanceOf<T>,
         ) -> DispatchResult {
-            let pool = Pallet::<T>::pool_by_id(pool_id)?;
-            let pool_ref = &pool;
-            let pool_account_id = Pallet::<T>::pool_account_id(pool_id);
             let who = ensure_signed(origin)?;
-            let who_clone = who.clone();
-
-            let params = PoolJoinWithExactAmountParams {
-                asset: asset_in,
-                asset_amount: |_, _| Ok(asset_amount),
-                bound: min_pool_amount,
-                pool_amount: move |asset_balance: BalanceOf<T>, total_supply: BalanceOf<T>| {
-                    let mul: BalanceOf<T> = bmul(
-                        asset_balance.saturated_into(),
-                        T::MaxInRatio::get().saturated_into(),
-                    )?
-                    .saturated_into();
-                    ensure!(asset_amount <= mul, Error::<T>::MaxInRatio);
-                    let pool_amount: BalanceOf<T> = crate::math::calc_pool_out_given_single_in(
-                        asset_balance.saturated_into(),
-                        Self::pool_weight_rslt(pool_ref, &asset_in)?,
-                        total_supply.saturated_into(),
-                        pool_ref.total_weight.saturated_into(),
-                        asset_amount.saturated_into(),
-                        pool_ref.swap_fee.saturated_into(),
-                    )?
-                    .saturated_into();
-                    ensure!(pool_amount >= min_pool_amount, Error::<T>::LimitOut);
-                    T::LiquidityMining::add_shares(who.clone(), pool_ref.market_id, asset_amount);
-                    Ok(pool_amount)
-                },
-                event: |evt| Self::deposit_event(Event::PoolJoinWithExactAssetAmount(evt)),
-                who: who_clone,
-                pool_account_id: &pool_account_id,
+            <Self as Swaps<T::AccountId>>::pool_join_with_exact_asset_amount(
+                who,
                 pool_id,
-                pool: pool_ref,
-            };
-            pool_join_with_exact_amount::<_, _, _, T>(params)
+                asset_in,
+                asset_amount,
+                min_pool_amount,
+            )
+            .map(|_| ())
         }
 
         /// Pool - Join with exact pool amount
@@ -855,6 +794,103 @@ mod pallet {
             }));
 
             Ok(next_pool_id)
+        }
+
+        fn pool_exit_with_exact_asset_amount(
+            who: T::AccountId,
+            pool_id: PoolId,
+            asset: Asset<T::MarketId>,
+            asset_amount: BalanceOf<T>,
+            max_pool_amount: BalanceOf<T>,
+        ) -> Result<Weight, DispatchError> {
+            let pool = Self::pool_by_id(pool_id)?;
+            let pool_ref = &pool;
+            let who_clone = who.clone();
+
+            let params = PoolExitWithExactAmountParams {
+                asset,
+                asset_amount: |_, _| Ok(asset_amount),
+                bound: max_pool_amount,
+                ensure_balance: |asset_balance: BalanceOf<T>| {
+                    ensure!(
+                        asset_amount
+                            <= bmul(
+                                asset_balance.saturated_into(),
+                                T::MaxOutRatio::get().saturated_into()
+                            )?
+                            .saturated_into(),
+                        Error::<T>::MaxOutRatio
+                    );
+                    Ok(())
+                },
+                pool_amount: |asset_balance: BalanceOf<T>, total_supply: BalanceOf<T>| {
+                    let pool_amount: BalanceOf<T> = crate::math::calc_pool_in_given_single_out(
+                        asset_balance.saturated_into(),
+                        Self::pool_weight_rslt(pool_ref, &asset)?,
+                        total_supply.saturated_into(),
+                        pool_ref.total_weight,
+                        asset_amount.saturated_into(),
+                        pool_ref.swap_fee.saturated_into(),
+                    )?
+                    .saturated_into();
+                    ensure!(pool_amount != Zero::zero(), Error::<T>::MathApproximation);
+                    ensure!(pool_amount <= max_pool_amount, Error::<T>::LimitIn);
+                    T::LiquidityMining::remove_shares(&who, &pool_ref.market_id, asset_amount);
+                    Ok(pool_amount)
+                },
+                event: |evt| Self::deposit_event(Event::PoolExitWithExactAssetAmount(evt)),
+                who: who_clone,
+                pool_id,
+                pool: pool_ref,
+            };
+            let weight = T::WeightInfo::pool_exit_with_exact_asset_amount();
+            pool_exit_with_exact_amount::<_, _, _, _, T>(params).map(|_| weight)
+        }
+
+        fn pool_join_with_exact_asset_amount(
+            who: T::AccountId,
+            pool_id: PoolId,
+            asset_in: Asset<T::MarketId>,
+            asset_amount: BalanceOf<T>,
+            min_pool_amount: BalanceOf<T>,
+        ) -> Result<Weight, DispatchError> {
+            let pool = Pallet::<T>::pool_by_id(pool_id)?;
+            let pool_ref = &pool;
+            let pool_account_id = Pallet::<T>::pool_account_id(pool_id);
+            let who_clone = who.clone();
+
+            let params = PoolJoinWithExactAmountParams {
+                asset: asset_in,
+                asset_amount: |_, _| Ok(asset_amount),
+                bound: min_pool_amount,
+                pool_amount: move |asset_balance: BalanceOf<T>, total_supply: BalanceOf<T>| {
+                    let mul: BalanceOf<T> = bmul(
+                        asset_balance.saturated_into(),
+                        T::MaxInRatio::get().saturated_into(),
+                    )?
+                    .saturated_into();
+                    ensure!(asset_amount <= mul, Error::<T>::MaxInRatio);
+                    let pool_amount: BalanceOf<T> = crate::math::calc_pool_out_given_single_in(
+                        asset_balance.saturated_into(),
+                        Self::pool_weight_rslt(pool_ref, &asset_in)?,
+                        total_supply.saturated_into(),
+                        pool_ref.total_weight.saturated_into(),
+                        asset_amount.saturated_into(),
+                        pool_ref.swap_fee.saturated_into(),
+                    )?
+                    .saturated_into();
+                    ensure!(pool_amount >= min_pool_amount, Error::<T>::LimitOut);
+                    T::LiquidityMining::add_shares(who.clone(), pool_ref.market_id, asset_amount);
+                    Ok(pool_amount)
+                },
+                event: |evt| Self::deposit_event(Event::PoolJoinWithExactAssetAmount(evt)),
+                who: who_clone,
+                pool_account_id: &pool_account_id,
+                pool_id,
+                pool: pool_ref,
+            };
+            let weight = T::WeightInfo::pool_exit_with_exact_asset_amount();
+            pool_join_with_exact_amount::<_, _, _, T>(params).map(|_| weight)
         }
 
         fn pool(pool_id: PoolId) -> Result<Pool<Self::Balance, Self::MarketId>, DispatchError> {

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -160,7 +160,6 @@ mod pallet {
         /// * `max_pool_amount`: The calculated amount of assets for the pool must the equal or
         /// greater than the given value.
         #[pallet::weight(T::WeightInfo::pool_exit_with_exact_asset_amount())]
-        #[frame_support::transactional]
         pub fn pool_exit_with_exact_asset_amount(
             origin: OriginFor<T>,
             pool_id: PoolId,
@@ -299,7 +298,6 @@ mod pallet {
         /// * `min_pool_amount`: The calculated amount for the pool must be equal or greater
         /// than the given value.
         #[pallet::weight(T::WeightInfo::pool_join_with_exact_asset_amount())]
-        #[frame_support::transactional]
         pub fn pool_join_with_exact_asset_amount(
             origin: OriginFor<T>,
             pool_id: PoolId,
@@ -796,6 +794,7 @@ mod pallet {
             Ok(next_pool_id)
         }
 
+        #[frame_support::transactional]
         fn pool_exit_with_exact_asset_amount(
             who: T::AccountId,
             pool_id: PoolId,
@@ -847,6 +846,7 @@ mod pallet {
             pool_exit_with_exact_amount::<_, _, _, _, T>(params).map(|_| weight)
         }
 
+        #[frame_support::transactional]
         fn pool_join_with_exact_asset_amount(
             who: T::AccountId,
             pool_id: PoolId,


### PR DESCRIPTION
closes #269 

It modified the Swaps API a bit, such that prediction market can call the relevant function to deploy additional assets. An alternative would be to create a new pallet whose `Config` trait is tightly coupled to our prediction market and swaps pallet.

The `pool_join_additional_assets` parameter uses `Asset` as the first element in the 3-tuple. `Asset` contains a market id, but this argument will be replaced by the market id of the market that was created previously during the processing of `create_market_and_deploy_assets`. It is not the most transparent way, but it makes use of existing types, which doesn't further complicate the `types.json`. It is also documented. If preferred, I can replace this by a new type instead.