### PR TITLE
Fix incorrect type of `resolved_outcome`

### DIFF
--- a/misc/types.json
+++ b/misc/types.json
@@ -121,7 +121,7 @@
     "scoring_rule": "ScoringRule",
     "status": "MarketStatus",
     "report": "Option<Report>",
-    "resolved_outcome": "Option<Outcome>",
+    "resolved_outcome": "Option<OutcomeReport>",
     "mdm": "MarketDisputeMechanism"
   },
   "MarketCreation": {


### PR DESCRIPTION
Strangely enough, this only causes errors in the parachain version.