### PR TITLE
Disallow zero balance in `buy_complete_set`/`sell_complete_set`

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1011,6 +1011,7 @@ mod pallet {
             #[pallet::compact] amount: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
+            ensure!(amount != BalanceOf::<T>::zero(), Error::<T>::ZeroAmount);
 
             let market = T::MarketCommons::market(&market_id)?;
             ensure!(market.scoring_rule == ScoringRule::CPMM, Error::<T>::InvalidScoringRule);
@@ -1198,7 +1199,7 @@ mod pallet {
         InsufficientFundsInMarketAccount,
         /// Sender does not have enough share balance.
         InsufficientShareBalance,
-        /// An invalid Hash was included in a multihash parameter
+        /// An invalid Hash was included in a multihash parameter.
         InvalidMultihash,
         /// An invalid market type was found.
         InvalidMarketType,
@@ -1232,11 +1233,11 @@ mod pallet {
         MaxDisputesReached,
         /// The number of assets specified in a parameter does not match the total asset count.
         NotEnoughAssets,
-        /// The number of categories for a categorical market is too low
+        /// The number of categories for a categorical market is too low.
         NotEnoughCategories,
         /// The user has no winning balance.
         NoWinningBalance,
-        /// Submitted outcome does not match market type
+        /// Submitted outcome does not match market type.
         OutcomeMismatch,
         /// The report is not coming from designated oracle.
         ReporterNotOracle,
@@ -1244,8 +1245,10 @@ mod pallet {
         StorageOverflow,
         /// A swap pool already exists for this market.
         SwapPoolExists,
-        /// Too many categories for a categorical market
+        /// Too many categories for a categorical market.
         TooManyCategories,
+        /// An amount was illegally specified as zero.
+        ZeroAmount,
     }
 
     #[pallet::event]
@@ -1418,6 +1421,7 @@ mod pallet {
             market_id: MarketIdOf<T>,
             amount: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
+            ensure!(amount != BalanceOf::<T>::zero(), Error::<T>::ZeroAmount);
             ensure!(CurrencyOf::<T>::free_balance(&who) >= amount, Error::<T>::NotEnoughBalance);
 
             let market = T::MarketCommons::market(&market_id)?;

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -275,13 +275,14 @@ mod pallet {
             Ok(Some(T::WeightInfo::approve_market().saturating_add(extra_weight)).into())
         }
 
-        /// Buys the complete set of outcome shares of a market. For example, when calling this
-        /// function on a categorical market with five different outcomes, five different shares
-        /// will be transferred to the callee.
+        /// Buy a complete set of outcome shares of a market.
         ///
-        /// The amount of each share will equal the provided `amount` parameter.
+        /// The cost of a full set is exactly one unit of the market's base asset. For example,
+        /// when calling `buy_complete_set(origin, 1, 2)` on a categorical market with five
+        /// different outcomes, the caller pays `2` of the base asset and receives `2` of each of
+        /// the five outcome tokens.
         ///
-        /// NOTE: This is the only way to create new shares.
+        /// NOTE: This is the only way to create new shares of outcome tokens.
         // Note: `buy_complete_set` weight consumption is dependent on how many assets exists.
         // Unfortunately this information can only be retrieved with a storage call, therefore
         // The worst-case scenario is assumed and the correct weight is calculated at the end of this function.
@@ -1000,8 +1001,9 @@ mod pallet {
             Ok(())
         }
 
-        /// Destroys a complete set of outcomes shares for a market.
+        /// Sells a complete set of outcomes shares for a market.
         ///
+        /// Each complete set is sold for one unit of the market's base asset.
         #[pallet::weight(
             T::WeightInfo::sell_complete_set(T::MaxCategories::get().into())
         )]

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -188,10 +188,11 @@ fn it_allows_the_advisory_origin_to_reject_markets() {
 #[test]
 fn it_allows_to_buy_a_complete_set() {
     ExtBuilder::default().build().execute_with(|| {
+        frame_system::Pallet::<Runtime>::set_block_number(1);
         // Creates a permissionless market.
         simple_create_categorical_market::<Runtime>(
             MarketCreation::Permissionless,
-            0..1,
+            0..2,
             ScoringRule::CPMM,
         );
 
@@ -214,6 +215,7 @@ fn it_allows_to_buy_a_complete_set() {
         let market_account = PredictionMarkets::market_account(0);
         let market_bal = Balances::free_balance(market_account);
         assert_eq!(market_bal, CENT);
+        assert!(event_exists(Event::BoughtCompleteSet(0, CENT, BOB)));
     });
 }
 
@@ -313,10 +315,11 @@ fn it_does_not_allow_to_deploy_a_pool_on_pending_advised_market() {
 #[test]
 fn it_allows_to_sell_a_complete_set() {
     ExtBuilder::default().build().execute_with(|| {
+        frame_system::Pallet::<Runtime>::set_block_number(1);
         // Creates a permissionless market.
         simple_create_categorical_market::<Runtime>(
             MarketCreation::Permissionless,
-            0..1,
+            0..2,
             ScoringRule::CPMM,
         );
 
@@ -336,6 +339,8 @@ fn it_allows_to_sell_a_complete_set() {
         // also check native balance
         let bal = Balances::free_balance(&BOB);
         assert_eq!(bal, 1_000 * BASE);
+
+        assert!(event_exists(Event::SoldCompleteSet(0, CENT, BOB)));
     });
 }
 

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -234,6 +234,21 @@ fn it_does_not_allow_to_buy_a_complete_set_on_pending_advised_market() {
 }
 
 #[test]
+fn it_does_not_allow_zero_amounts_in_buy_complete_set() {
+    ExtBuilder::default().build().execute_with(|| {
+        simple_create_categorical_market::<Runtime>(
+            MarketCreation::Permissionless,
+            0..1,
+            ScoringRule::CPMM,
+        );
+        assert_noop!(
+            PredictionMarkets::buy_complete_set(Origin::signed(BOB), 0, 0),
+            Error::<Runtime>::ZeroAmount
+        );
+    });
+}
+
+#[test]
 fn it_allows_to_deploy_a_pool() {
     ExtBuilder::default().build().execute_with(|| {
         // Creates a permissionless market.
@@ -306,6 +321,21 @@ fn it_allows_to_sell_a_complete_set() {
         // also check native balance
         let bal = Balances::free_balance(&BOB);
         assert_eq!(bal, 1_000 * BASE);
+    });
+}
+
+#[test]
+fn it_does_not_allow_zero_amounts_in_sell_complete_set() {
+    ExtBuilder::default().build().execute_with(|| {
+        simple_create_categorical_market::<Runtime>(
+            MarketCreation::Permissionless,
+            0..1,
+            ScoringRule::CPMM,
+        );
+        assert_noop!(
+            PredictionMarkets::sell_complete_set(Origin::signed(BOB), 0, 0),
+            Error::<Runtime>::ZeroAmount
+        );
     });
 }
 

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -249,6 +249,21 @@ fn it_does_not_allow_zero_amounts_in_buy_complete_set() {
 }
 
 #[test]
+fn it_does_not_allow_buying_complete_sets_with_insufficient_balance() {
+    ExtBuilder::default().build().execute_with(|| {
+        simple_create_categorical_market::<Runtime>(
+            MarketCreation::Permissionless,
+            0..1,
+            ScoringRule::CPMM,
+        );
+        assert_noop!(
+            PredictionMarkets::buy_complete_set(Origin::signed(BOB), 0, 10000 * BASE),
+            Error::<Runtime>::NotEnoughBalance
+        );
+    });
+}
+
+#[test]
 fn it_allows_to_deploy_a_pool() {
     ExtBuilder::default().build().execute_with(|| {
         // Creates a permissionless market.
@@ -335,6 +350,23 @@ fn it_does_not_allow_zero_amounts_in_sell_complete_set() {
         assert_noop!(
             PredictionMarkets::sell_complete_set(Origin::signed(BOB), 0, 0),
             Error::<Runtime>::ZeroAmount
+        );
+    });
+}
+
+#[test]
+fn it_does_not_allow_to_sell_complete_sets_with_insufficient_balance() {
+    ExtBuilder::default().build().execute_with(|| {
+        simple_create_categorical_market::<Runtime>(
+            MarketCreation::Permissionless,
+            0..1,
+            ScoringRule::CPMM,
+        );
+        assert_ok!(PredictionMarkets::buy_complete_set(Origin::signed(BOB), 0, 2 * CENT));
+        assert_eq!(Currency::slash(Asset::CategoricalOutcome(0, 1), &BOB, CENT), 0);
+        assert_noop!(
+            PredictionMarkets::sell_complete_set(Origin::signed(BOB), 0, 2 * CENT),
+            Error::<Runtime>::InsufficientShareBalance
         );
     });
 }


### PR DESCRIPTION
Fixes zeitgeistpm/runtime-audit-2#9.

We also extend the tests for `buy_complete_set` and `sell_complete_set`.