### PR TITLE
Fix weight of `pool_join_with_exact_asset_amount`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11903,7 +11903,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-node"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "cfg-if 1.0.0",
  "cumulus-client-cli",
@@ -11978,7 +11978,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-primitives"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "frame-support",
@@ -11995,7 +11995,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-runtime"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "cfg-if 1.0.0",
  "cumulus-pallet-dmp-queue",
@@ -12093,7 +12093,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-authorized"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12110,7 +12110,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-court"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "arrayvec 0.7.2",
  "frame-benchmarking",
@@ -12130,7 +12130,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-liquidity-mining"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12148,7 +12148,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-market-commons"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12161,7 +12161,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-orderbook-v1"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12190,7 +12190,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12234,7 +12234,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets-runtime-api"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "parity-scale-codec 2.3.1",
  "sp-api",
@@ -12243,7 +12243,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-rikiddo"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "cfg-if 1.0.0",
@@ -12276,7 +12276,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-simple-disputes"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12293,7 +12293,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12330,7 +12330,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-rpc"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -12345,7 +12345,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-runtime-api"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "parity-scale-codec 2.3.1",
  "sp-api",

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -1592,7 +1592,7 @@ mod pallet {
                 pool_id,
                 pool: pool_ref,
             };
-            let weight = T::WeightInfo::pool_exit_with_exact_asset_amount();
+            let weight = T::WeightInfo::pool_join_with_exact_asset_amount();
             pool_join_with_exact_amount::<_, _, _, T>(params).map(|_| weight)
         }
 


### PR DESCRIPTION
General note (I think others have pointed this out): It seems like the way that weights are specified in `swaps` is a bit inconsistent. Maybe in a future refactor, this should be cleaned up more thoroughly.