### PR TITLE
Use BoundedVec instead of WeakBoundedVec

### DIFF
--- a/zrml/orderbook-v1/src/lib.rs
+++ b/zrml/orderbook-v1/src/lib.rs
@@ -43,7 +43,7 @@ mod pallet {
             Currency, ExistenceRequirement, Hooks, IsType, ReservableCurrency, StorageVersion,
             WithdrawReasons,
         },
-        transactional, Blake2_128Concat, Identity, WeakBoundedVec,
+        transactional, Blake2_128Concat, Identity, BoundedVec,
     };
     use frame_system::{ensure_signed, pallet_prelude::OriginFor};
     use orml_traits::{MultiCurrency, MultiReservableCurrency};
@@ -209,7 +209,7 @@ mod pallet {
                         Error::<T>::InsufficientBalance,
                     );
 
-                    <Bids<T>>::try_mutate(asset, |b: &mut WeakBoundedVec<T::Hash, _>| {
+                    <Bids<T>>::try_mutate(asset, |b: &mut BoundedVec<T::Hash, _>| {
                         b.try_push(hash).map_err(|_| <Error<T>>::StorageOverflow)
                     })?;
 
@@ -304,7 +304,7 @@ mod pallet {
         _,
         Blake2_128Concat,
         Asset<T::MarketId>,
-        WeakBoundedVec<T::Hash, ConstU32<1_048_576>>,
+        BoundedVec<T::Hash, ConstU32<1_048_576>>,
         ValueQuery,
     >;
 
@@ -314,7 +314,7 @@ mod pallet {
         _,
         Blake2_128Concat,
         Asset<T::MarketId>,
-        WeakBoundedVec<T::Hash, ConstU32<1_048_576>>,
+        BoundedVec<T::Hash, ConstU32<1_048_576>>,
         ValueQuery,
     >;
 
@@ -342,7 +342,7 @@ mod pallet {
         }
     }
 
-    fn remove_item<I: cmp::PartialEq + Copy, G>(items: &mut WeakBoundedVec<I, G>, item: I) {
+    fn remove_item<I: cmp::PartialEq + Copy, G>(items: &mut BoundedVec<I, G>, item: I) {
         let pos = items.iter().position(|&i| i == item).unwrap();
         items.swap_remove(pos);
     }

--- a/zrml/orderbook-v1/src/lib.rs
+++ b/zrml/orderbook-v1/src/lib.rs
@@ -43,7 +43,7 @@ mod pallet {
             Currency, ExistenceRequirement, Hooks, IsType, ReservableCurrency, StorageVersion,
             WithdrawReasons,
         },
-        transactional, Blake2_128Concat, Identity, BoundedVec,
+        transactional, Blake2_128Concat, BoundedVec, Identity,
     };
     use frame_system::{ensure_signed, pallet_prelude::OriginFor};
     use orml_traits::{MultiCurrency, MultiReservableCurrency};

--- a/zrml/prediction-markets/src/benchmarks.rs
+++ b/zrml/prediction-markets/src/benchmarks.rs
@@ -11,7 +11,7 @@ use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, vec, wh
 use frame_support::{
     dispatch::UnfilteredDispatchable,
     traits::{Currency, EnsureOrigin, Get, Hooks},
-    WeakBoundedVec,
+    BoundedVec,
 };
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
@@ -423,7 +423,7 @@ benchmarks! {
             period: MarketPeriod::Block(T::BlockNumber::one()..T::BlockNumber::one())
         };
 
-        let markets = WeakBoundedVec::try_from(vec![market_info; a as usize]).unwrap();
+        let markets = BoundedVec::try_from(vec![market_info; a as usize]).unwrap();
         <MarketsCollectingSubsidy<T>>::put(markets);
     }: {
         Pallet::<T>::process_subsidy_collecting_markets(

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -78,7 +78,7 @@ mod pallet {
             Currency, EnsureOrigin, ExistenceRequirement, Get, Hooks, Imbalance, IsType,
             NamedReservableCurrency, OnUnbalanced, StorageVersion,
         },
-        transactional, Blake2_128Concat, PalletId, Twox64Concat, WeakBoundedVec,
+        transactional, Blake2_128Concat, PalletId, Twox64Concat, BoundedVec,
     };
     use frame_system::{ensure_signed, pallet_prelude::OriginFor};
     use orml_traits::MultiCurrency;
@@ -1341,7 +1341,7 @@ mod pallet {
         _,
         Blake2_128Concat,
         MarketIdOf<T>,
-        WeakBoundedVec<MarketDispute<T::AccountId, T::BlockNumber>, T::MaxDisputes>,
+        BoundedVec<MarketDispute<T::AccountId, T::BlockNumber>, T::MaxDisputes>,
         ValueQuery,
     >;
 
@@ -1352,7 +1352,7 @@ mod pallet {
         _,
         Twox64Concat,
         T::BlockNumber,
-        WeakBoundedVec<MarketIdOf<T>, ConstU32<1024>>,
+        BoundedVec<MarketIdOf<T>, ConstU32<1024>>,
         ValueQuery,
     >;
 
@@ -1362,7 +1362,7 @@ mod pallet {
         _,
         Twox64Concat,
         T::BlockNumber,
-        WeakBoundedVec<MarketIdOf<T>, ConstU32<1024>>,
+        BoundedVec<MarketIdOf<T>, ConstU32<1024>>,
         ValueQuery,
     >;
 
@@ -1372,7 +1372,7 @@ mod pallet {
     #[pallet::storage]
     pub type MarketsCollectingSubsidy<T: Config> = StorageValue<
         _,
-        WeakBoundedVec<
+        BoundedVec<
             SubsidyUntil<T::BlockNumber, MomentOf<T>, MarketIdOf<T>>,
             ConstU32<1_048_576>,
         >,
@@ -1934,7 +1934,7 @@ mod pallet {
 
             let mut weight_basis = 0;
             <MarketsCollectingSubsidy<T>>::mutate(
-                |e: &mut WeakBoundedVec<
+                |e: &mut BoundedVec<
                     SubsidyUntil<T::BlockNumber, MomentOf<T>, MarketIdOf<T>>,
                     _,
                 >| {
@@ -2093,7 +2093,7 @@ mod pallet {
         )
     }
 
-    fn remove_item<I: cmp::PartialEq, G>(items: &mut WeakBoundedVec<I, G>, item: &I) {
+    fn remove_item<I: cmp::PartialEq, G>(items: &mut BoundedVec<I, G>, item: &I) {
         if let Some(pos) = items.iter().position(|i| i == item) {
             items.swap_remove(pos);
         }

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -78,7 +78,7 @@ mod pallet {
             Currency, EnsureOrigin, ExistenceRequirement, Get, Hooks, Imbalance, IsType,
             NamedReservableCurrency, OnUnbalanced, StorageVersion,
         },
-        transactional, Blake2_128Concat, PalletId, Twox64Concat, BoundedVec,
+        transactional, Blake2_128Concat, BoundedVec, PalletId, Twox64Concat,
     };
     use frame_system::{ensure_signed, pallet_prelude::OriginFor};
     use orml_traits::MultiCurrency;
@@ -1372,10 +1372,7 @@ mod pallet {
     #[pallet::storage]
     pub type MarketsCollectingSubsidy<T: Config> = StorageValue<
         _,
-        BoundedVec<
-            SubsidyUntil<T::BlockNumber, MomentOf<T>, MarketIdOf<T>>,
-            ConstU32<1_048_576>,
-        >,
+        BoundedVec<SubsidyUntil<T::BlockNumber, MomentOf<T>, MarketIdOf<T>>, ConstU32<1_048_576>>,
         ValueQuery,
     >;
 


### PR DESCRIPTION
We initially used `WeakBoundedVec` instead of `BoundedVec` because of pre-existing vector size concerns. `BoundedVec` is preferred over `WeakBoundedVec` though (due to stricter checks).
Since those concern only target the battery station testnet and in reality are very very unlikely to occur, plus that it is a breaking change later down the line, I decided to fast-track that PR (before mainnet launch)