### PR TITLE
Ensure that market can only be reported when closed

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -953,7 +953,7 @@ mod pallet {
 
             T::MarketCommons::mutate_market(&market_id, |market| {
                 ensure!(market.report.is_none(), Error::<T>::MarketAlreadyReported);
-                Self::ensure_market_is_closed(&market.period)?;
+                Self::ensure_market_is_closed(&market)?;
                 Self::ensure_outcome_matches_market_type(market, &market_report.outcome)?;
 
                 let mut should_check_origin = false;
@@ -1536,10 +1536,11 @@ mod pallet {
 
         // Check that the market has reached the end of its period.
         fn ensure_market_is_closed(
-            period: &MarketPeriod<T::BlockNumber, MomentOf<T>>,
+            market: &Market<T::AccountId, T::BlockNumber, MomentOf<T>>,
         ) -> DispatchResult {
+            ensure!(market.status == MarketStatus::Active, Error::<T>::MarketIsNotClosed);
             ensure!(
-                match period {
+                match &market.period {
                     MarketPeriod::Block(range) => {
                         <frame_system::Pallet<T>>::block_number() >= range.end
                     }

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -953,7 +953,7 @@ mod pallet {
 
             T::MarketCommons::mutate_market(&market_id, |market| {
                 ensure!(market.report.is_none(), Error::<T>::MarketAlreadyReported);
-                Self::ensure_market_is_closed(&market)?;
+                Self::ensure_market_is_closed(market)?;
                 Self::ensure_outcome_matches_market_type(market, &market_report.outcome)?;
 
                 let mut should_check_origin = false;

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -1114,7 +1114,7 @@ fn market_resolve_does_not_hold_liquidity_withdraw() {
 }
 
 #[test]
-fn report_fails_if_market_is_proposed() {
+fn report_failss_on_market_state_proposed() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(PredictionMarkets::create_categorical_market(
             Origin::signed(ALICE),
@@ -1134,7 +1134,7 @@ fn report_fails_if_market_is_proposed() {
 }
 
 #[test]
-fn report_fails_if_market_is_proposed_after_close() {
+fn report_fails_on_market_state_closed_for_advised_market() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(PredictionMarkets::create_categorical_market(
             Origin::signed(ALICE),
@@ -1155,7 +1155,7 @@ fn report_fails_if_market_is_proposed_after_close() {
 }
 
 #[test]
-fn report_fails_if_market_is_collecting_subsidy() {
+fn report_fails_on_market_state_collecting_subsidy() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(PredictionMarkets::create_categorical_market(
             Origin::signed(ALICE),
@@ -1175,7 +1175,7 @@ fn report_fails_if_market_is_collecting_subsidy() {
 }
 
 #[test]
-fn report_fails_if_market_has_insufficient_subsidy() {
+fn report_fails_on_market_state_insufficient_subsidy() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(PredictionMarkets::create_categorical_market(
             Origin::signed(ALICE),
@@ -1199,7 +1199,7 @@ fn report_fails_if_market_has_insufficient_subsidy() {
 }
 
 #[test]
-fn report_fails_if_market_is_active() {
+fn report_fails_on_market_state_active() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(PredictionMarkets::create_categorical_market(
             Origin::signed(ALICE),
@@ -1219,7 +1219,31 @@ fn report_fails_if_market_is_active() {
 }
 
 #[test]
-fn report_fails_if_market_is_resolved() {
+fn report_fails_on_market_state_suspended() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(PredictionMarkets::create_categorical_market(
+            Origin::signed(ALICE),
+            BOB,
+            MarketPeriod::Timestamp(0..100_000_000),
+            gen_metadata(2),
+            MarketCreation::Permissionless,
+            2,
+            MarketDisputeMechanism::SimpleDisputes,
+            ScoringRule::CPMM
+        ));
+        let _ = MarketCommons::mutate_market(&0, |market| {
+            market.status = MarketStatus::Suspended;
+            Ok(())
+        });
+        assert_noop!(
+            PredictionMarkets::report(Origin::signed(BOB), 0, OutcomeReport::Categorical(1)),
+            Error::<Runtime>::MarketIsNotClosed,
+        );
+    });
+}
+
+#[test]
+fn report_fails_on_market_state_resolved() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(PredictionMarkets::create_categorical_market(
             Origin::signed(ALICE),

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -423,7 +423,7 @@ fn it_allows_to_report_the_outcome_of_a_market() {
 
         // Reset and report again as approval origin
         let _ = MarketCommons::mutate_market(&0, |market| {
-            market.status = MarketStatus::Closed;
+            market.status = MarketStatus::Active;
             market.report = None;
             Ok(())
         });


### PR DESCRIPTION
Fixes zeitgeistpm/runtime-audit-2#3. This is also related to #554.