### PR TITLE
Allow external calls for the authorized and court pallets

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -126,8 +126,8 @@ macro_rules! create_zeitgeist_runtime {
 
                 // Zeitgeist
                 MarketCommons: zrml_market_commons::{Pallet, Storage} = 40,
-                Authorized: zrml_authorized::{Event<T>, Pallet, Storage} = 41,
-                Court: zrml_court::{Event<T>, Pallet, Storage} = 42,
+                Authorized: zrml_authorized::{Call, Event<T>, Pallet, Storage} = 41,
+                Court: zrml_court::{Call, Event<T>, Pallet, Storage} = 42,
                 LiquidityMining: zrml_liquidity_mining::{Call, Config<T>, Event<T>, Pallet, Storage} = 43,
                 RikiddoSigmoidFeeMarketEma: zrml_rikiddo::<Instance1>::{Pallet, Storage} = 44,
                 SimpleDisputes: zrml_simple_disputes::{Event<T>, Pallet, Storage} = 45,


### PR DESCRIPTION
These pallets are meant to be called by accounts to actually work with the pm crate