### PR TITLE
Add sp-io to runtime dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11903,7 +11903,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-node"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "cfg-if 1.0.0",
  "cumulus-client-cli",
@@ -11978,7 +11978,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-primitives"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "frame-support",
@@ -11995,7 +11995,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-runtime"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "cfg-if 1.0.0",
  "cumulus-pallet-dmp-queue",
@@ -12048,6 +12048,7 @@ dependencies = [
  "sp-core",
  "sp-finality-grandpa",
  "sp-inherents",
+ "sp-io",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
@@ -12093,7 +12094,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-authorized"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12110,7 +12111,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-court"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "arrayvec 0.7.2",
  "frame-benchmarking",
@@ -12130,7 +12131,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-liquidity-mining"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12148,7 +12149,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-market-commons"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12161,7 +12162,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-orderbook-v1"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12190,7 +12191,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12234,7 +12235,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets-runtime-api"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "parity-scale-codec 2.3.1",
  "sp-api",
@@ -12243,7 +12244,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-rikiddo"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "cfg-if 1.0.0",
@@ -12276,7 +12277,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-simple-disputes"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12293,7 +12294,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12330,7 +12331,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-rpc"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -12345,7 +12346,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-runtime-api"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "parity-scale-codec 2.3.1",
  "sp-api",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -93,6 +93,9 @@ zrml-simple-disputes = { default-features = false, path = "../zrml/simple-disput
 zrml-swaps = { default-features = false, path = "../zrml/swaps" }
 zrml-swaps-runtime-api = { default-features = false, path = "../zrml/swaps/runtime-api" }
 
+[dev-dependencies]
+sp-io = { branch = "moonbeam-polkadot-v0.9.16", git = "https://github.com/purestake/substrate" }
+
 [features]
 default = ["std"]
 parachain = [


### PR DESCRIPTION
I randomly get this error when calling `cargo test --features=runtime-benchmarks`:

```
   Compiling zeitgeist-runtime v0.3.0 (/Users/malte/zeitgeist-fork/runtime)
error[E0433]: failed to resolve: use of undeclared crate or module `sp_io`
  --> runtime/src/benchmarking/utils.rs:41:30
   |
41 |     pub fn new_test_ext() -> sp_io::TestExternalities {
   |                              ^^^^^ use of undeclared crate or module `sp_io`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `zeitgeist-runtime` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```

Seems like sp-io is missing as dev-dependency.