### PR TITLE
Audit the use of unchecked arithmetic operations

### DIFF
--- a/node/src/chain_spec/battery_station.rs
+++ b/node/src/chain_spec/battery_station.rs
@@ -3,7 +3,9 @@ use crate::chain_spec::{
     telemetry_endpoints, token_properties, zeitgeist_wasm, ChainSpec,
 };
 use sc_service::ChainType;
-use zeitgeist_primitives::constants::BASE;
+use zeitgeist_primitives::{constants::BASE, types::Balance};
+
+const INITIAL_BALANCE: Balance = 10_000 * BASE;
 
 pub fn battery_station_staging_config(
     #[cfg(feature = "parachain")] parachain_id: cumulus_primitives_core::ParaId,
@@ -21,7 +23,7 @@ pub fn battery_station_staging_config(
                     parachain_id,
                 ),
                 endowed_accounts_staging(),
-                10_000 * BASE,
+                INITIAL_BALANCE,
                 root_key_staging(),
                 zeitgeist_wasm,
             )

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -6,6 +6,9 @@ use crate::chain_spec::{
 };
 use sc_service::ChainType;
 use sp_core::sr25519;
+use zeitgeist_primitives::types::Balance;
+
+const INITIAL_BALANCE: Balance = Balance::MAX >> 4;
 
 pub fn dev_config(
     #[cfg(feature = "parachain")] parachain_id: cumulus_primitives_core::ParaId,
@@ -46,7 +49,7 @@ pub fn dev_config(
                     get_account_id_from_seed::<sr25519::Public>("Ferdie"),
                     get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                 ],
-                zeitgeist_primitives::types::Balance::MAX >> 4,
+                INITIAL_BALANCE,
                 get_account_id_from_seed::<sr25519::Public>("Alice"),
                 zeitgeist_wasm,
             )

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -1,8 +1,17 @@
+#![allow(
+  // Constants parameters inside `parameter_types!` already check
+  // arithmetic operations at compile time
+    clippy::integer_arithmetic
+)]
+
 pub mod ztg;
 
-use crate::types::{Balance, BlockNumber};
+use crate::{
+    asset::Asset,
+    types::{AccountId, AccountIdTest, Balance, BlockNumber, CurrencyId},
+};
 use frame_support::{parameter_types, PalletId};
-use sp_runtime::Permill;
+use sp_runtime::{traits::AccountIdConversion, Permill};
 
 // Definitions for time
 pub const BLOCKS_PER_DAY: BlockNumber = BLOCKS_PER_HOUR * 24;
@@ -38,6 +47,13 @@ parameter_types! {
 // Liquidity Mining parameters
 parameter_types! {
     pub const LiquidityMiningPalletId: PalletId = PalletId(*b"zge/lymg");
+}
+
+// ORML
+parameter_types! {
+    pub const GetNativeCurrencyId: CurrencyId = Asset::Ztg;
+    pub DustAccount: AccountId = PalletId(*b"orml/dst").into_account();
+    pub DustAccountTest: AccountIdTest = PalletId(*b"orml/dst").into_account();
 }
 
 // Prediction Market parameters

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 mod asset;
 pub mod constants;
 mod market;
+mod max_usize;
 mod outcome_report;
 mod pool;
 mod pool_status;

--- a/primitives/src/max_usize.rs
+++ b/primitives/src/max_usize.rs
@@ -1,0 +1,55 @@
+use core::ops::Deref;
+
+/// The biggest pointer size taking into consideration all known targeting machine architectures.
+///
+/// Useful to cast `usize` into `MaxUsize` with the guarantee that no truncation will occur.
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    parity_scale_codec::CompactAs,
+    parity_scale_codec::Decode,
+    parity_scale_codec::Encode,
+)]
+pub struct MaxUsize(u64);
+
+impl AsRef<u64> for MaxUsize {
+    #[inline]
+    fn as_ref(&self) -> &u64 {
+        &self.0
+    }
+}
+
+impl Deref for MaxUsize {
+    type Target = u64;
+
+    #[inline]
+    fn deref(&self) -> &u64 {
+        &self.0
+    }
+}
+
+// As per contract, `usize` will never be greater than `u64`.
+impl From<usize> for MaxUsize {
+    #[inline]
+    fn from(n: usize) -> Self {
+        Self(n as u64)
+    }
+}
+
+macro_rules! impl_from {
+    ($n:ty) => {
+        impl From<$n> for MaxUsize {
+            #[inline]
+            fn from(n: $n) -> Self {
+                Self(n.into())
+            }
+        }
+    };
+}
+
+impl_from!(u8);
+impl_from!(u16);
+impl_from!(u32);
+impl_from!(u64);

--- a/primitives/src/traits/zeitgeist_multi_reservable_currency.rs
+++ b/primitives/src/traits/zeitgeist_multi_reservable_currency.rs
@@ -23,6 +23,10 @@ where
         currency_id: Self::CurrencyId,
     ) -> (usize, Vec<(T::AccountId, AccountData<T::Balance>)>) {
         let mut total = 0;
+        #[allow(
+            // Iterator will never yield more than `usize::MAX` elements
+            clippy::integer_arithmetic
+        )]
         let accounts = <Accounts<T>>::iter()
             .filter_map(|(k0, k1, v)| {
                 total += 1;

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -1,6 +1,6 @@
 pub use crate::{
-    asset::*, market::*, outcome_report::OutcomeReport, pool::Pool, pool_status::PoolStatus,
-    serde_wrapper::*,
+    asset::*, market::*, max_usize::*, outcome_report::OutcomeReport, pool::Pool,
+    pool_status::PoolStatus, serde_wrapper::*,
 };
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Result, Unstructured};
@@ -70,11 +70,6 @@ pub type DigestItem = generic::DigestItem<Hash>;
 
 /// The market identifier type.
 pub type MarketId = u128;
-
-/// The biggest pointer size taking into consideration all known targeting machine architectures.
-///
-/// Useful to cast `usize` into `MaxUsize` with the guarantee that no truncation will occur.
-pub type MaxUsize = u64;
 
 /// Time
 pub type Moment = u64;

--- a/runtime/src/parameters.rs
+++ b/runtime/src/parameters.rs
@@ -1,0 +1,62 @@
+#![allow(
+  // Constants parameters inside `parameter_types!` already check
+  // arithmetic operations at compile time
+  clippy::integer_arithmetic
+)]
+
+use crate::VERSION;
+use frame_support::{
+    parameter_types,
+    weights::{
+        constants::{BlockExecutionWeight, ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
+        DispatchClass, Weight,
+    },
+};
+use frame_system::limits::{BlockLength, BlockWeights};
+use orml_traits::parameter_type_with_key;
+use sp_runtime::{Perbill, Percent};
+use sp_version::RuntimeVersion;
+use zeitgeist_primitives::{constants::*, types::*};
+
+pub(crate) const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
+pub(crate) const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND / 2;
+pub(crate) const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+
+parameter_types! {
+  pub const BondDuration: u32 = BLOCKS_PER_DAY as u32;
+  pub const CollatorDeposit: Balance = 2 * BASE;
+  pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
+  pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
+  pub const MaxCollatorsPerNominator: u32 = 16;
+  pub const MaxNominatorsPerCollator: u32 = 32;
+  pub const MinBlocksPerRound: u32 = (BLOCKS_PER_DAY / 6) as _;
+  pub const MinCollatorStake: u128 = 64 * BASE;
+  pub const MinNominatorStake: u128 = BASE / 2;
+  pub const MinSelectedCandidates: u32 = 1;
+  pub const SS58Prefix: u8 = 73;
+  pub const TransactionByteFee: Balance = 100 * MICRO;
+  pub const Version: RuntimeVersion = VERSION;
+  pub RuntimeBlockLength: BlockLength = BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
+  pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
+    .base_block(BlockExecutionWeight::get())
+    .for_class(DispatchClass::all(), |weights| {
+      weights.base_extrinsic = ExtrinsicBaseWeight::get();
+    })
+    .for_class(DispatchClass::Normal, |weights| {
+      weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
+    })
+    .for_class(DispatchClass::Operational, |weights| {
+      weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
+      weights.reserved = Some(
+        MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT
+      );
+    })
+    .avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
+    .build_or_panic();
+}
+
+parameter_type_with_key! {
+    pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
+      Default::default()
+    };
+}

--- a/scripts/tests/clippy.sh
+++ b/scripts/tests/clippy.sh
@@ -11,4 +11,5 @@ cargo clippy --all-features --release -- \
   -Aclippy::type_complexity \
   -Aclippy::unnecessary_cast \
   -Aclippy::unnecessary_mut_passed \
-  -Aclippy::unused_unit
+  -Aclippy::unused_unit \
+  -Dclippy::integer_arithmetic

--- a/zrml/liquidity-mining/src/benchmarks.rs
+++ b/zrml/liquidity-mining/src/benchmarks.rs
@@ -1,3 +1,7 @@
+#![allow(
+    // Auto-generated code is a no man's land
+    clippy::integer_arithmetic
+)]
 #![cfg(feature = "runtime-benchmarks")]
 
 use crate::pallet::{BalanceOf, Call, Config, Pallet};

--- a/zrml/liquidity-mining/src/lib.rs
+++ b/zrml/liquidity-mining/src/lib.rs
@@ -58,7 +58,7 @@ mod pallet {
     use frame_system::{ensure_root, pallet_prelude::OriginFor};
     use sp_runtime::{
         traits::{AccountIdConversion, Saturating, Zero},
-        SaturatedConversion, TransactionOutcome,
+        TransactionOutcome,
     };
     use zeitgeist_primitives::{
         traits::MarketId,
@@ -156,9 +156,9 @@ mod pallet {
         fn on_finalize(block: T::BlockNumber) {
             let fun = || {
                 let added_len = TrackIncentivesBasedOnBoughtShares::<T>::exec(block)?;
-                Self::deposit_event(Event::AddedIncentives(added_len.saturated_into()));
+                Self::deposit_event(Event::AddedIncentives(added_len.into()));
                 let subtracted_len = TrackIncentivesBasedOnSoldShares::<T>::exec();
-                Self::deposit_event(Event::SubtractedIncentives(subtracted_len.saturated_into()));
+                Self::deposit_event(Event::SubtractedIncentives(subtracted_len.into()));
                 Some(())
             };
             with_transaction(|| match fun() {
@@ -250,7 +250,7 @@ mod pallet {
             )
             .map_err(|_err| Error::<T>::FundDoesNotHaveEnoughBalance)?;
 
-            let accounts_len = values.len().saturated_into();
+            let accounts_len = values.len().into();
             for (account_id, incentives) in values {
                 T::Currency::transfer(
                     &pallet_account_id,

--- a/zrml/orderbook-v1/src/benchmarks.rs
+++ b/zrml/orderbook-v1/src/benchmarks.rs
@@ -1,3 +1,7 @@
+#![allow(
+    // Auto-generated code is a no man's land
+    clippy::integer_arithmetic
+)]
 #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;

--- a/zrml/orderbook-v1/src/mock.rs
+++ b/zrml/orderbook-v1/src/mock.rs
@@ -1,15 +1,14 @@
 #![cfg(feature = "mock")]
 
 use crate as orderbook_v1;
-use frame_support::{construct_runtime, parameter_types, PalletId};
+use frame_support::{construct_runtime, parameter_types};
 use orml_traits::parameter_type_with_key;
 use sp_runtime::{
     testing::Header,
-    traits::{AccountIdConversion, BlakeTwo256, IdentityLookup},
-    Perbill,
+    traits::{BlakeTwo256, IdentityLookup},
 };
 use zeitgeist_primitives::{
-    constants::{BlockHashCount, MaxLocks, MaxReserves},
+    constants::{BlockHashCount, DustAccountTest, MaxLocks, MaxReserves},
     types::{
         AccountIdTest, Amount, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index, MarketId,
         UncheckedExtrinsicTest,
@@ -23,9 +22,7 @@ pub type Block = BlockTest<Runtime>;
 pub type UncheckedExtrinsic = UncheckedExtrinsicTest<Runtime>;
 
 parameter_types! {
-    pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
     pub const ExistentialDeposit: Balance = 1;
-    pub DustAccount: AccountIdTest = PalletId(*b"orml/dst").into_account();
 }
 
 parameter_type_with_key! {
@@ -89,7 +86,7 @@ impl orml_tokens::Config for Runtime {
     type Event = ();
     type ExistentialDeposits = ExistentialDeposits;
     type MaxLocks = ();
-    type OnDust = orml_tokens::TransferDust<Runtime, DustAccount>;
+    type OnDust = orml_tokens::TransferDust<Runtime, DustAccountTest>;
     type WeightInfo = ();
 }
 

--- a/zrml/prediction-markets/src/benchmarks.rs
+++ b/zrml/prediction-markets/src/benchmarks.rs
@@ -1,3 +1,7 @@
+#![allow(
+    // Auto-generated code is a no man's land
+    clippy::integer_arithmetic
+)]
 #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -1,3 +1,7 @@
+#![allow(
+    // Mocks are only used for fuzzing and unit tests
+    clippy::integer_arithmetic
+)]
 #![cfg(feature = "mock")]
 
 use crate as prediction_markets;
@@ -5,20 +9,20 @@ use frame_support::{
     construct_runtime, ord_parameter_types, parameter_types,
     traits::{OnFinalize, OnInitialize},
     weights::Weight,
-    PalletId,
 };
 use frame_system::EnsureSignedBy;
 use orml_traits::parameter_type_with_key;
 use sp_runtime::{
     testing::Header,
-    traits::{AccountIdConversion, BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, IdentityLookup},
     Perbill,
 };
 use zeitgeist_primitives::{
     constants::{
-        BlockHashCount, ExitFee, LiquidityMiningPalletId, MaxAssets, MaxCategories, MaxDisputes,
-        MaxInRatio, MaxOutRatio, MaxReserves, MaxTotalWeight, MaxWeight, MinCategories,
-        MinLiquidity, MinWeight, PmPalletId, SimpleDisputesPalletId, SwapsPalletId, BASE,
+        BlockHashCount, DustAccountTest, ExitFee, GetNativeCurrencyId, LiquidityMiningPalletId,
+        MaxAssets, MaxCategories, MaxDisputes, MaxInRatio, MaxOutRatio, MaxReserves,
+        MaxTotalWeight, MaxWeight, MinCategories, MinLiquidity, MinWeight, PmPalletId,
+        SimpleDisputesPalletId, SwapsPalletId, BASE,
     },
     types::{
         AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
@@ -50,14 +54,12 @@ parameter_types! {
     pub const DisputeFactor: Balance = 25;
     pub const DisputePeriod: BlockNumber = 10;
     pub const ExistentialDeposit: u64 = 1;
-    pub const GetNativeCurrencyId: Asset<MarketId> = Asset::Ztg;
     pub const MaximumBlockLength: u32 = 2 * 1024;
     pub const MaximumBlockWeight: Weight = 1024;
     pub const MinimumPeriod: u64 = 0;
     pub const OracleBond: Balance = 100;
     pub const ReportingPeriod: u32 = 10;
     pub const ValidityBond: Balance = 200;
-    pub DustAccount: AccountIdTest = PalletId(*b"orml/dst").into_account();
 }
 
 parameter_type_with_key! {
@@ -150,7 +152,7 @@ impl orml_tokens::Config for Runtime {
     type Event = Event;
     type ExistentialDeposits = ExistentialDeposits;
     type MaxLocks = ();
-    type OnDust = orml_tokens::TransferDust<Runtime, DustAccount>;
+    type OnDust = orml_tokens::TransferDust<Runtime, DustAccountTest>;
     type WeightInfo = ();
 }
 

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -228,7 +228,7 @@ impl<FU: FixedUnsigned + From<u32>> MarketAverage for EmaMarketVolume<FU> {
                 // It should not state transit, if the amount of gathered data is too low.
                 // This would result in a multiplier that is greater than 1, which can lead to
                 // a negative ema. The amount depends on the size of the smoothing factor.
-                if timestamp_sub_start_time > comparison_value as u64
+                if timestamp_sub_start_time > Into::<u64>::into(comparison_value)
                     && (*self.volumes_per_period() + 1.into()) >= self.config.smoothing
                 {
                     // We extrapolate the txs per period

--- a/zrml/swaps/src/benchmarks.rs
+++ b/zrml/swaps/src/benchmarks.rs
@@ -1,3 +1,7 @@
+#![allow(
+    // Auto-generated code is a no man's land
+    clippy::integer_arithmetic
+)]
 #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;

--- a/zrml/swaps/src/mock.rs
+++ b/zrml/swaps/src/mock.rs
@@ -1,18 +1,18 @@
 #![cfg(feature = "mock")]
 
 use crate as zrml_swaps;
-use frame_support::{construct_runtime, parameter_types, PalletId};
+use frame_support::{construct_runtime, parameter_types};
 use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::parameter_type_with_key;
 use sp_runtime::{
     testing::Header,
-    traits::{AccountIdConversion, BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, IdentityLookup},
 };
 use zeitgeist_primitives::{
     constants::{
-        BlockHashCount, ExitFee, LiquidityMiningPalletId, MaxAssets, MaxInRatio, MaxLocks,
-        MaxOutRatio, MaxReserves, MaxTotalWeight, MaxWeight, MinLiquidity, MinWeight,
-        MinimumPeriod, SwapsPalletId,
+        BlockHashCount, DustAccountTest, ExitFee, GetNativeCurrencyId, LiquidityMiningPalletId,
+        MaxAssets, MaxInRatio, MaxLocks, MaxOutRatio, MaxReserves, MaxTotalWeight, MaxWeight,
+        MinLiquidity, MinWeight, MinimumPeriod, SwapsPalletId,
     },
     types::{
         AccountIdTest, Amount, Asset, Balance, BlockNumber, BlockTest, CurrencyId, Hash, Index,
@@ -23,8 +23,6 @@ use zeitgeist_primitives::{
 // parameter_types imported from zeitgeist_primitives
 parameter_types! {
     pub const ExistentialDeposit: u32 = 1;
-    pub const GetNativeCurrencyId: CurrencyId = Asset::Ztg;
-    pub DustAccount: AccountIdTest = PalletId(*b"orml/dst").into_account();
 }
 
 parameter_type_with_key! {
@@ -119,7 +117,7 @@ impl orml_tokens::Config for Runtime {
     type Event = Event;
     type ExistentialDeposits = ExistentialDeposits;
     type MaxLocks = MaxLocks;
-    type OnDust = orml_tokens::TransferDust<Runtime, DustAccount>;
+    type OnDust = orml_tokens::TransferDust<Runtime, DustAccountTest>;
     type WeightInfo = ();
 }
 


### PR DESCRIPTION
Basically removes explicit arithmetic operations (`+`, `/`, `*`, etc...)  where appropriated to avoid overflows and unexpected outcomes. 