### PR TITLE
Remove panickers from Rikiddo code

### DIFF
--- a/zrml/rikiddo/fuzz/fixedi_to_fixedu_conversion.rs
+++ b/zrml/rikiddo/fuzz/fixedi_to_fixedu_conversion.rs
@@ -7,7 +7,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use substrate_fixed::{types::extra::U33, FixedU128};
-use zrml_rikiddo::types::convert_to_unsigned;
+use zrml_rikiddo::utils::convert_to_unsigned;
 
 mod shared;
 use shared::fixed_from_i128;

--- a/zrml/rikiddo/fuzz/fixedu_to_fixedi_conversion.rs
+++ b/zrml/rikiddo/fuzz/fixedu_to_fixedi_conversion.rs
@@ -7,7 +7,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use substrate_fixed::{types::extra::U33, FixedI128};
-use zrml_rikiddo::types::convert_to_signed;
+use zrml_rikiddo::utils::convert_to_signed;
 
 mod shared;
 use shared::fixed_from_u128;

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -24,6 +24,7 @@ pub mod mock;
 mod tests;
 pub mod traits;
 pub mod types;
+pub mod utils;
 pub use pallet::*;
 
 /// The pallet that bridges Rikiddo instances to pools.

--- a/zrml/rikiddo/src/tests.rs
+++ b/zrml/rikiddo/src/tests.rs
@@ -9,7 +9,7 @@ use substrate_fixed::{
 
 use crate::{
     traits::{FromFixedDecimal, FromFixedToDecimal, IntoFixedDecimal, IntoFixedFromDecimal},
-    types::{convert_to_signed, convert_to_unsigned},
+    utils::{convert_to_signed, convert_to_unsigned},
 };
 
 mod ema_market_volume;

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/cost.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/cost.rs
@@ -3,10 +3,7 @@ use hashbrown::HashMap;
 use substrate_fixed::{traits::ToFixed, types::extra::U64, FixedI128, FixedU128};
 
 use super::{cost, max_allowed_error, Rikiddo};
-use crate::{
-    traits::Lmsr,
-    types::{convert_to_signed, RikiddoFormulaComponents},
-};
+use crate::{traits::Lmsr, types::RikiddoFormulaComponents, utils::convert_to_signed};
 
 #[test]
 fn rikiddo_cost_function_rejects_empty_list() {

--- a/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/misc.rs
+++ b/zrml/rikiddo/src/tests/rikiddo_sigmoid_mv/misc.rs
@@ -5,9 +5,8 @@ use super::{initial_outstanding_assets, ln_exp_sum, Rikiddo};
 use crate::{
     constants::INITIAL_FEE,
     traits::{Fee, Lmsr},
-    types::{
-        convert_to_signed, EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoFormulaComponents,
-    },
+    types::{EmaMarketVolume, FeeSigmoid, RikiddoConfig, RikiddoFormulaComponents},
+    utils::convert_to_signed,
 };
 
 #[test]

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -2,27 +2,18 @@
 //! functionality, as well as the Rikiddo core functionality itself.
 
 extern crate alloc;
-use super::{
-    traits::{FromFixedDecimal, FromFixedToDecimal, IntoFixedDecimal, IntoFixedFromDecimal},
-    utils::{fixed_zero, max_value_u128},
-};
-use alloc::{borrow::ToOwned, string::ToString};
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Result as ArbiraryResult, Unstructured};
 #[cfg(feature = "arbitrary")]
 use core::mem;
-use core::{cmp::Ordering, convert::TryFrom};
 use frame_support::dispatch::{Decode, Encode};
 use sp_core::RuntimeDebug;
-use substrate_fixed::{
-    traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
-    types::extra::{U127, U128},
-    FixedI128, FixedU128, ParseFixedError,
-};
+use substrate_fixed::traits::Fixed;
 #[cfg(feature = "arbitrary")]
 use substrate_fixed::{
     types::extra::{LeEqU128, LeEqU16, LeEqU32, LeEqU64, LeEqU8},
-    FixedI16, FixedI32, FixedI64, FixedI8, FixedU16, FixedU32, FixedU64, FixedU8,
+    FixedI128, FixedI16, FixedI32, FixedI64, FixedI8, FixedU128, FixedU16, FixedU32, FixedU64,
+    FixedU8,
 };
 
 mod ema_market_volume;
@@ -124,189 +115,5 @@ impl Timespan {
                 .saturating_mul(24)
                 .saturating_mul(7),
         }
-    }
-}
-
-/// Returns integer part of `FROM`, if the msb is not set and and num does it into `FROM`.
-fn convert_common<FROM: Fixed, TO: Fixed>(num: FROM) -> Result<TO, &'static str> {
-    // Check if number is negatie
-    if num < fixed_zero::<FROM>()? {
-        return Err("Cannot convert negative signed number into unsigned number");
-    }
-
-    // PartialOrd is bugged, therefore the workaround
-    // https://github.com/encointer/substrate-fixed/issues/9
-    let num_u128: u128 = num.int().checked_to_num().ok_or("Conversion from FROM to u128 failed")?;
-    if max_value_u128::<TO>()? < num_u128 {
-        return Err("Fixed point conversion failed: FROM type does not fit in TO type");
-    }
-
-    num_u128.checked_to_fixed().ok_or("Integer part of fixed point number does not fit into u128")
-}
-
-/// Converts an unsigned fixed point number into a signed fixed point number (fallible).
-pub fn convert_to_signed<FROM: FixedUnsigned, TO: FixedSigned + LossyFrom<FixedI128<U127>>>(
-    num: FROM,
-) -> Result<TO, &'static str> {
-    let integer_part: TO = convert_common(num)?;
-    let fractional_part: FixedI128<U127> = num
-        .frac()
-        .checked_to_fixed()
-        .ok_or("Fraction of fixed point number unexpectedly does not fit into FixedI128<U127>")?;
-
-    if let Some(res) = integer_part.checked_add(fractional_part.lossy_into()) {
-        Ok(res)
-    } else {
-        // This error should be impossible to reach.
-        Err("Something went wrong during FixedUnsigned to FixedSigned type conversion")
-    }
-}
-
-/// Converts a signed fixed point number into an unsigned fixed point number (fallible).
-pub fn convert_to_unsigned<FROM: FixedSigned, TO: FixedUnsigned + LossyFrom<FixedU128<U128>>>(
-    num: FROM,
-) -> Result<TO, &'static str> {
-    // We can safely cast because until here we know that the msb is not set.
-    let integer_part: TO = convert_common(num)?;
-    let fractional_part: FixedU128<U128> = num
-        .frac()
-        .checked_to_fixed()
-        .ok_or("Fraction of fixed point number unexpectedly does not fit into FixedU128<U128>")?;
-    if let Some(res) = integer_part.checked_add(fractional_part.lossy_into()) {
-        Ok(res)
-    } else {
-        // This error should be impossible to reach.
-        Err("Something went wrong during FixedSigned to FixedUnsigned type conversion")
-    }
-}
-
-impl<F: Fixed, N: Into<u128>> FromFixedDecimal<N> for F {
-    /// Craft a `Fixed` type from a fixed point decimal number of type `N`
-    fn from_fixed_decimal(decimal: N, places: u8) -> Result<Self, ParseFixedError> {
-        let decimal_u128 = decimal.into();
-        let mut decimal_string = decimal_u128.to_string();
-
-        if decimal_string.len() <= places as usize {
-            // This can never underflow (places >= len). Saturating subtraction to satisfy clippy.
-            decimal_string = "0.".to_owned()
-                + &"0".repeat((places as usize).saturating_sub(decimal_string.len()))
-                + &decimal_string;
-        } else {
-            // This can never underflow (len >= places). Saturating subtraction to satisfy clippy.
-            decimal_string.insert(decimal_string.len().saturating_sub(places as usize), '.');
-        }
-
-        F::from_str(&decimal_string)
-    }
-}
-
-impl<F, N> IntoFixedFromDecimal<F> for N
-where
-    F: Fixed + FromFixedDecimal<Self>,
-    N: Into<u128>,
-{
-    /// Converts a fixed point decimal number into `Fixed` type (e.g. `Balance` -> `Fixed`).
-    fn to_fixed_from_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError> {
-        F::from_fixed_decimal(self, places)
-    }
-}
-
-impl<F: Fixed, N: TryFrom<u128>> FromFixedToDecimal<F> for N {
-    /// Craft a fixed point decimal number from a `Fixed` type (e.g. `Fixed` -> `Balance`).
-    fn from_fixed_to_fixed_decimal(fixed: F, places: u8) -> Result<N, &'static str> {
-        if places == 0 {
-            let mut result = fixed
-                .checked_to_num::<u128>()
-                .ok_or("The fixed point number does not fit into a u128")?;
-
-            // Arithmetic rounding (+1 if >= 0.5)
-            if F::frac_nbits() > 0 {
-                let two = F::checked_from_num(2)
-                    .ok_or("Unexpectedly failed to convert 2 to fixed point number")?;
-                let one = F::checked_from_num(1)
-                    .ok_or("Unexpectedly failed to convert 1 to fixed point number")?;
-                let half =
-                    one.checked_div(two).ok_or("Unexpected overflow when dividing one by two")?;
-
-                if fixed.frac() >= half {
-                    result = result.saturating_add(1);
-                }
-            }
-
-            if let Ok(res) = N::try_from(result) {
-                return Ok(res);
-            } else {
-                return Err(
-                    "The parsed fixed decimal representation does not fit into the target type"
-                );
-            }
-        }
-
-        let mut fixed_str = fixed.to_string();
-        let fixed_frac = fixed.frac();
-
-        let places_usize: usize = places.into();
-
-        if fixed_frac == 0 {
-            // Add `places` times 0 to pad all remaining fractional decimal places
-            fixed_str += &"0".repeat(places_usize);
-        } else {
-            let frac_string = fixed_frac.to_string();
-            let frac_str = frac_string.get(2..).unwrap_or_default();
-
-            match frac_str.len().cmp(&places_usize) {
-                Ordering::Less => {
-                    fixed_str.retain(|c| c != '.');
-                    // Padding to the right side up to `places`. Cannot underflow.
-                    fixed_str += &"0".repeat(places_usize.saturating_sub(frac_str.len()));
-                }
-                Ordering::Greater => {
-                    // Cutting down to `places` + arithmetic rounding of the last digit
-                    let frac_plus_one_digit_str =
-                        frac_str.get(..places_usize.saturating_add(1)).unwrap_or_default();
-
-                    if let Ok(mut res) = frac_plus_one_digit_str.parse::<u128>() {
-                        let last_digit = res % 10;
-                        res /= 10;
-
-                        if last_digit >= 5 {
-                            res = res.saturating_add(1);
-                        }
-
-                        fixed_str = fixed.int().to_string() + &res.to_string()
-                    } else {
-                        // Impossible unless there is a bug in Fixed's to_string()
-                        return Err(
-                            "Error parsing the string representation of the fixed point number"
-                        );
-                    };
-                }
-                Ordering::Equal => fixed_str.retain(|c| c != '.'),
-            };
-        }
-
-        let result = if let Ok(res) = fixed_str[..].parse::<u128>() {
-            res
-        } else {
-            // Impossible unless there is a bug in Fixed's to_string()
-            return Err("Error parsing the string representation of the fixed point number");
-        };
-
-        if let Ok(res) = N::try_from(result) {
-            Ok(res)
-        } else {
-            Err("The parsed fixed decimal representation does not fit into the target type")
-        }
-    }
-}
-
-impl<F, N> IntoFixedDecimal<N> for F
-where
-    F: Fixed,
-    N: FromFixedToDecimal<Self>,
-{
-    /// Converts a `Fixed` type into a fixed point decimal number.
-    fn to_fixed_decimal(self, places: u8) -> Result<N, &'static str> {
-        N::from_fixed_to_fixed_decimal(self, places)
     }
 }

--- a/zrml/rikiddo/src/types.rs
+++ b/zrml/rikiddo/src/types.rs
@@ -2,7 +2,10 @@
 //! functionality, as well as the Rikiddo core functionality itself.
 
 extern crate alloc;
-use super::traits::{FromFixedDecimal, FromFixedToDecimal, IntoFixedDecimal, IntoFixedFromDecimal};
+use super::{
+    traits::{FromFixedDecimal, FromFixedToDecimal, IntoFixedDecimal, IntoFixedFromDecimal},
+    utils::fixed_zero,
+};
 use alloc::{borrow::ToOwned, string::ToString};
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Result as ArbiraryResult, Unstructured};
@@ -127,9 +130,7 @@ impl Timespan {
 /// Returns integer part of `FROM`, if the msb is not set and and num does it into `FROM`.
 fn convert_common<FROM: Fixed, TO: Fixed>(num: FROM) -> Result<TO, &'static str> {
     // Check if number is negatie
-    let zero = FROM::checked_from_num(0u8)
-        .ok_or("Unexpectedly failed to convert 0u8 to fixed point number")?;
-    if num < zero {
+    if num < fixed_zero::<FROM>()? {
         return Err("Cannot convert negative signed number into unsigned number");
     }
 
@@ -139,7 +140,7 @@ fn convert_common<FROM: Fixed, TO: Fixed>(num: FROM) -> Result<TO, &'static str>
     let max_value: u128 = TO::max_value()
         .int()
         .checked_to_num()
-        .ok_or("Converting fixed point numerical limit to u128 failed uexpectedly")?;
+        .ok_or("Converting fixed point numerical limit to u128 failed unexpectedly")?;
     if max_value < num_u128 {
         return Err("Fixed point conversion failed: FROM type does not fit in TO type");
     }

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -145,7 +145,7 @@ macro_rules! impl_arbitrary_for_ema_market_volume {
         impl<'a, Frac> Arbitrary<'a> for EmaMarketVolume<$t<Frac>>
         where
             Frac: $LeEqU,
-            $t<Frac>: FixedUnsigned,
+            $t<Frac>: FixedUnsigned + From<u32>,
         {
             fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
                 Ok(EmaMarketVolume::<$t<Frac>>::new(

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -145,7 +145,7 @@ macro_rules! impl_arbitrary_for_ema_market_volume {
         impl<'a, Frac> Arbitrary<'a> for EmaMarketVolume<$t<Frac>>
         where
             Frac: $LeEqU,
-            $t<Frac>: FixedUnsigned + From<u32>,
+            $t<Frac>: FixedUnsigned + From<u8>,
         {
             fn arbitrary(u: &mut Unstructured<'a>) -> ArbitraryResult<Self> {
                 Ok(EmaMarketVolume::<$t<Frac>>::new(
@@ -206,7 +206,7 @@ cfg_if::cfg_if! {
     }
 }
 
-impl<FU: FixedUnsigned + From<u32>> EmaMarketVolume<FU> {
+impl<FU: FixedUnsigned + From<u8>> EmaMarketVolume<FU> {
     /// Initialize the structure based on a configuration.
     ///
     /// # Arguments
@@ -215,12 +215,12 @@ impl<FU: FixedUnsigned + From<u32>> EmaMarketVolume<FU> {
     pub fn new(config: EmaConfig<FU>) -> Self {
         Self {
             config,
-            ema: 0u32.into(),
+            ema: 0u8.into(),
             state: MarketVolumeState::Uninitialized,
             start_time: 0,
             last_time: 0,
-            volumes_per_period: 0u32.into(),
-            multiplier: 0u32.into(),
+            volumes_per_period: 0u8.into(),
+            multiplier: 0u8.into(),
         }
     }
 
@@ -237,7 +237,7 @@ impl<FU: FixedUnsigned + From<u32>> EmaMarketVolume<FU> {
         };
 
         // Overflow is impossible here.
-        let one_minus_multiplier = if let Some(res) = FU::from(1u32).checked_sub(self.multiplier) {
+        let one_minus_multiplier = if let Some(res) = FU::from(1u8).checked_sub(self.multiplier) {
             res
         } else {
             return Err("[EmaMarketVolume] Overflow during calculation: 1 - multiplier");
@@ -285,7 +285,7 @@ impl<FU: FixedUnsigned + From<u32>> EmaMarketVolume<FU> {
 
         // This can't overflow.
         self.ema = if let Some(res) = sma_times_vpp_plus_volume
-            .checked_div(self.volumes_per_period.saturating_add(FU::from(1u32)))
+            .checked_div(self.volumes_per_period.saturating_add(FU::from(1u8)))
         {
             res
         } else {
@@ -323,13 +323,13 @@ impl<FU: FixedUnsigned + From<u32>> EmaMarketVolume<FU> {
     }
 }
 
-impl<FU: FixedUnsigned + From<u32> + LossyFrom<FixedU32<U24>>> Default for EmaMarketVolume<FU> {
+impl<FU: FixedUnsigned + From<u8> + LossyFrom<FixedU32<U24>>> Default for EmaMarketVolume<FU> {
     fn default() -> Self {
         EmaMarketVolume::new(EmaConfig::default())
     }
 }
 
-impl<FU: FixedUnsigned + From<u32>> MarketAverage for EmaMarketVolume<FU> {
+impl<FU: FixedUnsigned + From<u8>> MarketAverage for EmaMarketVolume<FU> {
     type FU = FU;
 
     /// Get the ema value if available, otherwise `None`. Using this function is prefered in most
@@ -345,12 +345,12 @@ impl<FU: FixedUnsigned + From<u32>> MarketAverage for EmaMarketVolume<FU> {
 
     /// Clear market data.
     fn clear(&mut self) {
-        self.ema = 0u32.into();
-        self.multiplier = 0u32.into();
+        self.ema = 0u8.into();
+        self.multiplier = 0u8.into();
         self.last_time = 0;
         self.state = MarketVolumeState::Uninitialized;
         self.start_time = 0;
-        self.volumes_per_period = 0u32.into();
+        self.volumes_per_period = 0u8.into();
     }
 
     /// Update market data. This implementation will count the

--- a/zrml/rikiddo/src/types/ema_market_volume.rs
+++ b/zrml/rikiddo/src/types/ema_market_volume.rs
@@ -416,7 +416,7 @@ impl<FU: FixedUnsigned + From<u32>> MarketAverage for EmaMarketVolume<FU> {
                         // Overflow impossible
                         let estimate_ratio = mature_time_fixed.saturating_div(premature_time_fixed);
 
-                        // Cannot occur as long as the From<U32> trait is required for FU and
+                        // Cannot fail as long as the From<U32> trait is required for FU and
                         // Timespan::to_seconds() returns u32.
                         let estimate_ratio_fu: FU = estimate_ratio
                             .checked_to_fixed()

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -108,16 +108,16 @@ where
 
 impl<FS> Default for RikiddoFormulaComponents<FS>
 where
-    FS: FixedSigned + From<I9F23> + From<i32> + LossyFrom<FixedI32<U31>> + LossyFrom<U1F127>,
+    FS: FixedSigned + From<I9F23> + From<i8> + LossyFrom<FixedI32<U31>> + LossyFrom<U1F127>,
 {
     fn default() -> Self {
         Self {
-            one: 1i32.into(),
-            fee: 0i32.into(),
-            sum_balances: 0i32.into(),
-            sum_times_fee: 0i32.into(),
-            emax: 0i32.into(),
-            sum_exp: 0i32.into(),
+            one: 1i8.into(),
+            fee: 0i8.into(),
+            sum_balances: 0i8.into(),
+            sum_times_fee: 0i8.into(),
+            emax: 0i8.into(),
+            sum_exp: 0i8.into(),
             exponents: HashMap::new(),
             reduced_exponential_results: HashMap::new(),
         }
@@ -156,7 +156,7 @@ macro_rules! impl_arbitrary_for_rikiddo_sigmoid_mv {
             $tu<FracU>: FixedUnsigned + LossyFrom<FixedU32<U32>> + LossyFrom<FixedU128<U128>>,
             $ts<FracS>: FixedSigned
                 + From<I9F23>
-                + From<i32>
+                + From<i8>
                 + LossyFrom<FixedI32<U31>>
                 + LossyFrom<U1F127>
                 + LossyFrom<FixedI128<U127>>
@@ -210,7 +210,7 @@ where
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>> + LossyFrom<FixedU128<U128>>,
     FS: FixedSigned
         + From<I9F23>
-        + From<i32>
+        + From<i8>
         + LossyFrom<FixedI32<U31>>
         + LossyFrom<U1F127>
         + LossyFrom<FixedI128<U127>>
@@ -559,7 +559,7 @@ where
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>> + LossyFrom<FixedU128<U128>>,
     FS: FixedSigned
         + From<I9F23>
-        + From<i32>
+        + From<i8>
         + LossyFrom<FixedI32<U31>>
         + LossyFrom<U1F127>
         + LossyFrom<FixedI128<U127>>
@@ -737,7 +737,7 @@ where
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>> + LossyFrom<FixedU128<U128>>,
     FS: FixedSigned
         + From<I9F23>
-        + From<i32>
+        + From<i8>
         + LossyFrom<FixedI32<U31>>
         + LossyFrom<U1F127>
         + LossyFrom<FixedI128<U127>>

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use crate::{
     constants::INITIAL_FEE,
     traits::{Fee, Lmsr, MarketAverage, RikiddoMV},
-    utils::{fixed_zero},
+    utils::{fixed_zero, max_value_u128},
 };
 use alloc::vec::Vec;
 #[cfg(feature = "arbitrary")]
@@ -294,11 +294,7 @@ where
 
         formula_components.emax = biggest_exponent;
 
-        let max_value: u128 = FS::max_value()
-            .int()
-            .checked_to_num()
-            .ok_or("Converting fixed point numerical limit to u128 failed unexpectedly")?;
-        if max_value < asset_balances.len() as u128 {
+        if max_value_u128::<FS>()? < asset_balances.len() as u128 {
             return Err("[RikidoSigmoidMV] Number of assets does not fit in FS");
         }
 
@@ -497,11 +493,7 @@ where
     ) -> Result<FS, &'static str> {
         let mut biggest_exponent_used = false;
 
-        let max_value: u128 = FS::max_value()
-            .int()
-            .checked_to_num()
-            .ok_or("Converting fixed point numerical limit to u64 failed unexpectedly")?;
-        if max_value < 1u128 {
+        if max_value_u128::<FS>()? < 1u128 {
             // Impossible due to trait bounds (at least 1 sign bit and 8 integer bits)
             return Err("[RikiddoSigmoidMV] Error, cannot initialize FS with one");
         }

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -108,18 +108,16 @@ where
 
 impl<FS> Default for RikiddoFormulaComponents<FS>
 where
-    FS: FixedSigned + From<I9F23> + LossyFrom<FixedI32<U31>> + LossyFrom<U1F127>,
+    FS: FixedSigned + From<I9F23> + From<i32> + LossyFrom<FixedI32<U31>> + LossyFrom<U1F127>,
 {
     fn default() -> Self {
-        // TODO
-        let zero = 0.to_fixed();
         Self {
-            one: 1i32.to_fixed(),
-            fee: zero,
-            sum_balances: zero,
-            sum_times_fee: zero,
-            emax: zero,
-            sum_exp: zero,
+            one: 1i32.into(),
+            fee: 0i32.into(),
+            sum_balances: 0i32.into(),
+            sum_times_fee: 0i32.into(),
+            emax: 0i32.into(),
+            sum_exp: 0i32.into(),
             exponents: HashMap::new(),
             reduced_exponential_results: HashMap::new(),
         }
@@ -211,6 +209,7 @@ where
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>> + LossyFrom<FixedU128<U128>>,
     FS: FixedSigned
         + From<I9F23>
+        + From<i32>
         + LossyFrom<FixedI32<U31>>
         + LossyFrom<U1F127>
         + LossyFrom<FixedI128<U127>>
@@ -559,6 +558,7 @@ where
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>> + LossyFrom<FixedU128<U128>>,
     FS: FixedSigned
         + From<I9F23>
+        + From<i32>
         + LossyFrom<FixedI32<U31>>
         + LossyFrom<U1F127>
         + LossyFrom<FixedI128<U127>>
@@ -736,6 +736,7 @@ where
     FU: FixedUnsigned + LossyFrom<FixedU32<U32>> + LossyFrom<FixedU128<U128>>,
     FS: FixedSigned
         + From<I9F23>
+        + From<i32>
         + LossyFrom<FixedI32<U31>>
         + LossyFrom<U1F127>
         + LossyFrom<FixedI128<U127>>

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -156,6 +156,7 @@ macro_rules! impl_arbitrary_for_rikiddo_sigmoid_mv {
             $tu<FracU>: FixedUnsigned + LossyFrom<FixedU32<U32>> + LossyFrom<FixedU128<U128>>,
             $ts<FracS>: FixedSigned
                 + From<I9F23>
+                + From<i32>
                 + LossyFrom<FixedI32<U31>>
                 + LossyFrom<U1F127>
                 + LossyFrom<FixedI128<U127>>

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -244,7 +244,8 @@ where
 
         let fee = self.fee()?;
         formula_components.fee = convert_to_signed(fee)?;
-        let mut total_balance = FU::from_num(0u8);
+        let mut total_balance = FU::checked_from_num(0u8)
+            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
 
         for elem in asset_balances {
             if let Some(res) = total_balance.checked_add(*elem) {
@@ -266,7 +267,8 @@ where
         formula_components.sum_times_fee = convert_to_signed(denominator)?;
 
         let mut exponents: Vec<FS> = Vec::with_capacity(asset_balances.len());
-        let mut biggest_exponent: FS = FS::from_num(0u8);
+        let mut biggest_exponent: FS = FS::checked_from_num(0u8)
+            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
 
         for elem in asset_balances {
             let exponent = if let Some(res) = elem.checked_div(denominator) {
@@ -292,7 +294,11 @@ where
 
         formula_components.emax = biggest_exponent;
 
-        if FS::max_value().int().to_num::<u128>() < asset_balances.len() as u128 {
+        let max_value: u128 = FS::max_value()
+            .int()
+            .checked_to_num()
+            .ok_or("Converting fixed point numerical limit to u128 failed unexpectedly")?;
+        if max_value < asset_balances.len() as u128 {
             return Err("[RikidoSigmoidMV] Number of assets does not fit in FS");
         }
 
@@ -333,7 +339,9 @@ where
                             question in RikiddoFormulaComponents HashMap");
             };
 
-        let mut sum: FS = 0.to_fixed();
+        let mut sum: FS = 0
+            .checked_to_fixed()
+            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
         let mut skipped = false;
 
         for elem in asset_balances {
@@ -363,7 +371,8 @@ where
             } else {
                 // In that case the final result will not fit into the fractional bits
                 // and therefore is approximated to zero. Cannot panic.
-                0.to_fixed()
+                0.checked_to_fixed()
+                    .ok_or("Unexpectedly failed to convert zero to fixed point number")?
             };
 
             sum = if let Some(res) = sum.checked_add(exponential_result) {
@@ -371,7 +380,9 @@ where
             } else {
                 // In that case the final result will not fit into the fractional bits
                 // and therefore is approximated to zero. Cannot panic.
-                return Ok(0.to_fixed());
+                return 0
+                    .checked_to_fixed()
+                    .ok_or("Unexpectedly failed to convert zero to fixed point number");
             };
         }
 
@@ -380,13 +391,15 @@ where
         } else {
             // In that case the final result will not fit into the fractional bits
             // and therefore is approximated to zero. Cannot panic.
-            return Ok(0.to_fixed());
+            return 0
+                .checked_to_fixed()
+                .ok_or("Unexpectedly failed to convert zero to fixed point number");
         };
 
         if let Some(res) = formula_components.one.checked_div(sum) {
             Ok(res)
         } else {
-            Ok(0.to_fixed())
+            0.checked_to_fixed().ok_or("Unexpectedly failed to convert zero to fixed point number")
         }
     }
 
@@ -396,7 +409,9 @@ where
         asset_balances: &[FS],
         formula_components: &RikiddoFormulaComponents<FS>,
     ) -> Result<FS, &'static str> {
-        let mut numerator: FS = 0.to_fixed();
+        let mut numerator: FS = 0
+            .checked_to_fixed()
+            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
         let mut skipped = false;
 
         for elem in asset_balances {
@@ -491,7 +506,11 @@ where
     ) -> Result<FS, &'static str> {
         let mut biggest_exponent_used = false;
 
-        if FS::max_value().int().to_num::<u128>() < 1u128 {
+        let max_value: u128 = FS::max_value()
+            .int()
+            .checked_to_num()
+            .ok_or("Converting fixed point numerical limit to u64 failed unexpectedly")?;
+        if max_value < 1u128 {
             // Impossible due to trait bounds (at least 1 sign bit and 8 integer bits)
             return Err("[RikiddoSigmoidMV] Error, cannot initialize FS with one");
         }
@@ -636,7 +655,9 @@ where
             return convert_to_unsigned(self.config.initial_fee);
         };
 
-        if mal == FU::from_num(0u8) {
+        let zero = FU::checked_from_num(0u8)
+            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
+        if mal == zero {
             return Err(
                 "[RikiddoSigmoidMV] Zero division error during calculation: ma_short / ma_long"
             );
@@ -699,7 +720,9 @@ where
     ) -> Result<Self::FU, &'static str> {
         let mut formula_components = RikiddoFormulaComponents::default();
         let mut asset_balances_signed = Vec::with_capacity(asset_balances.len());
-        let mut asset_in_question_balance_signed = 0.to_fixed();
+        let mut asset_in_question_balance_signed = 0
+            .checked_to_fixed()
+            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
         let mut asset_in_question_found = false;
 
         for asset_balance in asset_balances {
@@ -762,7 +785,10 @@ where
 
         if let Some(mas) = mas {
             if let Some(mal) = mal {
-                if mal != 0u32.to_fixed::<FU>() {
+                let zero = 0u32
+                    .checked_to_fixed::<FU>()
+                    .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
+                if mal != zero {
                     return Ok(Some(mas.saturating_div(mal)));
                 }
             };

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use crate::{
     constants::INITIAL_FEE,
     traits::{Fee, Lmsr, MarketAverage, RikiddoMV},
-    utils::{fixed_zero, max_value_u128},
+    utils::{convert_to_signed, convert_to_unsigned, fixed_zero, max_value_u128},
 };
 use alloc::vec::Vec;
 #[cfg(feature = "arbitrary")]
@@ -30,7 +30,7 @@ use substrate_fixed::{
     FixedI64, FixedU64,
 };
 
-use super::{convert_to_signed, convert_to_unsigned, TimestampedVolume};
+use super::TimestampedVolume;
 
 /// Configuration values used within the Rikiddo core functions.
 #[derive(scale_info::TypeInfo, Clone, RuntimeDebug, Decode, Encode, Eq, PartialEq)]

--- a/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
+++ b/zrml/rikiddo/src/types/rikiddo_sigmoid_mv.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 use crate::{
     constants::INITIAL_FEE,
     traits::{Fee, Lmsr, MarketAverage, RikiddoMV},
+    utils::{fixed_zero},
 };
 use alloc::vec::Vec;
 #[cfg(feature = "arbitrary")]
@@ -110,6 +111,7 @@ where
     FS: FixedSigned + From<I9F23> + LossyFrom<FixedI32<U31>> + LossyFrom<U1F127>,
 {
     fn default() -> Self {
+        // TODO
         let zero = 0.to_fixed();
         Self {
             one: 1i32.to_fixed(),
@@ -244,8 +246,7 @@ where
 
         let fee = self.fee()?;
         formula_components.fee = convert_to_signed(fee)?;
-        let mut total_balance = FU::checked_from_num(0u8)
-            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
+        let mut total_balance = fixed_zero::<FU>()?;
 
         for elem in asset_balances {
             if let Some(res) = total_balance.checked_add(*elem) {
@@ -267,8 +268,7 @@ where
         formula_components.sum_times_fee = convert_to_signed(denominator)?;
 
         let mut exponents: Vec<FS> = Vec::with_capacity(asset_balances.len());
-        let mut biggest_exponent: FS = FS::checked_from_num(0u8)
-            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
+        let mut biggest_exponent: FS = fixed_zero::<FS>()?;
 
         for elem in asset_balances {
             let exponent = if let Some(res) = elem.checked_div(denominator) {
@@ -339,9 +339,7 @@ where
                             question in RikiddoFormulaComponents HashMap");
             };
 
-        let mut sum: FS = 0
-            .checked_to_fixed()
-            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
+        let mut sum = fixed_zero::<FS>()?;
         let mut skipped = false;
 
         for elem in asset_balances {
@@ -371,8 +369,7 @@ where
             } else {
                 // In that case the final result will not fit into the fractional bits
                 // and therefore is approximated to zero. Cannot panic.
-                0.checked_to_fixed()
-                    .ok_or("Unexpectedly failed to convert zero to fixed point number")?
+                fixed_zero::<FS>()?
             };
 
             sum = if let Some(res) = sum.checked_add(exponential_result) {
@@ -380,9 +377,7 @@ where
             } else {
                 // In that case the final result will not fit into the fractional bits
                 // and therefore is approximated to zero. Cannot panic.
-                return 0
-                    .checked_to_fixed()
-                    .ok_or("Unexpectedly failed to convert zero to fixed point number");
+                return fixed_zero::<FS>();
             };
         }
 
@@ -391,15 +386,13 @@ where
         } else {
             // In that case the final result will not fit into the fractional bits
             // and therefore is approximated to zero. Cannot panic.
-            return 0
-                .checked_to_fixed()
-                .ok_or("Unexpectedly failed to convert zero to fixed point number");
+            return fixed_zero::<FS>();
         };
 
         if let Some(res) = formula_components.one.checked_div(sum) {
             Ok(res)
         } else {
-            0.checked_to_fixed().ok_or("Unexpectedly failed to convert zero to fixed point number")
+            fixed_zero::<FS>()
         }
     }
 
@@ -409,9 +402,7 @@ where
         asset_balances: &[FS],
         formula_components: &RikiddoFormulaComponents<FS>,
     ) -> Result<FS, &'static str> {
-        let mut numerator: FS = 0
-            .checked_to_fixed()
-            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
+        let mut numerator = fixed_zero::<FS>()?;
         let mut skipped = false;
 
         for elem in asset_balances {
@@ -655,9 +646,7 @@ where
             return convert_to_unsigned(self.config.initial_fee);
         };
 
-        let zero = FU::checked_from_num(0u8)
-            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
-        if mal == zero {
+        if mal == fixed_zero::<FU>()? {
             return Err(
                 "[RikiddoSigmoidMV] Zero division error during calculation: ma_short / ma_long"
             );
@@ -720,9 +709,7 @@ where
     ) -> Result<Self::FU, &'static str> {
         let mut formula_components = RikiddoFormulaComponents::default();
         let mut asset_balances_signed = Vec::with_capacity(asset_balances.len());
-        let mut asset_in_question_balance_signed = 0
-            .checked_to_fixed()
-            .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
+        let mut asset_in_question_balance_signed = fixed_zero()?;
         let mut asset_in_question_found = false;
 
         for asset_balance in asset_balances {
@@ -785,10 +772,7 @@ where
 
         if let Some(mas) = mas {
             if let Some(mal) = mal {
-                let zero = 0u32
-                    .checked_to_fixed::<FU>()
-                    .ok_or("Unexpectedly failed to convert zero to fixed point number")?;
-                if mal != zero {
+                if mal != fixed_zero::<FU>()? {
                     return Ok(Some(mas.saturating_div(mal)));
                 }
             };

--- a/zrml/rikiddo/src/types/sigmoid_fee.rs
+++ b/zrml/rikiddo/src/types/sigmoid_fee.rs
@@ -1,9 +1,9 @@
 //! This module contains the structures used to calculate the fee based on a sigmoid curve.
 
-use super::convert_to_signed;
 use crate::{
     constants::{INITIAL_FEE, M, MINIMAL_REVENUE, N, P},
     traits::Fee,
+    utils::convert_to_signed,
 };
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Result as ArbiraryResult, Unstructured};

--- a/zrml/rikiddo/src/utils.rs
+++ b/zrml/rikiddo/src/utils.rs
@@ -11,3 +11,12 @@ pub fn fixed_zero<FixedType: Fixed>() -> Result<FixedType, &'static str> {
         Err("Unexpectedly failed to convert zero to fixed point type")
     }
 }
+
+/// Return the maximum value of FixedType as u128.
+pub fn max_value_u128<FixedType: Fixed>() -> Result<u128, &'static str> {
+    if let Some(res) = FixedType::max_value().int().checked_to_num() {
+        Ok(res)
+    } else {
+        Err("Unexpectedly failed to convert max_value of fixed point type to u128")
+    }
+}

--- a/zrml/rikiddo/src/utils.rs
+++ b/zrml/rikiddo/src/utils.rs
@@ -1,0 +1,22 @@
+//! This module contains utility functions for creating commonly used
+//! fixed point type constants.
+
+use substrate_fixed::traits::Fixed;
+
+/// Create a fixed point number that represents 0 (zero).
+pub fn fixed_zero<FixedType: Fixed>() -> Result<FixedType, &'static str> {
+    if let Some(res) = FixedType::checked_from_num(0) {
+        Ok(res)
+    } else {
+        Err("Unexpectedly failed to convert zero to fixed point type")
+    }
+}
+
+/// Create a fixed point number that represents 0 (zero).
+pub fn fixed_one<FixedType: Fixed>() -> Result<FixedType, &'static str> {
+    if let Some(res) = FixedType::checked_from_num(1) {
+        Ok(res)
+    } else {
+        Err("Unexpectedly failed to convert zero to fixed point type")
+    }
+}

--- a/zrml/rikiddo/src/utils.rs
+++ b/zrml/rikiddo/src/utils.rs
@@ -1,7 +1,14 @@
 //! This module contains utility functions for creating commonly used
 //! fixed point type constants.
 
-use substrate_fixed::traits::Fixed;
+use super::traits::{FromFixedDecimal, FromFixedToDecimal, IntoFixedDecimal, IntoFixedFromDecimal};
+use alloc::{borrow::ToOwned, string::ToString};
+use core::{cmp::Ordering, convert::TryFrom};
+use substrate_fixed::{
+    traits::{Fixed, FixedSigned, FixedUnsigned, LossyFrom, LossyInto, ToFixed},
+    types::extra::{U127, U128},
+    FixedI128, FixedU128, ParseFixedError,
+};
 
 /// Create a fixed point number that represents 0 (zero).
 pub fn fixed_zero<FixedType: Fixed>() -> Result<FixedType, &'static str> {
@@ -18,5 +25,189 @@ pub fn max_value_u128<FixedType: Fixed>() -> Result<u128, &'static str> {
         Ok(res)
     } else {
         Err("Unexpectedly failed to convert max_value of fixed point type to u128")
+    }
+}
+
+/// Returns integer part of `FROM`, if the msb is not set and and num does it into `FROM`.
+fn convert_common<FROM: Fixed, TO: Fixed>(num: FROM) -> Result<TO, &'static str> {
+    // Check if number is negatie
+    if num < fixed_zero::<FROM>()? {
+        return Err("Cannot convert negative signed number into unsigned number");
+    }
+
+    // PartialOrd is bugged, therefore the workaround
+    // https://github.com/encointer/substrate-fixed/issues/9
+    let num_u128: u128 = num.int().checked_to_num().ok_or("Conversion from FROM to u128 failed")?;
+    if max_value_u128::<TO>()? < num_u128 {
+        return Err("Fixed point conversion failed: FROM type does not fit in TO type");
+    }
+
+    num_u128.checked_to_fixed().ok_or("Integer part of fixed point number does not fit into u128")
+}
+
+/// Converts an unsigned fixed point number into a signed fixed point number (fallible).
+pub fn convert_to_signed<FROM: FixedUnsigned, TO: FixedSigned + LossyFrom<FixedI128<U127>>>(
+    num: FROM,
+) -> Result<TO, &'static str> {
+    let integer_part: TO = convert_common(num)?;
+    let fractional_part: FixedI128<U127> = num
+        .frac()
+        .checked_to_fixed()
+        .ok_or("Fraction of fixed point number unexpectedly does not fit into FixedI128<U127>")?;
+
+    if let Some(res) = integer_part.checked_add(fractional_part.lossy_into()) {
+        Ok(res)
+    } else {
+        // This error should be impossible to reach.
+        Err("Something went wrong during FixedUnsigned to FixedSigned type conversion")
+    }
+}
+
+/// Converts a signed fixed point number into an unsigned fixed point number (fallible).
+pub fn convert_to_unsigned<FROM: FixedSigned, TO: FixedUnsigned + LossyFrom<FixedU128<U128>>>(
+    num: FROM,
+) -> Result<TO, &'static str> {
+    // We can safely cast because until here we know that the msb is not set.
+    let integer_part: TO = convert_common(num)?;
+    let fractional_part: FixedU128<U128> = num
+        .frac()
+        .checked_to_fixed()
+        .ok_or("Fraction of fixed point number unexpectedly does not fit into FixedU128<U128>")?;
+    if let Some(res) = integer_part.checked_add(fractional_part.lossy_into()) {
+        Ok(res)
+    } else {
+        // This error should be impossible to reach.
+        Err("Something went wrong during FixedSigned to FixedUnsigned type conversion")
+    }
+}
+
+impl<F: Fixed, N: Into<u128>> FromFixedDecimal<N> for F {
+    /// Craft a `Fixed` type from a fixed point decimal number of type `N`
+    fn from_fixed_decimal(decimal: N, places: u8) -> Result<Self, ParseFixedError> {
+        let decimal_u128 = decimal.into();
+        let mut decimal_string = decimal_u128.to_string();
+
+        if decimal_string.len() <= places as usize {
+            // This can never underflow (places >= len). Saturating subtraction to satisfy clippy.
+            decimal_string = "0.".to_owned()
+                + &"0".repeat((places as usize).saturating_sub(decimal_string.len()))
+                + &decimal_string;
+        } else {
+            // This can never underflow (len >= places). Saturating subtraction to satisfy clippy.
+            decimal_string.insert(decimal_string.len().saturating_sub(places as usize), '.');
+        }
+
+        F::from_str(&decimal_string)
+    }
+}
+
+impl<F, N> IntoFixedFromDecimal<F> for N
+where
+    F: Fixed + FromFixedDecimal<Self>,
+    N: Into<u128>,
+{
+    /// Converts a fixed point decimal number into `Fixed` type (e.g. `Balance` -> `Fixed`).
+    fn to_fixed_from_fixed_decimal(self, places: u8) -> Result<F, ParseFixedError> {
+        F::from_fixed_decimal(self, places)
+    }
+}
+
+impl<F: Fixed, N: TryFrom<u128>> FromFixedToDecimal<F> for N {
+    /// Craft a fixed point decimal number from a `Fixed` type (e.g. `Fixed` -> `Balance`).
+    fn from_fixed_to_fixed_decimal(fixed: F, places: u8) -> Result<N, &'static str> {
+        if places == 0 {
+            let mut result = fixed
+                .checked_to_num::<u128>()
+                .ok_or("The fixed point number does not fit into a u128")?;
+
+            // Arithmetic rounding (+1 if >= 0.5)
+            if F::frac_nbits() > 0 {
+                let two = F::checked_from_num(2)
+                    .ok_or("Unexpectedly failed to convert 2 to fixed point number")?;
+                let one = F::checked_from_num(1)
+                    .ok_or("Unexpectedly failed to convert 1 to fixed point number")?;
+                let half =
+                    one.checked_div(two).ok_or("Unexpected overflow when dividing one by two")?;
+
+                if fixed.frac() >= half {
+                    result = result.saturating_add(1);
+                }
+            }
+
+            if let Ok(res) = N::try_from(result) {
+                return Ok(res);
+            } else {
+                return Err(
+                    "The parsed fixed decimal representation does not fit into the target type"
+                );
+            }
+        }
+
+        let mut fixed_str = fixed.to_string();
+        let fixed_frac = fixed.frac();
+
+        let places_usize: usize = places.into();
+
+        if fixed_frac == 0 {
+            // Add `places` times 0 to pad all remaining fractional decimal places
+            fixed_str += &"0".repeat(places_usize);
+        } else {
+            let frac_string = fixed_frac.to_string();
+            let frac_str = frac_string.get(2..).unwrap_or_default();
+
+            match frac_str.len().cmp(&places_usize) {
+                Ordering::Less => {
+                    fixed_str.retain(|c| c != '.');
+                    // Padding to the right side up to `places`. Cannot underflow.
+                    fixed_str += &"0".repeat(places_usize.saturating_sub(frac_str.len()));
+                }
+                Ordering::Greater => {
+                    // Cutting down to `places` + arithmetic rounding of the last digit
+                    let frac_plus_one_digit_str =
+                        frac_str.get(..places_usize.saturating_add(1)).unwrap_or_default();
+
+                    if let Ok(mut res) = frac_plus_one_digit_str.parse::<u128>() {
+                        let last_digit = res % 10;
+                        res /= 10;
+
+                        if last_digit >= 5 {
+                            res = res.saturating_add(1);
+                        }
+
+                        fixed_str = fixed.int().to_string() + &res.to_string()
+                    } else {
+                        // Impossible unless there is a bug in Fixed's to_string()
+                        return Err(
+                            "Error parsing the string representation of the fixed point number"
+                        );
+                    };
+                }
+                Ordering::Equal => fixed_str.retain(|c| c != '.'),
+            };
+        }
+
+        let result = if let Ok(res) = fixed_str[..].parse::<u128>() {
+            res
+        } else {
+            // Impossible unless there is a bug in Fixed's to_string()
+            return Err("Error parsing the string representation of the fixed point number");
+        };
+
+        if let Ok(res) = N::try_from(result) {
+            Ok(res)
+        } else {
+            Err("The parsed fixed decimal representation does not fit into the target type")
+        }
+    }
+}
+
+impl<F, N> IntoFixedDecimal<N> for F
+where
+    F: Fixed,
+    N: FromFixedToDecimal<Self>,
+{
+    /// Converts a `Fixed` type into a fixed point decimal number.
+    fn to_fixed_decimal(self, places: u8) -> Result<N, &'static str> {
+        N::from_fixed_to_fixed_decimal(self, places)
     }
 }

--- a/zrml/rikiddo/src/utils.rs
+++ b/zrml/rikiddo/src/utils.rs
@@ -11,12 +11,3 @@ pub fn fixed_zero<FixedType: Fixed>() -> Result<FixedType, &'static str> {
         Err("Unexpectedly failed to convert zero to fixed point type")
     }
 }
-
-/// Create a fixed point number that represents 0 (zero).
-pub fn fixed_one<FixedType: Fixed>() -> Result<FixedType, &'static str> {
-    if let Some(res) = FixedType::checked_from_num(1) {
-        Ok(res)
-    } else {
-        Err("Unexpectedly failed to convert zero to fixed point type")
-    }
-}

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -598,7 +598,7 @@ mod pallet {
         type FixedTypeU: Decode
             + Encode
             + FixedUnsigned
-            + From<u32>
+            + From<u8>
             + LossyFrom<FixedU32<U24>>
             + LossyFrom<FixedU32<U32>>
             + LossyFrom<FixedU128<U128>>;


### PR DESCRIPTION
Removed all instances of `to_num`, `from_num`, `to_fixed` and `from_fixed`. Some repeated code is now abstracted into utility functions.

To remove panickers from implementations of the `Default` trait, we've added a `From<u32>` or `From<i32>` trait bounds to some Rikiddo structs. These do not seem to be serious restrictions.

Closes #338.