### PR TITLE
Add missing parachain-staking migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,7 +4943,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/purestake/moonbeam?rev=45257659f04b28dd4927b5dc611fac6f9e8905fd#45257659f04b28dd4927b5dc611fac6f9e8905fd"
+source = "git+https://github.com/purestake/moonbeam?rev=30b955354981b6d11808c10d728e1b93fa919f33#30b955354981b6d11808c10d728e1b93fa919f33"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "parachain-staking"
 version = "3.0.0"
-source = "git+https://github.com/zeitgeistpm/moonbeam?branch=parachain-staking-migrations-3#3fbd882f551e629d5a29791b302d80dd4e4b4364"
+source = "git+https://github.com/zeitgeistpm/moonbeam?branch=parachain-staking-migrations-3#916f2748e4caa3c384ea9e9de2c471e6abca3ed5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -56,7 +56,7 @@ cumulus-relay-chain-local = { branch = "moonbeam-polkadot-v0.9.16", git = "https
 nimbus-consensus = { branch = "moonbeam-polkadot-v0.9.16", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
 nimbus-primitives = { branch = "moonbeam-polkadot-v0.9.16", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
 pallet-author-inherent = { branch = "moonbeam-polkadot-v0.9.16", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
-parachain-staking = { rev = "45257659f04b28dd4927b5dc611fac6f9e8905fd", git = "https://github.com/purestake/moonbeam", optional = true }
+parachain-staking = { rev = "30b955354981b6d11808c10d728e1b93fa919f33", git = "https://github.com/purestake/moonbeam", optional = true }
 parity-scale-codec = { optional = true, version = "3.0.0" }
 sc-chain-spec = { branch = "moonbeam-polkadot-v0.9.16", git = "https://github.com/purestake/substrate", optional = true }
 sc-network = { branch = "moonbeam-polkadot-v0.9.16", git = "https://github.com/purestake/substrate", optional = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -58,10 +58,10 @@ parachain-info = { branch = "moonbeam-polkadot-v0.9.16", default-features = fals
 
 nimbus-primitives = { branch = "moonbeam-polkadot-v0.9.16", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
 pallet-author-inherent = { branch = "moonbeam-polkadot-v0.9.16", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
-pallet-author-mapping = { rev = "45257659f04b28dd4927b5dc611fac6f9e8905fd", default-features = false, git = "https://github.com/purestake/moonbeam", optional = true }
+pallet-author-mapping = { rev = "30b955354981b6d11808c10d728e1b93fa919f33", default-features = false, git = "https://github.com/purestake/moonbeam", optional = true }
 pallet-author-slot-filter = { branch = "moonbeam-polkadot-v0.9.16", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
 pallet-crowdloan-rewards = { branch = "moonbeam-polkadot-v0.9.16", default-features = false, git = "https://github.com/PureStake/crowdloan-rewards", optional = true }
-parachain-staking = { rev = "45257659f04b28dd4927b5dc611fac6f9e8905fd", default-features = false, git = "https://github.com/purestake/moonbeam", optional = true }
+parachain-staking = { rev = "30b955354981b6d11808c10d728e1b93fa919f33", default-features = false, git = "https://github.com/purestake/moonbeam", optional = true }
 
 # Polkadot
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,7 +21,9 @@ pub use parachain_params::*;
 pub use parameters::*;
 
 #[cfg(feature = "parachain")]
-use parachain_staking::migrations::{PurgeStaleStorage, RemoveExitQueue};
+use parachain_staking::migrations::{
+    PurgeStaleStorage, RemoveExitQueue, SplitCandidateStateToDecreasePoV,
+};
 
 use alloc::{boxed::Box, vec, vec::Vec};
 use frame_support::{
@@ -78,7 +80,11 @@ type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (PurgeStaleStorage<Runtime>, RemoveExitQueue<Runtime>),
+    (
+        PurgeStaleStorage<Runtime>,
+        RemoveExitQueue<Runtime>,
+        SplitCandidateStateToDecreasePoV<Runtime>,
+    ),
 >;
 
 #[cfg(not(feature = "parachain"))]


### PR DESCRIPTION
Unfortunately the [`SplitCandidateStateToDecreasePoV` migration](https://github.com/PureStake/moonbeam/pull/1117) was not listed in the overview document, consequently it was not regarded for inclusion. The `SplitCandidateStateToDecreasePoV` migration is mandatory, leaving it out will brick the parachain because it will be unable to select a collator.

This PR also increases the version of `parachain-staking` to avoid a critical bug that requires a future migration and messes up the inflation expectancy.