### PR TITLE
Ensure that first dispute has different outcome

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -65,7 +65,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("zeitgeist"),
     impl_name: create_runtime_str!("zeitgeist"),
     authoring_version: 1,
-    spec_version: 29,
+    spec_version: 30,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 8,

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -2041,7 +2041,7 @@ mod pallet {
             Self::ensure_can_not_dispute_the_same_outcome(
                 disputes,
                 (&market.report.as_ref()).ok_or(Error::<T>::MarketNotReported)?,
-                outcome
+                outcome,
             )?;
             Self::ensure_disputes_does_not_exceed_max_disputes(num_disputes)?;
             Ok(())

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1477,10 +1477,13 @@ mod pallet {
 
         fn ensure_can_not_dispute_the_same_outcome(
             disputes: &[MarketDispute<T::AccountId, T::BlockNumber>],
+            report: &Report<T::AccountId, T::BlockNumber>,
             outcome: &OutcomeReport,
         ) -> DispatchResult {
             if let Some(last_dispute) = disputes.last() {
                 ensure!(&last_dispute.outcome != outcome, Error::<T>::CannotDisputeSameOutcome);
+            } else {
+                ensure!(&report.outcome != outcome, Error::<T>::CannotDisputeSameOutcome);
             }
             Ok(())
         }
@@ -2035,7 +2038,11 @@ mod pallet {
         ) -> DispatchResult {
             ensure!(market.report.is_some(), Error::<T>::MarketNotReported);
             Self::ensure_outcome_matches_market_type(market, outcome)?;
-            Self::ensure_can_not_dispute_the_same_outcome(disputes, outcome)?;
+            Self::ensure_can_not_dispute_the_same_outcome(
+                disputes,
+                &market.report.as_ref().unwrap(),
+                outcome
+            )?;
             Self::ensure_disputes_does_not_exceed_max_disputes(num_disputes)?;
             Ok(())
         }

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -2040,7 +2040,7 @@ mod pallet {
             Self::ensure_outcome_matches_market_type(market, outcome)?;
             Self::ensure_can_not_dispute_the_same_outcome(
                 disputes,
-                &market.report.as_ref().unwrap(),
+                (&market.report.as_ref()).ok_or(Error::<T>::MarketNotReported)?,
                 outcome
             )?;
             Self::ensure_disputes_does_not_exceed_max_disputes(num_disputes)?;


### PR DESCRIPTION
This is already ensured for the second and later disputes, and should probably be checked when making the first dispute, as well.