### PR TITLE
Remove nimbus patch and parachain-staking migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/zeitgeistpm/nimbus?branch=moonbeam-polkadot-v0.9.16#24f7c50ed1e8652f7f68342c9cb12f52df985079"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.16#0e06b186bdbde069ba9c2177f9baed1bae833b19"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/zeitgeistpm/nimbus?branch=moonbeam-polkadot-v0.9.16#24f7c50ed1e8652f7f68342c9cb12f52df985079"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.16#0e06b186bdbde069ba9c2177f9baed1bae833b19"
 dependencies = [
  "async-trait",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,5 @@ members = [
 ]
 resolver = "2"
 
-[patch."https://github.com/purestake/nimbus"]
-nimbus-consensus = { git = "https://github.com/zeitgeistpm/nimbus", branch = "moonbeam-polkadot-v0.9.16" }
-nimbus-primitives = { git = "https://github.com/zeitgeistpm/nimbus", branch = "moonbeam-polkadot-v0.9.16" }
-
 [patch."https://github.com/purestake/moonbeam"]
 parachain-staking = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "parachain-staking-migrations-3" }

--- a/docs/changelog_for_devs.md
+++ b/docs/changelog_for_devs.md
@@ -1,2 +1,2 @@
 # v0.3.1
-- Removed function parameter "keep_outcome_assets" from dispatchables "create_cpmm_market_and_deploy_assets" and "deploy_swap_pool_and_additional_liquidity" in prediction-markets pallet.
+- Removed function parameter `keep_outcome_assets` from dispatchables `create_cpmm_market_and_deploy_assets` and `deploy_swap_pool_and_additional_liquidity` in prediction-markets pallet.

--- a/docs/changelog_for_devs.md
+++ b/docs/changelog_for_devs.md
@@ -1,0 +1,2 @@
+# v0.3.1
+- Removed function parameter "keep_outcome_assets" from dispatchables "create_cpmm_market_and_deploy_assets" and "deploy_swap_pool_and_additional_liquidity" in prediction-markets pallet.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,21 +73,6 @@ pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 
 type Address = sp_runtime::MultiAddress<AccountId, ()>;
 
-#[cfg(feature = "parachain")]
-type Executive = frame_executive::Executive<
-    Runtime,
-    Block,
-    frame_system::ChainContext<Runtime>,
-    Runtime,
-    AllPalletsWithSystem,
-    (
-        PurgeStaleStorage<Runtime>,
-        RemoveExitQueue<Runtime>,
-        SplitCandidateStateToDecreasePoV<Runtime>,
-    ),
->;
-
-#[cfg(not(feature = "parachain"))]
 type Executive = frame_executive::Executive<
     Runtime,
     Block,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -20,11 +20,6 @@ mod xcm_config;
 pub use parachain_params::*;
 pub use parameters::*;
 
-#[cfg(feature = "parachain")]
-use parachain_staking::migrations::{
-    PurgeStaleStorage, RemoveExitQueue, SplitCandidateStateToDecreasePoV,
-};
-
 use alloc::{boxed::Box, vec, vec::Vec};
 use frame_support::{
     construct_runtime,


### PR DESCRIPTION
closes #459 

Also removes parachain-staking migrations. The patch will be removed after dependency upgrade to v0.9.18 (due to usage of `parity-scale-codec v3`
In addition, a document is added that contains all the changes that affect developers who interact with our node directly. Internally this will help SDK, subsquid and frontend devs to figure out how to adjust for the next release