### PR TITLE
Fix tokenomics, set initial liquidity mining to zero

### DIFF
--- a/primitives/src/constants/ztg.rs
+++ b/primitives/src/constants/ztg.rs
@@ -2,35 +2,32 @@ use sp_runtime::Perbill;
 
 // Distribution
 
-/// Total ZTG amount for airdrops
-pub const AIRDROPS: u128 = 3_000_000;
-
-/// Total ZTG amount for collators
-pub const COLLATORS: u128 = 10_000_000;
-
-/// Total ZTG amount for community incentives
+/// Total ZTG amount for community incentives.
 pub const COMMUNITY_INCENTIVES: u128 = 2_000_000;
 
-/// Total ZTG amount for liquidity mining
-pub const LIQUIDITY_MINING: u128 = 10_000_000;
+/// Total ZTG amount for collators
+pub const COLLATORS: u128 = 0;
 
-/// Total ZTG amount for parachain lease
+/// Total ZTG amount for liquidity mining
+pub const LIQUIDITY_MINING: u128 = 0;
+
+/// Total ZTG amount for parachain lease.
 pub const PARACHAIN_LEASE: u128 = 40_000_000;
 
-/// Total ZTG amount for public sale
-pub const PUBLIC_SALE: u128 = 10_000_000;
+/// Total ZTG amount for public sale.
+pub const PUBLIC_SALE: u128 = 8_000_000;
 
-/// Total ZTG amount for seed sale
+/// Total ZTG amount for seed sale.
 pub const SEED_SALE: u128 = 7_000_000;
 
-/// Total ZTG amount for strategic sale
-pub const STRATEGIC_SALE: u128 = 8_000_000;
+/// Total ZTG amount for strategic sale.
+pub const STRATEGIC_SALE: u128 = 6_000_000;
 
-/// Total ZTG amount for Team and advisors
+/// Total ZTG amount for Team and advisors.
 pub const TEAM_AND_ADVISORS: u128 = 15_000_000;
 
-/// Total ZTG amount for Zeitgesit foundation
-pub const ZEITGEIST_FOUNDATION: u128 = 15_000_000;
+/// Total ZTG amount for Zeitgesit foundation.
+pub const ZEITGEIST_FOUNDATION: u128 = 22_000_000;
 
 // Inflation
 


### PR DESCRIPTION
Fixes zeitgeistpm/runtime-audit-1#29. Changes made according to internal communication. The inital funds for liquidity mining have been set to zero.