### PR TITLE
Fill `benchmark_metadata`

### DIFF
--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -27,7 +27,7 @@ pub fn dev_config(
                         get_from_seed::<nimbus_primitives::NimbusId>("Alice"),
                         crate::chain_spec::DEFAULT_STAKING_AMOUNT,
                     )],
-                    crowdloan_fund_pot: 100u128.saturating_mul(zeitgeist_primitives::constants::BASE),
+                    crowdloan_fund_pot: zeitgeist_primitives::constants::BASE.saturating_mul(100),
                     inflation_info: crate::chain_spec::DEFAULT_COLLATOR_INFLATION_INFO,
                     nominations: vec![],
                     parachain_id,

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -6,7 +6,7 @@ use crate::chain_spec::{
 };
 use sc_service::ChainType;
 use sp_core::sr25519;
-use zeitgeist_primitives::{constants::BASE, types::Balance};
+use zeitgeist_primitives::types::Balance;
 
 const INITIAL_BALANCE: Balance = Balance::MAX >> 4;
 
@@ -27,7 +27,7 @@ pub fn dev_config(
                         get_from_seed::<nimbus_primitives::NimbusId>("Alice"),
                         crate::chain_spec::DEFAULT_STAKING_AMOUNT,
                     )],
-                    crowdloan_fund_pot: 100u128.saturating_mul(BASE),
+                    crowdloan_fund_pot: 100u128.saturating_mul(zeitgeist_primitives::constants::BASE),
                     inflation_info: crate::chain_spec::DEFAULT_COLLATOR_INFLATION_INFO,
                     nominations: vec![],
                     parachain_id,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -538,8 +538,8 @@ impl_runtime_apis! {
             Vec<frame_support::traits::StorageInfo>,
         ) {
             use frame_benchmarking::{list_benchmark, Benchmarking, BenchmarkList};
-			use frame_support::traits::StorageInfoTrait;
-			use frame_system_benchmarking::Pallet as SystemBench;
+            use frame_support::traits::StorageInfoTrait;
+            use frame_system_benchmarking::Pallet as SystemBench;
 
             let mut list = Vec::<BenchmarkList>::new();
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -533,17 +533,28 @@ impl_runtime_apis! {
 
     #[cfg(feature = "runtime-benchmarks")]
     impl frame_benchmarking::Benchmark<Block> for Runtime {
-        fn benchmark_metadata(_: bool) -> (
+        fn benchmark_metadata(extra: bool) -> (
             Vec<frame_benchmarking::BenchmarkList>,
             Vec<frame_support::traits::StorageInfo>,
         ) {
-            use frame_benchmarking::BenchmarkList;
-            use frame_support::traits::StorageInfoTrait;
+            use frame_benchmarking::{list_benchmark, Benchmarking, BenchmarkList};
+			use frame_support::traits::StorageInfoTrait;
+			use frame_system_benchmarking::Pallet as SystemBench;
 
-            let list = Vec::<BenchmarkList>::new();
-            let storage_info = AllPalletsWithSystem::storage_info();
+            let mut list = Vec::<BenchmarkList>::new();
 
-            (list, storage_info)
+            list_benchmark!(list, extra, frame_system, SystemBench::<Runtime>);
+            list_benchmark!(list, extra, pallet_balances, Balances);
+            list_benchmark!(list, extra, pallet_timestamp, Timestamp);
+            list_benchmark!(list, extra, pallet_utility, Utility);
+            list_benchmark!(list, extra, zrml_swaps, Swaps);
+            list_benchmark!(list, extra, zrml_authorized, Authorized);
+            list_benchmark!(list, extra, zrml_court, Court);
+            list_benchmark!(list, extra, zrml_prediction_markets, PredictionMarkets);
+            list_benchmark!(list, extra, zrml_liquidity_mining, LiquidityMining);
+            list_benchmark!(list, extra, zrml_orderbook_v1, Orderbook);
+
+            (list, AllPalletsWithSystem::storage_info())
         }
 
         fn dispatch_benchmark(
@@ -553,6 +564,7 @@ impl_runtime_apis! {
                 add_benchmark, vec, BenchmarkBatch, Benchmarking, TrackedStorageKey, Vec
             };
             use frame_system_benchmarking::Pallet as SystemBench;
+
             impl frame_system_benchmarking::Config for Runtime {}
 
             let whitelist: Vec<TrackedStorageKey> = vec![


### PR DESCRIPTION
Turns out that the newly introduced benchmark method must be filled in order to actually run benchmarks

cc @sea212 
cc https://github.com/zeitgeistpm/zeitgeist/issues/313