### PR TITLE
Check market status in `reject_market`

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -921,8 +921,8 @@ mod pallet {
         #[pallet::weight(T::WeightInfo::reject_market())]
         pub fn reject_market(origin: OriginFor<T>, market_id: MarketIdOf<T>) -> DispatchResult {
             T::ApprovalOrigin::ensure_origin(origin)?;
-
             let market = T::MarketCommons::market(&market_id)?;
+            ensure!(market.status == MarketStatus::Proposed, Error::<T>::InvalidMarketStatus);
             let creator = market.creator;
             let (imbalance, _) = CurrencyOf::<T>::slash_reserved_named(
                 &RESERVE_ID,

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -1125,6 +1125,39 @@ fn market_resolve_does_not_hold_liquidity_withdraw() {
     })
 }
 
+#[test]
+fn reject_market_fails_on_permissionless_market() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Creates an advised market.
+        simple_create_categorical_market::<Runtime>(
+            MarketCreation::Permissionless,
+            0..1,
+            ScoringRule::CPMM,
+        );
+        assert_noop!(
+            PredictionMarkets::reject_market(Origin::signed(SUDO), 0),
+            Error::<Runtime>::InvalidMarketStatus
+        );
+    });
+}
+
+#[test]
+fn reject_market_fails_on_approved_market() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Creates an advised market.
+        simple_create_categorical_market::<Runtime>(
+            MarketCreation::Advised,
+            0..1,
+            ScoringRule::CPMM,
+        );
+        assert_ok!(PredictionMarkets::approve_market(Origin::signed(SUDO), 0));
+        assert_noop!(
+            PredictionMarkets::reject_market(Origin::signed(SUDO), 0),
+            Error::<Runtime>::InvalidMarketStatus
+        );
+    });
+}
+
 fn deploy_swap_pool(market: Market<u128, u64, u64>, market_id: u128) -> DispatchResult {
     assert_ok!(PredictionMarkets::buy_complete_set(Origin::signed(FRED), 0, 100 * BASE));
     assert_ok!(Balances::transfer(


### PR DESCRIPTION
Note that the tests don't check every possible scenario over the dimension of `market.status`. For example, we don't check that a reported advised market cannot be rejected. The testing should be easier once we've switched to state machine markets.

Fixes zeitgeistpm/runtime-audit-2#4 and fixes zeitgeistpm/runtime-audit-2#5.

It also fixes zeitgeistpm/runtime-audit-2#8: The problem that the market could be rejected _after_ outcome assets have been created is solved since the market can only be rejected when in the state `Proposed`, in which it is impossible to execute `buy_complete_set` (the only way to create outcome assets). Note that it's impossible to return to `Proposed` state once the market has been approved.