### PR TITLE
Introduce StorageVersion

### DIFF
--- a/zrml/authorized/src/lib.rs
+++ b/zrml/authorized/src/lib.rs
@@ -20,7 +20,7 @@ mod pallet {
     use frame_support::{
         dispatch::DispatchResult,
         pallet_prelude::StorageDoubleMap,
-        traits::{Currency, Get, Hooks, IsType},
+        traits::{Currency, Get, Hooks, IsType, StorageVersion},
         Blake2_128Concat, PalletId,
     };
     use frame_system::{ensure_signed, pallet_prelude::OriginFor};
@@ -30,6 +30,9 @@ mod pallet {
         types::{Market, MarketDispute, MarketDisputeMechanism, OutcomeReport},
     };
     use zrml_market_commons::MarketCommonsPalletApi;
+
+    /// The current storage version.
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
     pub(crate) type BalanceOf<T> =
         <CurrencyOf<T> as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -114,6 +117,7 @@ mod pallet {
     impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
 
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T>(PhantomData<T>);
 
     impl<T> Pallet<T> where T: Config {}

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -35,6 +35,7 @@ mod pallet {
         pallet_prelude::{StorageDoubleMap, StorageMap, StorageValue, ValueQuery},
         traits::{
             BalanceStatus, Currency, Get, Hooks, IsType, NamedReservableCurrency, Randomness,
+            StorageVersion,
         },
         Blake2_128Concat, PalletId,
     };
@@ -56,6 +57,8 @@ mod pallet {
     // Number of jurors for an initial market dispute
     const INITIAL_JURORS_NUM: usize = 3;
     const MAX_RANDOM_JURORS: usize = 13;
+    /// The current storage version.
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
     // Weight used to increase the number of jurors for subsequent disputes
     // of the same market
     const SUBSEQUENT_JURORS_FACTOR: usize = 2;
@@ -185,6 +188,7 @@ mod pallet {
     impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
 
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T>(PhantomData<T>);
 
     impl<T> Pallet<T>

--- a/zrml/liquidity-mining/src/lib.rs
+++ b/zrml/liquidity-mining/src/lib.rs
@@ -50,7 +50,9 @@ mod pallet {
             types::{StorageDoubleMap, StorageValue, ValueQuery},
             with_transaction,
         },
-        traits::{Currency, ExistenceRequirement, Get, Hooks, IsType, WithdrawReasons},
+        traits::{
+            Currency, ExistenceRequirement, Get, Hooks, IsType, StorageVersion, WithdrawReasons,
+        },
         Blake2_128Concat, PalletId, Twox64Concat,
     };
     use frame_system::{ensure_root, pallet_prelude::OriginFor};
@@ -63,6 +65,9 @@ mod pallet {
         types::{MarketPeriod, MaxRuntimeUsize},
     };
     use zrml_market_commons::MarketCommonsPalletApi;
+
+    /// The current storage version.
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
     pub(crate) type BalanceOf<T> =
         <CurrencyOf<T> as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -182,6 +187,7 @@ mod pallet {
     }
 
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T>(PhantomData<T>);
 
     impl<T> Pallet<T>

--- a/zrml/market-commons/src/lib.rs
+++ b/zrml/market-commons/src/lib.rs
@@ -20,7 +20,7 @@ mod pallet {
     use frame_support::{
         dispatch::DispatchResult,
         pallet_prelude::{StorageMap, StorageValue, ValueQuery},
-        traits::{Hooks, NamedReservableCurrency, Time},
+        traits::{Hooks, NamedReservableCurrency, StorageVersion, Time},
         Blake2_128Concat, Parameter,
     };
     use sp_runtime::{
@@ -28,6 +28,9 @@ mod pallet {
         ArithmeticError, DispatchError,
     };
     use zeitgeist_primitives::types::{Market, PoolId, Report};
+
+    /// The current storage version.
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
     type MomentOf<T> = <<T as Config>::Timestamp as frame_support::traits::Time>::Moment;
 
@@ -70,6 +73,7 @@ mod pallet {
     impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
 
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T>(PhantomData<T>);
 
     impl<T> Pallet<T>

--- a/zrml/orderbook-v1/src/lib.rs
+++ b/zrml/orderbook-v1/src/lib.rs
@@ -40,7 +40,8 @@ mod pallet {
         ensure,
         pallet_prelude::{StorageMap, StorageValue, ValueQuery},
         traits::{
-            Currency, ExistenceRequirement, Hooks, IsType, ReservableCurrency, WithdrawReasons,
+            Currency, ExistenceRequirement, Hooks, IsType, ReservableCurrency, StorageVersion,
+            WithdrawReasons,
         },
         Blake2_128Concat, Identity,
     };
@@ -52,6 +53,9 @@ mod pallet {
         ArithmeticError, DispatchError,
     };
     use zeitgeist_primitives::{traits::MarketId, types::Asset};
+
+    /// The current storage version.
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
     pub(crate) type BalanceOf<T> =
         <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -285,6 +289,7 @@ mod pallet {
     impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
 
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T>(PhantomData<T>);
 
     #[pallet::storage]

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -76,7 +76,7 @@ mod pallet {
         storage::{with_transaction, TransactionOutcome},
         traits::{
             Currency, EnsureOrigin, ExistenceRequirement, Get, Hooks, Imbalance, IsType,
-            NamedReservableCurrency, OnUnbalanced,
+            NamedReservableCurrency, OnUnbalanced, StorageVersion,
         },
         transactional, Blake2_128Concat, PalletId, Twox64Concat,
     };
@@ -100,6 +100,9 @@ mod pallet {
     use zrml_market_commons::MarketCommonsPalletApi;
 
     pub(crate) const RESERVE_ID: [u8; 8] = PmPalletId::get().0;
+
+    /// The current storage version.
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
     pub(crate) type BalanceOf<T> =
         <CurrencyOf<T> as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -1324,6 +1327,7 @@ mod pallet {
     }
 
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T>(PhantomData<T>);
 
     /// For each market, this holds the dispute information for each dispute that's

--- a/zrml/rikiddo/src/lib.rs
+++ b/zrml/rikiddo/src/lib.rs
@@ -64,7 +64,7 @@ pub mod pallet {
         debug,
         dispatch::DispatchResult,
         pallet_prelude::StorageMap,
-        traits::{Get, Hooks, Time},
+        traits::{Get, Hooks, StorageVersion, Time},
         Twox64Concat,
     };
     use parity_scale_codec::{Decode, Encode, FullCodec, FullEncode};
@@ -77,6 +77,9 @@ pub mod pallet {
         },
         FixedI128, FixedI32, FixedU128, FixedU32,
     };
+
+    /// The current storage version.
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
     #[pallet::config]
     pub trait Config<I: 'static = ()>: frame_system::Config {
@@ -140,6 +143,7 @@ pub mod pallet {
     impl<T: Config<I>, I: 'static> Hooks<T::BlockNumber> for Pallet<T, I> {}
 
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T, I = ()>(PhantomData<T>, PhantomData<I>);
 
     #[pallet::call]

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -43,7 +43,7 @@ mod pallet {
         ensure, log,
         pallet_prelude::{StorageDoubleMap, StorageMap, StorageValue, ValueQuery},
         storage::{with_transaction, TransactionOutcome},
-        traits::{Get, IsType},
+        traits::{Get, IsType, StorageVersion},
         Blake2_128Concat, PalletId, Twox64Concat,
     };
     use frame_system::{ensure_root, ensure_signed, pallet_prelude::OriginFor};
@@ -75,6 +75,9 @@ mod pallet {
         traits::RikiddoMVPallet,
         types::{EmaMarketVolume, FeeSigmoid, RikiddoSigmoidMV},
     };
+
+    /// The current storage version.
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
     pub(crate) type BalanceOf<T> =
         <<T as Config>::Shares as MultiCurrency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -845,6 +848,7 @@ mod pallet {
     }
 
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     #[pallet::generate_store(pub(super) trait Store)]
     pub struct Pallet<T>(PhantomData<T>);
 


### PR DESCRIPTION
closes #397 

In response to https://github.com/paritytech/substrate/pull/9165

`PalletVersion` is replaced by `StorageVersion`. This PR adds `StorageVersion` to the storage of each of our pallets and initializes it with zero.
We could use https://github.com/paritytech/substrate/pull/9165#issuecomment-887675856 to migrate our major number of the previous `PalletVersion`, but this would result in no changes, since the major number was zero in every case and the default value of the `StorageVersion` ([`u16`](https://github.com/paritytech/substrate/blob/b8c5b846617f837116e63ab1794a5310fb960246/frame/support/src/traits/metadata.rs#L179)) is zero as well (the storage is not initialized, hence the default value is used). Consequently, we can just skip that migration.
