### PR TITLE
Implement export-header subcommand

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -32,6 +32,7 @@ pub enum Subcommand {
     ExportBlocks(sc_cli::ExportBlocksCmd),
 
     /// Export block header in hex format.
+    #[cfg(feature = "parachain")]
     ExportHeader(sc_cli::CheckBlockCmd),
 
     /// Export the genesis state of the parachain.

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -31,6 +31,9 @@ pub enum Subcommand {
     /// Export blocks.
     ExportBlocks(sc_cli::ExportBlocksCmd),
 
+    /// Export block header in hex format.
+    ExportHeader(sc_cli::CheckBlockCmd),
+
     /// Export the genesis state of the parachain.
     #[cfg(feature = "parachain")]
     #[structopt(name = "export-genesis-state")]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -3,11 +3,11 @@ use crate::{
     service::{new_partial, ExecutorDispatch},
 };
 use sc_cli::SubstrateCli;
-use sc_client_api::BlockBackend;
 use sc_service::PartialComponents;
 #[cfg(feature = "parachain")]
 use {
     parity_scale_codec::Encode, sp_core::hexdisplay::HexDisplay,
+    sc_client_api::client::BlockBackend,
     sp_runtime::traits::Block as BlockT, std::io::Write,
 };
 
@@ -61,6 +61,7 @@ pub fn run() -> sc_cli::Result<()> {
                 Ok((cmd.run(client, config.database), task_manager))
             })
         }
+        #[cfg(feature = "parachain")]
         Some(Subcommand::ExportHeader(cmd)) => {
             let runner = cli.create_runner(cmd)?;
 
@@ -69,7 +70,7 @@ pub fn run() -> sc_cli::Result<()> {
 
                 match client.block(&cmd.input.parse()?) {
                     Ok(Some(block)) => {
-                        println!("STATE: 0x{:?}", HexDisplay::from(&block.block.header.encode()));
+                        println!("0x{:?}", HexDisplay::from(&block.block.header.encode()));
                         Ok(())
                     }
                     Ok(None) => Err("Unknown block".into()),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -65,7 +65,10 @@ pub fn run() -> sc_cli::Result<()> {
             let runner = cli.create_runner(cmd)?;
 
             runner.sync_run(|config| {
-                let PartialComponents { client, .. }: crate::service::ParachainPartialComponents<ExecutorDispatch, RuntimeApi> = crate::service::new_partial(&config)?;
+                let PartialComponents { client, .. }: crate::service::ParachainPartialComponents<
+                    ExecutorDispatch,
+                    RuntimeApi,
+                > = crate::service::new_partial(&config)?;
 
                 match client.block(&cmd.input.parse()?) {
                     Ok(Some(block)) => {

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -3,6 +3,7 @@ use crate::{
     service::{new_partial, ExecutorDispatch},
 };
 use sc_cli::SubstrateCli;
+use sc_client_api::BlockBackend;
 use sc_service::PartialComponents;
 #[cfg(feature = "parachain")]
 use {
@@ -60,6 +61,23 @@ pub fn run() -> sc_cli::Result<()> {
                 Ok((cmd.run(client, config.database), task_manager))
             })
         }
+        Some(Subcommand::ExportHeader(cmd)) => {
+            let runner = cli.create_runner(cmd)?;
+
+            runner.sync_run(|config| {
+                let PartialComponents { client, .. } =
+                    crate::service::new_partial(&config)?;
+                
+                match client.block(&cmd.input.parse()?) {
+                    Ok(Some(block)) => {
+                        println!("STATE: 0x{:?}", HexDisplay::from(&block.block.header.encode()));
+                        Ok(())
+                    },
+                    Ok(None) => Err("Unknown block".into()),
+                    Err(e) => Err(format!("Error reading block: {:?}", e).into()),
+                }
+            })
+        },
         #[cfg(feature = "parachain")]
         Some(Subcommand::ExportGenesisState(params)) => {
             let mut builder = sc_cli::LoggerBuilder::new("");

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -6,9 +6,8 @@ use sc_cli::SubstrateCli;
 use sc_service::PartialComponents;
 #[cfg(feature = "parachain")]
 use {
-    parity_scale_codec::Encode, sp_core::hexdisplay::HexDisplay,
-    sc_client_api::client::BlockBackend,
-    sp_runtime::traits::Block as BlockT, std::io::Write,
+    parity_scale_codec::Encode, sc_client_api::client::BlockBackend,
+    sp_core::hexdisplay::HexDisplay, sp_runtime::traits::Block as BlockT, std::io::Write,
 };
 
 use zeitgeist_runtime::RuntimeApi;

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -65,19 +65,18 @@ pub fn run() -> sc_cli::Result<()> {
             let runner = cli.create_runner(cmd)?;
 
             runner.sync_run(|config| {
-                let PartialComponents { client, .. } =
-                    crate::service::new_partial(&config)?;
-                
+                let PartialComponents { client, .. } = crate::service::new_partial(&config)?;
+
                 match client.block(&cmd.input.parse()?) {
                     Ok(Some(block)) => {
                         println!("STATE: 0x{:?}", HexDisplay::from(&block.block.header.encode()));
                         Ok(())
-                    },
+                    }
                     Ok(None) => Err("Unknown block".into()),
                     Err(e) => Err(format!("Error reading block: {:?}", e).into()),
                 }
             })
-        },
+        }
         #[cfg(feature = "parachain")]
         Some(Subcommand::ExportGenesisState(params)) => {
             let mut builder = sc_cli::LoggerBuilder::new("");

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -65,7 +65,7 @@ pub fn run() -> sc_cli::Result<()> {
             let runner = cli.create_runner(cmd)?;
 
             runner.sync_run(|config| {
-                let PartialComponents { client, .. } = crate::service::new_partial(&config)?;
+                let PartialComponents { client, .. }: crate::service::ParachainPartialComponents<ExecutorDispatch, RuntimeApi> = crate::service::new_partial(&config)?;
 
                 match client.block(&cmd.input.parse()?) {
                     Ok(Some(block)) => {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -8,7 +8,7 @@ use zeitgeist_primitives::types::{AccountId, Balance, Index, MarketId, PoolId};
 use zeitgeist_runtime::opaque::Block;
 
 #[cfg(feature = "parachain")]
-pub use service_parachain::{new_full, new_partial};
+pub use service_parachain::{new_full, new_partial, ParachainPartialComponents};
 #[cfg(not(feature = "parachain"))]
 pub use service_standalone::{new_full, new_light, new_partial};
 

--- a/node/src/service/service_parachain.rs
+++ b/node/src/service/service_parachain.rs
@@ -45,10 +45,7 @@ pub async fn new_full(
 #[allow(clippy::type_complexity)]
 pub fn new_partial<RuntimeApi, Executor>(
     config: &Configuration,
-) -> Result<
-    ParachainPartialComponents<Executor, RuntimeApi>,
-    sc_service::error::Error,
->
+) -> Result<ParachainPartialComponents<Executor, RuntimeApi>, sc_service::error::Error>
 where
     RuntimeApi:
         ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>> + Send + Sync + 'static,

--- a/node/src/service/service_parachain.rs
+++ b/node/src/service/service_parachain.rs
@@ -19,6 +19,14 @@ use zeitgeist_runtime::{opaque::Block, RuntimeApi};
 type FullBackend = TFullBackend<Block>;
 type FullClient<RuntimeApi, Executor> =
     TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>;
+pub type ParachainPartialComponents<Executor, RuntimeApi> = PartialComponents<
+    FullClient<RuntimeApi, Executor>,
+    FullBackend,
+    (),
+    sc_consensus::DefaultImportQueue<Block, FullClient<RuntimeApi, Executor>>,
+    sc_transaction_pool::FullPool<Block, FullClient<RuntimeApi, Executor>>,
+    (Option<Telemetry>, Option<TelemetryWorkerHandle>),
+>;
 
 /// Start a parachain node.
 pub async fn new_full(
@@ -38,14 +46,7 @@ pub async fn new_full(
 pub fn new_partial<RuntimeApi, Executor>(
     config: &Configuration,
 ) -> Result<
-    PartialComponents<
-        FullClient<RuntimeApi, Executor>,
-        FullBackend,
-        (),
-        sc_consensus::DefaultImportQueue<Block, FullClient<RuntimeApi, Executor>>,
-        sc_transaction_pool::FullPool<Block, FullClient<RuntimeApi, Executor>>,
-        (Option<Telemetry>, Option<TelemetryWorkerHandle>),
-    >,
+    ParachainPartialComponents<Executor, RuntimeApi>,
     sc_service::error::Error,
 >
 where


### PR DESCRIPTION
This PR adds a new subcommand called `export-header`. For a given block number or hash, this subcommand will print the block header for the selected chain in a format that can be directly used to onboard the para chain for that selected block or to set the head of the para chain on the relay chain.