### PR TITLE
[Proposal] Temporarily remove `orderbook-v1` from the runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12314,7 +12314,6 @@ dependencies = [
  "zrml-court",
  "zrml-liquidity-mining",
  "zrml-market-commons",
- "zrml-orderbook-v1",
  "zrml-prediction-markets",
  "zrml-rikiddo",
  "zrml-simple-disputes",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -80,7 +80,6 @@ zrml-authorized = { default-features = false, path = "../zrml/authorized" }
 zrml-court = { default-features = false, path = "../zrml/court" }
 zrml-liquidity-mining = { default-features = false, path = "../zrml/liquidity-mining" }
 zrml-market-commons = { default-features = false, path = "../zrml/market-commons" }
-zrml-orderbook-v1 = { default-features = false, path = "../zrml/orderbook-v1" }
 zrml-prediction-markets = { default-features = false, path = "../zrml/prediction-markets" }
 zrml-rikiddo = { default-features = false, path = "../zrml/rikiddo" }
 zrml-simple-disputes = { default-features = false, path = "../zrml/simple-disputes" }
@@ -136,7 +135,6 @@ runtime-benchmarks = [
     "zrml-authorized/runtime-benchmarks",
     "zrml-court/runtime-benchmarks",
     "zrml-liquidity-mining/runtime-benchmarks",
-    "zrml-orderbook-v1/runtime-benchmarks",
     "zrml-prediction-markets/runtime-benchmarks",
     "zrml-simple-disputes/runtime-benchmarks",
     "zrml-swaps/runtime-benchmarks",
@@ -219,7 +217,6 @@ std = [
 	"zrml-court/std",
 	"zrml-liquidity-mining/std",
 	"zrml-market-commons/std",
-	"zrml-orderbook-v1/std",
 	"zrml-prediction-markets/std",
 	"zrml-rikiddo/std",
 	"zrml-simple-disputes/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -612,7 +612,6 @@ impl_runtime_apis! {
             list_benchmark!(list, extra, zrml_court, Court);
             list_benchmark!(list, extra, zrml_prediction_markets, PredictionMarkets);
             list_benchmark!(list, extra, zrml_liquidity_mining, LiquidityMining);
-            list_benchmark!(list, extra, zrml_orderbook_v1, Orderbook);
 
             (list, AllPalletsWithSystem::storage_info())
         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -126,15 +126,14 @@ macro_rules! create_zeitgeist_runtime {
                 Tokens: orml_tokens::{Config<T>, Event<T>, Pallet, Storage} = 31,
 
                 // Zeitgeist
-                LiquidityMining: zrml_liquidity_mining::{Call, Config<T>, Event<T>, Pallet, Storage} = 40,
-                Orderbook: zrml_orderbook_v1::{Call, Event<T>, Pallet, Storage} = 41,
-                MarketCommons: zrml_market_commons::{Pallet, Storage} = 42,
-                Authorized: zrml_authorized::{Event<T>, Pallet, Storage} = 43,
-                Court: zrml_court::{Event<T>, Pallet, Storage} = 44,
-                Swaps: zrml_swaps::{Call, Event<T>, Pallet, Storage} = 45,
-                SimpleDisputes: zrml_simple_disputes::{Event<T>, Pallet, Storage} = 46,
+                MarketCommons: zrml_market_commons::{Pallet, Storage} = 40,
+                Authorized: zrml_authorized::{Event<T>, Pallet, Storage} = 41,
+                Court: zrml_court::{Event<T>, Pallet, Storage} = 42,
+                LiquidityMining: zrml_liquidity_mining::{Call, Config<T>, Event<T>, Pallet, Storage} = 43,
+                RikiddoSigmoidFeeMarketEma: zrml_rikiddo::<Instance1>::{Pallet, Storage} = 44,
+                SimpleDisputes: zrml_simple_disputes::{Event<T>, Pallet, Storage} = 45,
+                Swaps: zrml_swaps::{Call, Event<T>, Pallet, Storage} = 46,
                 PredictionMarkets: zrml_prediction_markets::{Call, Event<T>, Pallet, Storage} = 47,
-                RikiddoSigmoidFeeMarketEma: zrml_rikiddo::<Instance1>::{Pallet, Storage} = 48,
 
                 $($additional_pallets)*
             }
@@ -492,14 +491,6 @@ impl zrml_market_commons::Config for Runtime {
     type Timestamp = Timestamp;
 }
 
-impl zrml_orderbook_v1::Config for Runtime {
-    type Currency = Balances;
-    type Event = Event;
-    type MarketId = MarketId;
-    type Shares = Tokens;
-    type WeightInfo = zrml_orderbook_v1::weights::WeightInfo<Runtime>;
-}
-
 impl zrml_prediction_markets::Config for Runtime {
     type AdvisoryBond = AdvisoryBond;
     type ApprovalOrigin = EnsureRootOrMoreThanHalfOfAdvisoryCommittee;
@@ -668,7 +659,6 @@ impl_runtime_apis! {
             add_benchmark!(params, batches, zrml_court, Court);
             add_benchmark!(params, batches, zrml_prediction_markets, PredictionMarkets);
             add_benchmark!(params, batches, zrml_liquidity_mining, LiquidityMining);
-            add_benchmark!(params, batches, zrml_orderbook_v1, Orderbook);
 
             if batches.is_empty() {
                 return Err("Benchmark not found for this pallet.".into());


### PR DESCRIPTION
AFAICT, the orderbook pallet wasn't audited/reviewed and is not currently being used anywhere. Therefore, its temporary removal will reduce the surface area of potential attacks and slim down runtime weight.

In any case, this is just a proposal so feel free to close this issue if desired.