### PR TITLE
Check that report matches market type and range

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1562,15 +1562,11 @@ mod pallet {
                     return Err(Error::<T>::OutcomeMismatch.into());
                 }
             }
-            if let OutcomeReport::Scalar(ref inner) = outcome {
-                if let MarketType::Scalar(ref outcome_range) = market.market_type {
-                    ensure!(
-                        inner >= outcome_range.start() && inner <= outcome_range.end(),
-                        Error::<T>::OutcomeOutOfRange
-                    );
-                } else {
-                    return Err(Error::<T>::OutcomeMismatch.into());
-                }
+            if let OutcomeReport::Scalar(_) = outcome {
+                ensure!(
+                    matches!(&market.market_type, MarketType::Scalar(_)),
+                    Error::<T>::OutcomeMismatch
+                );
             }
             Ok(())
         }

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -939,10 +939,8 @@ mod pallet {
             let market_report = Report { at: current_block, by: sender.clone(), outcome };
 
             T::MarketCommons::mutate_market(&market_id, |market| {
-                // TODO make this a conditional check
-                // ensure!(outcome <= market.outcomes(), Error::<T>::OutcomeOutOfRange);
                 ensure!(market.report.is_none(), Error::<T>::MarketAlreadyReported);
-
+                Self::ensure_outcome_matches_market_type(market, &market_report.outcome)?;
                 Self::ensure_market_is_closed(&market.period)?;
 
                 let mut should_check_origin = false;


### PR DESCRIPTION
Fixes #552.

Note that we remove the check that scalar markets are within range. Any value outside of the range is already treated as if saturated into the range, and it makes more sense to allow users to report the actual number instead of having to do the saturation themselves.