### PR TITLE
Re-name OutcomeReport to Outcome

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -6,7 +6,7 @@ mod asset;
 pub mod constants;
 mod market;
 mod max_runtime_usize;
-mod outcome_report;
+mod outcome;
 mod pool;
 mod pool_status;
 mod serde_wrapper;

--- a/primitives/src/market.rs
+++ b/primitives/src/market.rs
@@ -1,4 +1,4 @@
-use crate::{pool::ScoringRule, types::OutcomeReport};
+use crate::{pool::ScoringRule, types::Outcome};
 use alloc::vec::Vec;
 use core::ops::{Range, RangeInclusive};
 
@@ -37,7 +37,7 @@ pub struct Market<AI, BN, M> {
     /// The report of the market. Only `Some` if it has been reported.
     pub report: Option<Report<AI, BN>>,
     /// The resolved outcome.
-    pub resolved_outcome: Option<OutcomeReport>,
+    pub resolved_outcome: Option<Outcome>,
     /// See [`MarketDisputeMechanism`].
     pub mdm: MarketDisputeMechanism<AI>,
 }
@@ -80,7 +80,7 @@ pub enum MarketCreation {
 pub struct MarketDispute<AccountId, BlockNumber> {
     pub at: BlockNumber,
     pub by: AccountId,
-    pub outcome: OutcomeReport,
+    pub outcome: Outcome,
 }
 
 /// How a market should resolve disputes
@@ -182,7 +182,7 @@ pub enum MarketType {
 pub struct Report<AccountId, BlockNumber> {
     pub at: BlockNumber,
     pub by: AccountId,
-    pub outcome: OutcomeReport,
+    pub outcome: Outcome,
 }
 
 /// Contains a market id and the market period.

--- a/primitives/src/outcome.rs
+++ b/primitives/src/outcome.rs
@@ -11,7 +11,7 @@ use crate::types::CategoryIndex;
     parity_scale_codec::Decode,
     parity_scale_codec::Encode,
 )]
-pub enum OutcomeReport {
+pub enum Outcome {
     Categorical(CategoryIndex),
     Scalar(u128),
 }

--- a/primitives/src/traits/dispute_api.rs
+++ b/primitives/src/traits/dispute_api.rs
@@ -1,4 +1,4 @@
-use crate::{market::MarketDispute, outcome_report::OutcomeReport, types::Market};
+use crate::{market::MarketDispute, outcome::Outcome, types::Market};
 use frame_support::dispatch::DispatchResult;
 use sp_runtime::DispatchError;
 
@@ -23,5 +23,5 @@ pub trait DisputeApi {
         disputes: &[MarketDispute<Self::AccountId, Self::BlockNumber>],
         market_id: &Self::MarketId,
         market: &Market<Self::AccountId, Self::BlockNumber, Self::Moment>,
-    ) -> Result<OutcomeReport, DispatchError>;
+    ) -> Result<Outcome, DispatchError>;
 }

--- a/primitives/src/traits/swaps.rs
+++ b/primitives/src/traits/swaps.rs
@@ -1,6 +1,4 @@
-use crate::types::{
-    Asset, MarketType, OutcomeReport, Pool, PoolId, ResultWithWeightInfo, ScoringRule,
-};
+use crate::types::{Asset, MarketType, Outcome, Pool, PoolId, ResultWithWeightInfo, ScoringRule};
 use alloc::vec::Vec;
 use frame_support::dispatch::{DispatchError, Weight};
 
@@ -108,7 +106,7 @@ pub trait Swaps<AccountId> {
     fn set_pool_as_stale(
         market_type: &MarketType,
         pool_id: PoolId,
-        outcome_report: &OutcomeReport,
+        outcome_report: &Outcome,
         winner_payout_account: &AccountId,
     ) -> Result<Weight, DispatchError>;
 }

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -1,6 +1,6 @@
 pub use crate::{
-    asset::*, market::*, max_runtime_usize::*, outcome_report::OutcomeReport, pool::*,
-    pool_status::PoolStatus, serde_wrapper::*,
+    asset::*, market::*, max_runtime_usize::*, outcome::Outcome, pool::*, pool_status::PoolStatus,
+    serde_wrapper::*,
 };
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Result, Unstructured};

--- a/zrml/authorized/src/benchmarks.rs
+++ b/zrml/authorized/src/benchmarks.rs
@@ -9,7 +9,7 @@ use crate::Pallet as Court;
 use crate::{market_mock, Call, Config, Pallet};
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_system::RawOrigin;
-use zeitgeist_primitives::types::OutcomeReport;
+use zeitgeist_primitives::types::Outcome;
 use zrml_market_commons::MarketCommonsPalletApi;
 
 benchmarks! {
@@ -17,7 +17,7 @@ benchmarks! {
         let caller: T::AccountId = whitelisted_caller();
         let market = market_mock::<T>(caller.clone());
         T::MarketCommons::push_market(market).unwrap();
-    }: _(RawOrigin::Signed(caller), OutcomeReport::Scalar(1))
+    }: _(RawOrigin::Signed(caller), Outcome::Scalar(1))
 }
 
 impl_benchmark_test_suite!(Court, crate::mock::ExtBuilder::default().build(), crate::mock::Runtime);

--- a/zrml/authorized/src/lib.rs
+++ b/zrml/authorized/src/lib.rs
@@ -27,7 +27,7 @@ mod pallet {
     use sp_runtime::DispatchError;
     use zeitgeist_primitives::{
         traits::DisputeApi,
-        types::{Market, MarketDispute, MarketDisputeMechanism, OutcomeReport},
+        types::{Market, MarketDispute, MarketDisputeMechanism, Outcome},
     };
     use zrml_market_commons::MarketCommonsPalletApi;
 
@@ -44,10 +44,7 @@ mod pallet {
         /// Overwrites already provided outcomes for the same market and account.
         #[frame_support::transactional]
         #[pallet::weight(T::WeightInfo::authorize_market_outcome())]
-        pub fn authorize_market_outcome(
-            origin: OriginFor<T>,
-            outcome: OutcomeReport,
-        ) -> DispatchResult {
+        pub fn authorize_market_outcome(origin: OriginFor<T>, outcome: Outcome) -> DispatchResult {
             let who = ensure_signed(origin)?;
             let markets = T::MarketCommons::markets();
             let market_id = if let Some(rslt) = markets.iter().find(|el| {
@@ -144,7 +141,7 @@ mod pallet {
             _: &[MarketDispute<Self::AccountId, Self::BlockNumber>],
             market_id: &Self::MarketId,
             market: &Market<Self::AccountId, Self::BlockNumber, MomentOf<T>>,
-        ) -> Result<OutcomeReport, DispatchError> {
+        ) -> Result<Outcome, DispatchError> {
             let market_ai = if let MarketDisputeMechanism::Authorized(ref el) = market.mdm {
                 el
             } else {
@@ -174,7 +171,7 @@ mod pallet {
         MarketIdOf<T>,
         Blake2_128Concat,
         T::AccountId,
-        OutcomeReport,
+        Outcome,
     >;
 }
 

--- a/zrml/authorized/src/tests.rs
+++ b/zrml/authorized/src/tests.rs
@@ -8,7 +8,7 @@ use crate::{
 use frame_support::assert_noop;
 use zeitgeist_primitives::{
     traits::DisputeApi,
-    types::{MarketDisputeMechanism, OutcomeReport},
+    types::{MarketDisputeMechanism, Outcome},
 };
 use zrml_market_commons::Markets;
 
@@ -16,9 +16,8 @@ use zrml_market_commons::Markets;
 fn authorize_market_outcome_inserts_a_new_outcome() {
     ExtBuilder::default().build().execute_with(|| {
         Markets::<Runtime>::insert(0, market_mock::<Runtime>(ALICE));
-        Authorized::authorize_market_outcome(Origin::signed(ALICE), OutcomeReport::Scalar(1))
-            .unwrap();
-        assert_eq!(Outcomes::<Runtime>::get(0, ALICE).unwrap(), OutcomeReport::Scalar(1));
+        Authorized::authorize_market_outcome(Origin::signed(ALICE), Outcome::Scalar(1)).unwrap();
+        assert_eq!(Outcomes::<Runtime>::get(0, ALICE).unwrap(), Outcome::Scalar(1));
     });
 }
 
@@ -26,7 +25,7 @@ fn authorize_market_outcome_inserts_a_new_outcome() {
 fn authorize_market_outcome_forbids_accounts_without_an_authorized_market() {
     ExtBuilder::default().build().execute_with(|| {
         assert_noop!(
-            Authorized::authorize_market_outcome(Origin::signed(ALICE), OutcomeReport::Scalar(1)),
+            Authorized::authorize_market_outcome(Origin::signed(ALICE), Outcome::Scalar(1)),
             Error::<Runtime>::AccountIsNotLinkedToAnyAuthorizedMarket
         );
     });
@@ -36,13 +35,12 @@ fn authorize_market_outcome_forbids_accounts_without_an_authorized_market() {
 fn authorize_market_outcome_forbids_more_than_one_outcome_for_a_market() {
     ExtBuilder::default().build().execute_with(|| {
         Markets::<Runtime>::insert(0, market_mock::<Runtime>(ALICE));
-        Authorized::authorize_market_outcome(Origin::signed(ALICE), OutcomeReport::Scalar(1))
-            .unwrap();
+        Authorized::authorize_market_outcome(Origin::signed(ALICE), Outcome::Scalar(1)).unwrap();
         Markets::<Runtime>::mutate(0, |el| {
             el.as_mut().unwrap().mdm = MarketDisputeMechanism::Authorized(BOB);
         });
         assert_noop!(
-            Authorized::authorize_market_outcome(Origin::signed(BOB), OutcomeReport::Scalar(1)),
+            Authorized::authorize_market_outcome(Origin::signed(BOB), Outcome::Scalar(1)),
             Error::<Runtime>::MarketsCanNotHaveMoreThanOneAuthorizedAccount
         );
     });
@@ -87,8 +85,7 @@ fn on_resolution_removes_stored_outcomes() {
     ExtBuilder::default().build().execute_with(|| {
         let market = market_mock::<Runtime>(ALICE);
         Markets::<Runtime>::insert(0, &market);
-        Authorized::authorize_market_outcome(Origin::signed(ALICE), OutcomeReport::Scalar(1))
-            .unwrap();
+        Authorized::authorize_market_outcome(Origin::signed(ALICE), Outcome::Scalar(1)).unwrap();
         let _ = Authorized::on_resolution(&[], &0, &market).unwrap();
         assert_eq!(Outcomes::<Runtime>::get(0, ALICE), None);
     });
@@ -99,8 +96,7 @@ fn on_resolution_returns_the_canonical_outcome() {
     ExtBuilder::default().build().execute_with(|| {
         let market = market_mock::<Runtime>(ALICE);
         Markets::<Runtime>::insert(0, &market);
-        Authorized::authorize_market_outcome(Origin::signed(ALICE), OutcomeReport::Scalar(1))
-            .unwrap();
-        assert_eq!(Authorized::on_resolution(&[], &0, &market).unwrap(), OutcomeReport::Scalar(1));
+        Authorized::authorize_market_outcome(Origin::signed(ALICE), Outcome::Scalar(1)).unwrap();
+        assert_eq!(Authorized::on_resolution(&[], &0, &market).unwrap(), Outcome::Scalar(1));
     });
 }

--- a/zrml/court/src/benchmarks.rs
+++ b/zrml/court/src/benchmarks.rs
@@ -11,7 +11,7 @@ use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_call
 use frame_support::{dispatch::UnfilteredDispatchable, traits::Currency};
 use frame_system::RawOrigin;
 use sp_runtime::traits::Bounded;
-use zeitgeist_primitives::types::OutcomeReport;
+use zeitgeist_primitives::types::Outcome;
 
 fn deposit<T>(caller: &T::AccountId)
 where
@@ -44,7 +44,7 @@ benchmarks! {
     vote {
         let caller: T::AccountId = whitelisted_caller();
         let market_id = Default::default();
-        let outcome = OutcomeReport::Scalar(u128::MAX);
+        let outcome = Outcome::Scalar(u128::MAX);
         deposit_and_join_court::<T>(&caller);
     }: _(RawOrigin::Signed(caller), market_id, outcome)
 }

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -47,7 +47,7 @@ mod pallet {
     use zeitgeist_primitives::{
         constants::CourtPalletId,
         traits::DisputeApi,
-        types::{Market, MarketDispute, MarketDisputeMechanism, OutcomeReport},
+        types::{Market, MarketDispute, MarketDisputeMechanism, Outcome},
     };
     use zrml_market_commons::MarketCommonsPalletApi;
 
@@ -108,7 +108,7 @@ mod pallet {
         pub fn vote(
             origin: OriginFor<T>,
             market_id: MarketIdOf<T>,
-            outcome: OutcomeReport,
+            outcome: Outcome,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
             if Jurors::<T>::get(&who).is_none() {
@@ -267,12 +267,12 @@ mod pallet {
                 T::AccountId,
                 Juror,
                 T::BlockNumber,
-                Option<&(T::BlockNumber, OutcomeReport)>,
+                Option<&(T::BlockNumber, Outcome)>,
             )],
             mut cb: F,
-        ) -> Result<Vec<(&'b T::AccountId, &'b OutcomeReport)>, DispatchError>
+        ) -> Result<Vec<(&'b T::AccountId, &'b Outcome)>, DispatchError>
         where
-            F: FnMut(&OutcomeReport) -> bool,
+            F: FnMut(&Outcome) -> bool,
             'a: 'b,
         {
             let mut valid_winners_and_losers = Vec::with_capacity(requested_jurors.len());
@@ -355,8 +355,8 @@ mod pallet {
 
         // Every juror that not voted on the first or second most voted outcome are slashed.
         fn slash_losers_to_award_winners(
-            valid_winners_and_losers: &[(&T::AccountId, &OutcomeReport)],
-            winner_outcome: &OutcomeReport,
+            valid_winners_and_losers: &[(&T::AccountId, &Outcome)],
+            winner_outcome: &Outcome,
         ) -> DispatchResult {
             let mut total_incentives = BalanceOf::<T>::from(0u8);
             let mut total_winners = BalanceOf::<T>::from(0u8);
@@ -392,9 +392,9 @@ mod pallet {
 
         // For market resolution based on the votes of a market
         fn two_best_outcomes(
-            votes: &[(T::AccountId, (T::BlockNumber, OutcomeReport))],
-        ) -> Result<(OutcomeReport, Option<OutcomeReport>), DispatchError> {
-            let mut scores = BTreeMap::<OutcomeReport, u32>::new();
+            votes: &[(T::AccountId, (T::BlockNumber, Outcome))],
+        ) -> Result<(Outcome, Option<Outcome>), DispatchError> {
+            let mut scores = BTreeMap::<Outcome, u32>::new();
 
             for (_, (_, outcome_report)) in votes {
                 if let Some(el) = scores.get_mut(outcome_report) {
@@ -492,7 +492,7 @@ mod pallet {
             _: &[MarketDispute<Self::AccountId, Self::BlockNumber>],
             market_id: &Self::MarketId,
             market: &Market<Self::AccountId, Self::BlockNumber, MomentOf<T>>,
-        ) -> Result<OutcomeReport, DispatchError> {
+        ) -> Result<Outcome, DispatchError> {
             if market.mdm != MarketDisputeMechanism::Court {
                 return Err(Error::<T>::MarketDoesNotHaveCourtMechanism.into());
             }
@@ -548,6 +548,6 @@ mod pallet {
         MarketIdOf<T>,
         Blake2_128Concat,
         T::AccountId,
-        (T::BlockNumber, OutcomeReport),
+        (T::BlockNumber, Outcome),
     >;
 }

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -18,7 +18,7 @@ use zeitgeist_primitives::{
     traits::DisputeApi,
     types::{
         Market, MarketCreation, MarketDisputeMechanism, MarketPeriod, MarketStatus, MarketType,
-        OutcomeReport, ScoringRule,
+        Outcome, ScoringRule,
     },
 };
 
@@ -155,9 +155,9 @@ fn on_resolution_awards_winners_and_slashes_losers() {
         Court::join_court(Origin::signed(BOB)).unwrap();
         Court::join_court(Origin::signed(CHARLIE)).unwrap();
         Court::on_dispute(&[], &0, &DEFAULT_MARKET).unwrap();
-        Court::vote(Origin::signed(ALICE), 0, OutcomeReport::Scalar(1)).unwrap();
-        Court::vote(Origin::signed(BOB), 0, OutcomeReport::Scalar(2)).unwrap();
-        Court::vote(Origin::signed(CHARLIE), 0, OutcomeReport::Scalar(3)).unwrap();
+        Court::vote(Origin::signed(ALICE), 0, Outcome::Scalar(1)).unwrap();
+        Court::vote(Origin::signed(BOB), 0, Outcome::Scalar(2)).unwrap();
+        Court::vote(Origin::signed(CHARLIE), 0, Outcome::Scalar(3)).unwrap();
         let _ = Court::on_resolution(&[], &0, &DEFAULT_MARKET).unwrap();
         assert_eq!(Balances::free_balance(ALICE), 998 * BASE + 3 * BASE);
         assert_eq!(Balances::reserved_balance_named(&RESERVE_ID, &ALICE), 2 * BASE);
@@ -176,11 +176,11 @@ fn on_resolution_decides_market_outcome_based_on_the_majority() {
         Court::join_court(Origin::signed(BOB)).unwrap();
         Court::join_court(Origin::signed(CHARLIE)).unwrap();
         Court::on_dispute(&[], &0, &DEFAULT_MARKET).unwrap();
-        Court::vote(Origin::signed(ALICE), 0, OutcomeReport::Scalar(1)).unwrap();
-        Court::vote(Origin::signed(BOB), 0, OutcomeReport::Scalar(1)).unwrap();
-        Court::vote(Origin::signed(CHARLIE), 0, OutcomeReport::Scalar(2)).unwrap();
+        Court::vote(Origin::signed(ALICE), 0, Outcome::Scalar(1)).unwrap();
+        Court::vote(Origin::signed(BOB), 0, Outcome::Scalar(1)).unwrap();
+        Court::vote(Origin::signed(CHARLIE), 0, Outcome::Scalar(2)).unwrap();
         let outcome = Court::on_resolution(&[], &0, &DEFAULT_MARKET).unwrap();
-        assert_eq!(outcome, OutcomeReport::Scalar(1))
+        assert_eq!(outcome, Outcome::Scalar(1))
     });
 }
 
@@ -190,7 +190,7 @@ fn on_resolution_sets_late_jurors_as_tardy() {
         setup_blocks(1..2);
         Court::join_court(Origin::signed(ALICE)).unwrap();
         Court::join_court(Origin::signed(BOB)).unwrap();
-        Court::vote(Origin::signed(ALICE), 0, OutcomeReport::Scalar(1)).unwrap();
+        Court::vote(Origin::signed(ALICE), 0, Outcome::Scalar(1)).unwrap();
         Court::on_dispute(&[], &0, &DEFAULT_MARKET).unwrap();
         let _ = Court::on_resolution(&[], &0, &DEFAULT_MARKET).unwrap();
         assert_eq!(Jurors::<Runtime>::get(ALICE).unwrap().status, JurorStatus::Ok);
@@ -206,9 +206,9 @@ fn on_resolution_sets_jurors_that_voted_on_the_second_most_voted_outcome_as_tard
         Court::join_court(Origin::signed(BOB)).unwrap();
         Court::join_court(Origin::signed(CHARLIE)).unwrap();
         Court::on_dispute(&[], &0, &DEFAULT_MARKET).unwrap();
-        Court::vote(Origin::signed(ALICE), 0, OutcomeReport::Scalar(1)).unwrap();
-        Court::vote(Origin::signed(BOB), 0, OutcomeReport::Scalar(1)).unwrap();
-        Court::vote(Origin::signed(CHARLIE), 0, OutcomeReport::Scalar(2)).unwrap();
+        Court::vote(Origin::signed(ALICE), 0, Outcome::Scalar(1)).unwrap();
+        Court::vote(Origin::signed(BOB), 0, Outcome::Scalar(1)).unwrap();
+        Court::vote(Origin::signed(CHARLIE), 0, Outcome::Scalar(2)).unwrap();
         let _ = Court::on_resolution(&[], &0, &DEFAULT_MARKET).unwrap();
         assert_eq!(Jurors::<Runtime>::get(CHARLIE).unwrap().status, JurorStatus::Tardy);
     });
@@ -221,7 +221,7 @@ fn on_resolution_punishes_tardy_jurors_that_failed_to_vote_a_second_time() {
         Court::join_court(Origin::signed(ALICE)).unwrap();
         Court::join_court(Origin::signed(BOB)).unwrap();
         Court::set_stored_juror_as_tardy(&BOB).unwrap();
-        Court::vote(Origin::signed(ALICE), 0, OutcomeReport::Scalar(1)).unwrap();
+        Court::vote(Origin::signed(ALICE), 0, Outcome::Scalar(1)).unwrap();
         Court::on_dispute(&[], &0, &DEFAULT_MARKET).unwrap();
         let _ = Court::on_resolution(&[], &0, &DEFAULT_MARKET).unwrap();
         let join_court_stake = 40000000000;
@@ -240,9 +240,9 @@ fn on_resolution_removes_requested_jurors_and_votes() {
         Court::join_court(Origin::signed(BOB)).unwrap();
         Court::join_court(Origin::signed(CHARLIE)).unwrap();
         Court::on_dispute(&[], &0, &DEFAULT_MARKET).unwrap();
-        Court::vote(Origin::signed(ALICE), 0, OutcomeReport::Scalar(1)).unwrap();
-        Court::vote(Origin::signed(BOB), 0, OutcomeReport::Scalar(1)).unwrap();
-        Court::vote(Origin::signed(CHARLIE), 0, OutcomeReport::Scalar(2)).unwrap();
+        Court::vote(Origin::signed(ALICE), 0, Outcome::Scalar(1)).unwrap();
+        Court::vote(Origin::signed(BOB), 0, Outcome::Scalar(1)).unwrap();
+        Court::vote(Origin::signed(CHARLIE), 0, Outcome::Scalar(2)).unwrap();
         let _ = Court::on_resolution(&[], &0, &DEFAULT_MARKET).unwrap();
         assert_eq!(RequestedJurors::<Runtime>::iter().count(), 0);
         assert_eq!(Votes::<Runtime>::iter().count(), 0);
@@ -302,7 +302,7 @@ fn random_jurors_returns_a_subset_of_jurors() {
 fn vote_will_not_accept_unknown_accounts() {
     ExtBuilder::default().build().execute_with(|| {
         assert_noop!(
-            Court::vote(Origin::signed(ALICE), 0, OutcomeReport::Scalar(0)),
+            Court::vote(Origin::signed(ALICE), 0, Outcome::Scalar(0)),
             Error::<Runtime>::OnlyJurorsCanVote
         );
     });
@@ -312,8 +312,8 @@ fn vote_will_not_accept_unknown_accounts() {
 fn vote_will_stored_outcome_from_a_juror() {
     ExtBuilder::default().build().execute_with(|| {
         let _ = Court::join_court(Origin::signed(ALICE));
-        let _ = Court::vote(Origin::signed(ALICE), 0, OutcomeReport::Scalar(0));
-        assert_eq!(Votes::<Runtime>::get(ALICE, 0).unwrap(), (0, OutcomeReport::Scalar(0)));
+        let _ = Court::vote(Origin::signed(ALICE), 0, Outcome::Scalar(0));
+        assert_eq!(Votes::<Runtime>::get(ALICE, 0).unwrap(), (0, Outcome::Scalar(0)));
     });
 }
 

--- a/zrml/prediction-markets/fuzz/pm_full_workflow.rs
+++ b/zrml/prediction-markets/fuzz/pm_full_workflow.rs
@@ -5,7 +5,7 @@ use core::ops::{Range, RangeInclusive};
 use frame_support::traits::Hooks;
 use libfuzzer_sys::fuzz_target;
 use zeitgeist_primitives::types::{
-    MarketCreation, MarketDisputeMechanism, MarketPeriod, MultiHash, OutcomeReport, ScoringRule,
+    MarketCreation, MarketDisputeMechanism, MarketPeriod, MultiHash, Outcome, ScoringRule,
 };
 use zrml_prediction_markets::mock::{ExtBuilder, Origin, PredictionMarkets, System};
 
@@ -105,10 +105,6 @@ fn market_dispute_mechanism(seed: u8) -> MarketDisputeMechanism<u128> {
 }
 
 #[inline]
-fn outcome(seed: u128) -> OutcomeReport {
-    if seed % 2 == 0 {
-        OutcomeReport::Categorical(seed as _)
-    } else {
-        OutcomeReport::Scalar(seed as _)
-    }
+fn outcome(seed: u128) -> Outcome {
+    if seed % 2 == 0 { Outcome::Categorical(seed as _) } else { Outcome::Scalar(seed as _) }
 }

--- a/zrml/prediction-markets/src/benchmarks.rs
+++ b/zrml/prediction-markets/src/benchmarks.rs
@@ -20,7 +20,7 @@ use zeitgeist_primitives::{
     traits::DisputeApi,
     types::{
         Asset, MarketCreation, MarketDisputeMechanism, MarketPeriod, MarketStatus, MarketType,
-        MaxRuntimeUsize, MultiHash, OutcomeReport, ScalarPosition, ScoringRule, SubsidyUntil,
+        MaxRuntimeUsize, MultiHash, Outcome, ScalarPosition, ScoringRule, SubsidyUntil,
     },
 };
 use zrml_market_commons::MarketCommonsPalletApi;
@@ -92,7 +92,7 @@ fn create_market_common<T: Config>(
 fn create_close_and_report_market<T: Config>(
     permission: MarketCreation,
     options: MarketType,
-    outcome: OutcomeReport,
+    outcome: Outcome,
 ) -> Result<(T::AccountId, MarketIdOf<T>), &'static str> {
     let (caller, marketid) = create_market_common::<T>(permission, options, ScoringRule::CPMM)?;
     let _ = Call::<T>::admin_move_market_to_closed(marketid)
@@ -134,7 +134,7 @@ fn setup_resolve_common_categorical<T: Config>(
     let (caller, marketid) = create_close_and_report_market::<T>(
         MarketCreation::Permissionless,
         MarketType::Categorical(categories),
-        OutcomeReport::Categorical(categories.saturating_sub(1)),
+        Outcome::Categorical(categories.saturating_sub(1)),
     )?;
     let _ = generate_accounts_with_assets::<T>(
         acc_total,
@@ -153,12 +153,12 @@ fn setup_redeem_shares_common<T: Config>(
         market_type.clone(),
         ScoringRule::CPMM,
     )?;
-    let outcome: OutcomeReport;
+    let outcome: Outcome;
 
     if let MarketType::Categorical(categories) = market_type {
-        outcome = OutcomeReport::Categorical(categories.saturating_sub(1));
+        outcome = Outcome::Categorical(categories.saturating_sub(1));
     } else if let MarketType::Scalar(range) = market_type {
-        outcome = OutcomeReport::Scalar(*range.end());
+        outcome = Outcome::Scalar(*range.end());
     } else {
         panic!("setup_redeem_shares_common: Unsupported market type: {:?}", market_type);
     }
@@ -186,7 +186,7 @@ fn setup_resolve_common_scalar<T: Config>(
     let (caller, marketid) = create_close_and_report_market::<T>(
         MarketCreation::Permissionless,
         MarketType::Scalar(0u128..=u128::MAX),
-        OutcomeReport::Scalar(u128::MAX),
+        Outcome::Scalar(u128::MAX),
     )?;
     let _ = generate_accounts_with_assets::<T>(
         acc_total,
@@ -328,7 +328,7 @@ benchmarks! {
         let (caller, marketid) = create_close_and_report_market::<T>(
             MarketCreation::Permissionless,
             MarketType::Scalar(0u128..=u128::MAX),
-            OutcomeReport::Scalar(42)
+            Outcome::Scalar(42)
         )?;
     }:  {
         let origin = caller.clone();
@@ -459,7 +459,7 @@ benchmarks! {
             MarketType::Categorical(T::MaxCategories::get()),
             ScoringRule::CPMM
         )?;
-        let outcome = OutcomeReport::Categorical(0);
+        let outcome = Outcome::Categorical(0);
         let approval_origin = T::ApprovalOrigin::successful_origin();
         let _ = Call::<T>::admin_move_market_to_closed(marketid)
             .dispatch_bypass_filter(approval_origin)?;

--- a/zrml/simple-disputes/src/lib.rs
+++ b/zrml/simple-disputes/src/lib.rs
@@ -25,7 +25,7 @@ mod pallet {
     use sp_runtime::DispatchError;
     use zeitgeist_primitives::{
         traits::DisputeApi,
-        types::{Market, MarketDispute, MarketDisputeMechanism, MarketStatus, OutcomeReport},
+        types::{Market, MarketDispute, MarketDisputeMechanism, MarketStatus, Outcome},
     };
     use zrml_market_commons::MarketCommonsPalletApi;
 
@@ -98,7 +98,7 @@ mod pallet {
             disputes: &[MarketDispute<Self::AccountId, Self::BlockNumber>],
             _: &Self::MarketId,
             market: &Market<Self::AccountId, Self::BlockNumber, MomentOf<T>>,
-        ) -> Result<OutcomeReport, DispatchError> {
+        ) -> Result<Outcome, DispatchError> {
             if market.mdm != MarketDisputeMechanism::SimpleDisputes {
                 return Err(Error::<T>::MarketDoesNotHaveSimpleDisputesMechanism.into());
             }

--- a/zrml/simple-disputes/src/tests.rs
+++ b/zrml/simple-disputes/src/tests.rs
@@ -9,7 +9,7 @@ use zeitgeist_primitives::{
     traits::DisputeApi,
     types::{
         Market, MarketCreation, MarketDispute, MarketDisputeMechanism, MarketPeriod, MarketStatus,
-        MarketType, OutcomeReport, Report, ScoringRule,
+        MarketType, Outcome, Report, ScoringRule,
     },
 };
 
@@ -55,7 +55,7 @@ fn on_resolution_denies_non_simple_disputes_markets() {
 #[test]
 fn on_resolution_sets_reported_outcome_of_reported_markets_as_the_canonical_outcome() {
     ExtBuilder.build().execute_with(|| {
-        let outcome = OutcomeReport::Scalar(3);
+        let outcome = Outcome::Scalar(3);
         let mut market = DEFAULT_MARKET;
         market.status = MarketStatus::Reported;
         market.report = Some(Report { at: 0, by: 0, outcome: outcome.clone() });
@@ -69,8 +69,8 @@ fn on_resolution_sets_the_last_dispute_of_disputed_markets_as_the_canonical_outc
         let mut market = DEFAULT_MARKET;
         market.status = MarketStatus::Disputed;
         let disputes = [
-            MarketDispute { at: 0, by: 0, outcome: OutcomeReport::Scalar(0) },
-            MarketDispute { at: 0, by: 0, outcome: OutcomeReport::Scalar(20) },
+            MarketDispute { at: 0, by: 0, outcome: Outcome::Scalar(0) },
+            MarketDispute { at: 0, by: 0, outcome: Outcome::Scalar(20) },
         ];
         assert_eq!(
             &SimpleDisputes::on_resolution(&disputes, &0, &market).unwrap(),

--- a/zrml/swaps/src/benchmarks.rs
+++ b/zrml/swaps/src/benchmarks.rs
@@ -16,7 +16,7 @@ use sp_runtime::traits::{SaturatedConversion, Zero};
 use zeitgeist_primitives::{
     constants::BASE,
     traits::Swaps as _,
-    types::{Asset, MarketType, OutcomeReport, ScoringRule},
+    types::{Asset, MarketType, Outcome, ScoringRule},
 };
 
 // Generates `acc_total` accounts, of which `acc_asset` account do own `asset`
@@ -116,7 +116,7 @@ benchmarks! {
     admin_set_pool_as_stale {
         let caller: T::AccountId = whitelisted_caller();
         let (pool_id, ..) = bench_create_pool::<T>(caller, Some(T::MaxAssets::get().into()), None, ScoringRule::CPMM, false);
-    }: _(RawOrigin::Root, MarketType::Categorical(0), pool_id as _, OutcomeReport::Categorical(0))
+    }: _(RawOrigin::Root, MarketType::Categorical(0), pool_id as _, Outcome::Categorical(0))
 
     end_subsidy_phase {
         // Total assets
@@ -301,7 +301,7 @@ benchmarks! {
             false
         );
     }: {
-        Pallet::<T>::set_pool_as_stale(&MarketType::Categorical(a as u16), pool_id, &OutcomeReport::Categorical(0), &Default::default())?;
+        Pallet::<T>::set_pool_as_stale(&MarketType::Categorical(a as u16), pool_id, &Outcome::Categorical(0), &Default::default())?;
     }
 
     swap_exact_amount_in_cpmm {

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -65,7 +65,7 @@ mod pallet {
         constants::BASE,
         traits::{MarketId, Swaps, ZeitgeistMultiReservableCurrency},
         types::{
-            Asset, MarketType, OutcomeReport, Pool, PoolId, PoolStatus, ResultWithWeightInfo,
+            Asset, MarketType, Outcome, Pool, PoolId, PoolStatus, ResultWithWeightInfo,
             ScoringRule, SerdeWrapper,
         },
     };
@@ -87,7 +87,7 @@ mod pallet {
             origin: OriginFor<T>,
             market_type: MarketType,
             pool_id: PoolId,
-            outcome_report: OutcomeReport,
+            outcome_report: Outcome,
         ) -> DispatchResult {
             ensure_root(origin)?;
             Self::set_pool_as_stale(&market_type, pool_id, &outcome_report, &Default::default())?;
@@ -1658,7 +1658,7 @@ mod pallet {
         fn set_pool_as_stale(
             market_type: &MarketType,
             pool_id: PoolId,
-            outcome_report: &OutcomeReport,
+            outcome_report: &Outcome,
             winner_payout_account: &T::AccountId,
         ) -> Result<Weight, DispatchError> {
             let mut extra_weight = 0;
@@ -1677,7 +1677,7 @@ mod pallet {
                 if let MarketType::Categorical(_) = market_type {
                     let base_asset_or_default = base_asset.unwrap_or(Asset::Ztg);
 
-                    if let OutcomeReport::Categorical(winning_asset_idx) = outcome_report {
+                    if let Outcome::Categorical(winning_asset_idx) = outcome_report {
                         pool.assets.retain(|el| {
                             if let Asset::CategoricalOutcome(_, idx) = *el {
                                 if idx == *winning_asset_idx {

--- a/zrml/swaps/src/tests.rs
+++ b/zrml/swaps/src/tests.rs
@@ -11,9 +11,7 @@ use sp_runtime::SaturatedConversion;
 use zeitgeist_primitives::{
     constants::BASE,
     traits::Swaps as _,
-    types::{
-        AccountIdTest, Asset, MarketId, MarketType, OutcomeReport, PoolId, PoolStatus, ScoringRule,
-    },
+    types::{AccountIdTest, Asset, MarketId, MarketType, Outcome, PoolId, PoolStatus, ScoringRule},
 };
 use zrml_rikiddo::traits::RikiddoMVPallet;
 
@@ -352,7 +350,7 @@ fn ensure_which_operations_can_be_called_depending_on_the_pool_status() {
         assert_ok!(Swaps::set_pool_as_stale(
             &MarketType::Categorical(0),
             0,
-            &OutcomeReport::Categorical(if let Asset::CategoricalOutcome(_, idx) = ASSET_A {
+            &Outcome::Categorical(if let Asset::CategoricalOutcome(_, idx) = ASSET_A {
                 idx
             } else {
                 0
@@ -478,7 +476,7 @@ fn only_root_can_call_admin_set_pool_as_stale() {
                 alice_signed(),
                 MarketType::Categorical(0),
                 0,
-                OutcomeReport::Categorical(idx)
+                Outcome::Categorical(idx)
             ),
             BadOrigin
         );
@@ -489,7 +487,7 @@ fn only_root_can_call_admin_set_pool_as_stale() {
             Origin::root(),
             MarketType::Categorical(0),
             0,
-            OutcomeReport::Categorical(idx)
+            Outcome::Categorical(idx)
         ),);
     });
 }
@@ -788,7 +786,7 @@ fn set_pool_as_stale_leaves_only_correct_assets() {
             Swaps::set_pool_as_stale(
                 &MarketType::Categorical(1337),
                 pool_id,
-                &OutcomeReport::Categorical(1337),
+                &Outcome::Categorical(1337),
                 &Default::default()
             ),
             crate::Error::<Runtime>::WinningAssetNotFound
@@ -799,7 +797,7 @@ fn set_pool_as_stale_leaves_only_correct_assets() {
         assert_ok!(Swaps::set_pool_as_stale(
             &MarketType::Categorical(4),
             pool_id,
-            &OutcomeReport::Categorical(cat_idx),
+            &Outcome::Categorical(cat_idx),
             &Default::default()
         ));
 
@@ -820,7 +818,7 @@ fn set_pool_as_stale_handles_rikiddo_pools_properly() {
             Swaps::set_pool_as_stale(
                 &MarketType::Categorical(4),
                 pool_id,
-                &OutcomeReport::Categorical(cat_idx),
+                &Outcome::Categorical(cat_idx),
                 &Default::default()
             ),
             crate::Error::<Runtime>::InvalidStateTransition
@@ -834,7 +832,7 @@ fn set_pool_as_stale_handles_rikiddo_pools_properly() {
         assert_ok!(Swaps::set_pool_as_stale(
             &MarketType::Categorical(4),
             pool_id,
-            &OutcomeReport::Categorical(cat_idx),
+            &Outcome::Categorical(cat_idx),
             &Default::default()
         ));
 


### PR DESCRIPTION
`OutcomeReport` was originally named `Outcome` and its renaming was a over-sighted mistake. Changing back to `Outcome`.

cc @saboonikhil 