### PR TITLE
Add `MinSubsidyPerAccount` constant

### DIFF
--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -96,6 +96,7 @@ parameter_types! {
     pub const MaxWeight: Balance = 50 * BASE;
     pub const MinLiquidity: Balance = 100 * BASE;
     pub const MinSubsidy: Balance = MinLiquidity::get();
+    pub const MinSubsidyPerAccount: Balance = MinSubsidy::get();
     pub const MinWeight: Balance = BASE;
     pub const SwapsPalletId: PalletId = PalletId(*b"zge/swap");
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -931,6 +931,7 @@ impl zrml_swaps::Config for Runtime {
     type MaxWeight = MaxWeight;
     type MinLiquidity = MinLiquidity;
     type MinSubsidy = MinSubsidy;
+    type MinSubsidyPerAccount = MinSubsidyPerAccount;
     type MinWeight = MinWeight;
     type PalletId = SwapsPalletId;
     type RikiddoSigmoidFeeMarketEma = RikiddoSigmoidFeeMarketEma;

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -47,6 +47,7 @@ ord_parameter_types! {
 parameter_types! {
     pub const DisputePeriod: BlockNumber = 10;
     pub const TreasuryPalletId: PalletId = PalletId(*b"3.141592");
+    pub const MinSubsidyPerAccount: Balance = BASE;
 }
 
 construct_runtime!(
@@ -239,6 +240,7 @@ impl zrml_swaps::Config for Runtime {
     type MinAssets = MinAssets;
     type MinLiquidity = MinLiquidity;
     type MinSubsidy = MinSubsidy;
+    type MinSubsidyPerAccount = MinSubsidyPerAccount;
     type MinWeight = MinWeight;
     type PalletId = SwapsPalletId;
     type RikiddoSigmoidFeeMarketEma = RikiddoSigmoidFeeMarketEma;

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -172,6 +172,7 @@ mod pallet {
             amount: BalanceOf<T>,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
+            ensure!(amount != Zero::zero(), Error::<T>::ZeroAmount);
 
             <Pools<T>>::try_mutate(pool_id, |pool_opt| {
                 let pool = pool_opt.as_mut().ok_or(Error::<T>::PoolDoesNotExist)?;

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -400,6 +400,7 @@ mod pallet {
             amount: BalanceOf<T>,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
+            ensure!(amount != Zero::zero(), Error::<T>::ZeroAmount);
 
             <Pools<T>>::try_mutate(pool_id, |pool_opt| {
                 let pool = pool_opt.as_mut().ok_or(Error::<T>::PoolDoesNotExist)?;
@@ -772,6 +773,8 @@ mod pallet {
         UnsupportedTrade,
         /// The outcome asset specified as the winning asset was not found in the pool.
         WinningAssetNotFound,
+        /// Some amount in a transaction equals zero.
+        ZeroAmount,
     }
 
     #[pallet::event]

--- a/zrml/swaps/src/mock.rs
+++ b/zrml/swaps/src/mock.rs
@@ -32,6 +32,7 @@ pub type UncheckedExtrinsic = UncheckedExtrinsicTest<Runtime>;
 // Mocked exit fee for easier calculations
 parameter_types! {
     pub storage ExitFeeMock: Balance = BASE / 10;
+    pub const MinSubsidyPerAccount: Balance = BASE;
 }
 
 construct_runtime!(
@@ -68,6 +69,7 @@ impl crate::Config for Runtime {
     type MinAssets = MinAssets;
     type MinLiquidity = MinLiquidity;
     type MinSubsidy = MinSubsidy;
+    type MinSubsidyPerAccount = MinSubsidyPerAccount;
     type MinWeight = MinWeight;
     type PalletId = SwapsPalletId;
     type RikiddoSigmoidFeeMarketEma = RikiddoSigmoidFeeMarketEma;

--- a/zrml/swaps/src/tests.rs
+++ b/zrml/swaps/src/tests.rs
@@ -750,21 +750,8 @@ fn pool_exit_subsidy_unreserves_correct_values() {
         // Events cannot be emitted on block zero...
         frame_system::Pallet::<Runtime>::set_block_number(1);
 
-        create_initial_pool(ScoringRule::CPMM, true);
-        assert_noop!(
-            Swaps::pool_exit_subsidy(alice_signed(), 0, 42),
-            crate::Error::<Runtime>::InvalidScoringRule
-        );
-        assert_noop!(
-            Swaps::pool_exit_subsidy(alice_signed(), 1, 42),
-            crate::Error::<Runtime>::PoolDoesNotExist
-        );
         create_initial_pool_with_funds_for_alice(ScoringRule::RikiddoSigmoidFeeMarketEma, false);
-        let pool_id = 1;
-        assert_noop!(
-            Swaps::pool_exit_subsidy(alice_signed(), pool_id, 42),
-            crate::Error::<Runtime>::NoSubsidyProvided
-        );
+        let pool_id = 0;
 
         // Add some subsidy
         assert_ok!(Swaps::pool_join_subsidy(alice_signed(), pool_id, _25));
@@ -814,6 +801,49 @@ fn pool_exit_subsidy_unreserves_correct_values() {
         total_subsidy = Swaps::pool_by_id(pool_id).unwrap().total_subsidy.unwrap();
         assert_eq!(reserved, 0);
         assert_eq!(reserved, total_subsidy);
+    });
+}
+
+#[test]
+fn pool_exit_subsidy_fails_if_no_subsidy_is_provided() {
+    ExtBuilder::default().build().execute_with(|| {
+        create_initial_pool_with_funds_for_alice(ScoringRule::RikiddoSigmoidFeeMarketEma, false);
+        assert_noop!(
+            Swaps::pool_exit_subsidy(alice_signed(), 0, _1),
+            crate::Error::<Runtime>::NoSubsidyProvided
+        );
+    });
+}
+
+#[test]
+fn pool_exit_subsidy_fails_if_amount_is_zero() {
+    ExtBuilder::default().build().execute_with(|| {
+        create_initial_pool_with_funds_for_alice(ScoringRule::RikiddoSigmoidFeeMarketEma, false);
+        assert_noop!(
+            Swaps::pool_exit_subsidy(alice_signed(), 0, 0),
+            crate::Error::<Runtime>::ZeroAmount
+        );
+    });
+}
+
+#[test]
+fn pool_exit_subsidy_fails_if_pool_does_not_exist() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            Swaps::pool_exit_subsidy(alice_signed(), 0, _1),
+            crate::Error::<Runtime>::PoolDoesNotExist
+        );
+    });
+}
+
+#[test]
+fn pool_exit_subsidy_fails_if_scoring_rule_is_not_rikiddo() {
+    ExtBuilder::default().build().execute_with(|| {
+        create_initial_pool_with_funds_for_alice(ScoringRule::CPMM, true);
+        assert_noop!(
+            Swaps::pool_exit_subsidy(alice_signed(), 0, _1),
+            crate::Error::<Runtime>::InvalidScoringRule
+        );
     });
 }
 
@@ -1007,14 +1037,8 @@ fn pool_join_subsidy_reserves_correct_values() {
     ExtBuilder::default().build().execute_with(|| {
         // Events cannot be emitted on block zero...
         frame_system::Pallet::<Runtime>::set_block_number(1);
-
-        create_initial_pool(ScoringRule::CPMM, true);
-        assert_noop!(
-            Swaps::pool_join_subsidy(alice_signed(), 0, 42),
-            crate::Error::<Runtime>::InvalidScoringRule
-        );
         create_initial_pool_with_funds_for_alice(ScoringRule::RikiddoSigmoidFeeMarketEma, false);
-        let pool_id = 1;
+        let pool_id = 0;
         assert_ok!(Swaps::pool_join_subsidy(alice_signed(), pool_id, _20));
         let mut reserved = Currencies::reserved_balance(ASSET_D, &ALICE);
         let mut noted = <SubsidyProviders<Runtime>>::get(pool_id, &ALICE).unwrap();

--- a/zrml/swaps/src/tests.rs
+++ b/zrml/swaps/src/tests.rs
@@ -1043,6 +1043,38 @@ fn pool_join_subsidy_reserves_correct_values() {
 }
 
 #[test]
+fn pool_join_subsidy_fails_if_amount_is_zero() {
+    ExtBuilder::default().build().execute_with(|| {
+        create_initial_pool_with_funds_for_alice(ScoringRule::RikiddoSigmoidFeeMarketEma, false);
+        assert_noop!(
+            Swaps::pool_join_subsidy(alice_signed(), 0, 0),
+            crate::Error::<Runtime>::ZeroAmount
+        );
+    });
+}
+
+#[test]
+fn pool_join_subsidy_fails_if_pool_does_not_exist() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            Swaps::pool_join_subsidy(alice_signed(), 0, _1),
+            crate::Error::<Runtime>::PoolDoesNotExist
+        );
+    });
+}
+
+#[test]
+fn pool_join_subsidy_fails_if_scoring_rule_is_not_rikiddo() {
+    ExtBuilder::default().build().execute_with(|| {
+        create_initial_pool_with_funds_for_alice(ScoringRule::CPMM, true);
+        assert_noop!(
+            Swaps::pool_join_subsidy(alice_signed(), 0, _1),
+            crate::Error::<Runtime>::InvalidScoringRule
+        );
+    });
+}
+
+#[test]
 fn pool_join_with_exact_asset_amount_exchanges_correct_values() {
     ExtBuilder::default().build().execute_with(|| {
         frame_system::Pallet::<Runtime>::set_block_number(1);

--- a/zrml/swaps/src/tests.rs
+++ b/zrml/swaps/src/tests.rs
@@ -1075,6 +1075,65 @@ fn pool_join_subsidy_fails_if_scoring_rule_is_not_rikiddo() {
 }
 
 #[test]
+fn pool_join_subsidy_fails_if_subsidy_is_below_min_per_account() {
+    ExtBuilder::default().build().execute_with(|| {
+        create_initial_pool_with_funds_for_alice(ScoringRule::RikiddoSigmoidFeeMarketEma, false);
+        assert_noop!(
+            Swaps::pool_join_subsidy(
+                alice_signed(),
+                0,
+                <Runtime as Config>::MinSubsidyPerAccount::get() - 1
+            ),
+            crate::Error::<Runtime>::InvalidSubsidyAmount,
+        );
+    });
+}
+
+#[test]
+fn pool_join_subsidy_with_small_amount_is_ok_if_account_is_already_a_provider() {
+    ExtBuilder::default().build().execute_with(|| {
+        create_initial_pool_with_funds_for_alice(ScoringRule::RikiddoSigmoidFeeMarketEma, false);
+        let pool_id = 0;
+        let large_amount = <Runtime as Config>::MinSubsidyPerAccount::get();
+        let small_amount = 1;
+        let total_amount = large_amount + small_amount;
+        assert_ok!(Swaps::pool_join_subsidy(alice_signed(), pool_id, large_amount));
+        assert_ok!(Swaps::pool_join_subsidy(alice_signed(), pool_id, small_amount));
+        let reserved = Currencies::reserved_balance(ASSET_D, &ALICE);
+        let noted = <SubsidyProviders<Runtime>>::get(pool_id, &ALICE).unwrap();
+        let total_subsidy = Swaps::pool_by_id(pool_id).unwrap().total_subsidy.unwrap();
+        assert_eq!(reserved, total_amount);
+        assert_eq!(noted, total_amount);
+        assert_eq!(total_subsidy, total_amount);
+    });
+}
+
+#[test]
+fn pool_exit_subsidy_unreserves_remaining_subsidy_if_below_min_per_account() {
+    ExtBuilder::default().build().execute_with(|| {
+        frame_system::Pallet::<Runtime>::set_block_number(1);
+        create_initial_pool_with_funds_for_alice(ScoringRule::RikiddoSigmoidFeeMarketEma, false);
+        let pool_id = 0;
+        let large_amount = <Runtime as Config>::MinSubsidyPerAccount::get();
+        let small_amount = 1;
+        assert_ok!(Swaps::pool_join_subsidy(alice_signed(), pool_id, large_amount));
+        assert_ok!(Swaps::pool_exit_subsidy(alice_signed(), pool_id, small_amount));
+        let reserved = Currencies::reserved_balance(ASSET_D, &ALICE);
+        let noted = <SubsidyProviders<Runtime>>::get(pool_id, &ALICE);
+        let total_subsidy = Swaps::pool_by_id(pool_id).unwrap().total_subsidy.unwrap();
+        assert_eq!(reserved, 0);
+        assert!(noted.is_none());
+        assert_eq!(total_subsidy, 0);
+        assert!(event_exists(crate::Event::PoolExitSubsidy(
+            ASSET_D,
+            small_amount,
+            CommonPoolEventParams { pool_id, who: ALICE },
+            large_amount,
+        )));
+    });
+}
+
+#[test]
 fn pool_join_with_exact_asset_amount_exchanges_correct_values() {
     ExtBuilder::default().build().execute_with(|| {
         frame_system::Pallet::<Runtime>::set_block_number(1);


### PR DESCRIPTION
This is Rikiddo-related, but it can be tabled to another milestone if necessary.

We implement the `MinSubsidyPerAccount` constant, which is the minimum amount of subsidy that each subsidy provider must _at least_ contribute. The rules are as follows:

- If an account wishes to become subsidy provider and they provide less than the minimum, the transaction fails
- If an account is already subsidy provider and they wish to add more subsidy, they can do so in _any_ amount
- If an account is already subsidy provider and they wish to exit a part of their subsidy and leave behind less than the minimum, all of their subsidy is removed

I've thought about adding another constant which makes sure that there is a maximum of subsidy providers per market. This would prevent an attacker to provide subsidy from many accounts, clogging up our memory. However, the changes proposed by this PR _already_ fix that in the sense that the attacker would have to lock up large amounts of funds to perform this attack. Furthermore, if this type of attack was possible, it would also be possible simply by creating markets.

On the other hand, introducing a maximum number of subsidy providers per market would result in another attack: Create a bunch of accounts and provide the minimum required subsidy from each of them, until the maximum number of subsidy providers is reached. Then no-one else can provide subsidy. Not sure what the attacker gains, but this sure would be annoying.

Also, we raise an error if `pool_join_subsidy` or `pool_exit_subsidy` are called with amount zero. And we also add a bunch of tests for `pool_*_subsidy` behavior.

Anyways, this fixes zeitgeistpm/runtime-audit-2#11 and #562.