### PR TITLE
Remove commented code

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1335,17 +1335,6 @@ mod pallet {
             market_id: &MarketIdOf<T>,
             market: &Market<T::AccountId, T::BlockNumber, MomentOf<T>>,
         ) -> Result<u64, DispatchError> {
-            // if the market was permissionless and not invalid, return `ValidityBond`.
-            // if market.creation == MarketCreation::Permissionless {
-            //     if report.outcome != 0 {
-            //         CurrencyOf::<T>::unreserve(&market.creator, T::ValidityBond::get());
-            //     } else {
-            //         // Give it to the treasury instead.
-            //         let (imbalance, _) =
-            //             CurrencyOf::<T>::slash_reserved(&market.creator, T::ValidityBond::get());
-            //         T::Slash::on_unbalanced(imbalance);
-            //     }
-            // }
             CurrencyOf::<T>::unreserve_named(&RESERVE_ID, &market.creator, T::ValidityBond::get());
 
             let disputes = Disputes::<T>::get(market_id);


### PR DESCRIPTION
This snippet has always been commented and does not contain valid logic. For example, `report.outcome` is not a number or `unreserve` already uses `T::ValidityBond::get()` regardless.

If permission-less markets need special handling, then future development on this area should be discussed on https://github.com/zeitgeistpm/zeitgeist/issues/250 or another issue. If not, https://github.com/zeitgeistpm/zeitgeist/issues/250 can be closed.