### PR TITLE
OracleBond unreserve in reject_market

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -885,16 +885,13 @@ mod pallet {
             T::ApprovalOrigin::ensure_origin(origin)?;
 
             let market = T::MarketCommons::market(&market_id)?;
-            ensure!(market.creation == MarketCreation::Advised, Error::<T>::OnlyAdvisedMarket);
             let creator = market.creator;
             let (imbalance, _) = CurrencyOf::<T>::slash_reserved_named(
                 &RESERVE_ID,
                 &creator,
                 T::AdvisoryBond::get(),
             );
-            // Slashes the imbalance.
             T::Slash::on_unbalanced(imbalance);
-            // Unreserves the OracleBond
             CurrencyOf::<T>::unreserve_named(&RESERVE_ID, &creator, T::OracleBond::get());
             T::MarketCommons::remove_market(&market_id)?;
             Self::deposit_event(Event::MarketRejected(market_id));
@@ -1216,8 +1213,6 @@ mod pallet {
         InvalidMarketStatus,
         /// An amount was illegally specified as zero.
         ZeroAmount,
-        /// It's not an advised market creation.
-        OnlyAdvisedMarket,
     }
 
     #[pallet::event]

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -20,9 +20,6 @@ use zeitgeist_primitives::{
     },
 };
 use zrml_market_commons::MarketCommonsPalletApi;
-use zrml_prediction_markets::RESERVE_ID;
-
-const SENTINEL_AMOUNT: u128 = BASE;
 
 const SENTINEL_AMOUNT: u128 = BASE;
 

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -5,7 +5,7 @@ use core::ops::Range;
 use frame_support::{
     assert_err, assert_noop, assert_ok,
     dispatch::{DispatchError, DispatchResult},
-    traits::Get,
+    traits::{Get, NamedReservableCurrency},
 };
 
 use orml_traits::MultiCurrency;
@@ -21,6 +21,9 @@ use zeitgeist_primitives::{
     },
 };
 use zrml_market_commons::MarketCommonsPalletApi;
+use zrml_prediction_markets::RESERVE_ID;
+
+const SENTINEL_AMOUNT: u128 = BASE;
 
 fn gen_metadata(byte: u8) -> MultiHash {
     let mut metadata = [byte; 50];
@@ -198,6 +201,72 @@ fn it_allows_the_advisory_origin_to_reject_markets() {
         assert_noop!(
             MarketCommons::market(&0),
             zrml_market_commons::Error::<Runtime>::MarketDoesNotExist
+        );
+    });
+}
+
+#[test]
+fn it_does_not_allow_to_reject_markets_on_permissionless_markets() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Creates an permissionless market.
+        simple_create_categorical_market::<Runtime>(
+            MarketCreation::Permissionless,
+            0..1,
+            ScoringRule::CPMM,
+        );
+
+        // Don't allow the Advisory Committee to reject a permissionless market.
+        assert_noop!(
+            PredictionMarkets::reject_market(Origin::signed(SUDO), 0),
+            Error::<Runtime>::OnlyAdvisedMarket
+        );
+    });
+}
+
+#[test]
+fn reject_market_unreserves_oracle_bond_and_slashes_advisory_bond() {
+    ExtBuilder::default().build().execute_with(|| {
+        // Creates an advised market.
+        simple_create_categorical_market::<Runtime>(
+            MarketCreation::Advised,
+            0..1,
+            ScoringRule::CPMM,
+        );
+
+        // Give ALICE `SENTINEL_AMOUNT` free and reserved ZTG; we record the free balance to check
+        // that the AdvisoryBond gets slashed but the OracleBond gets unreserved.
+        assert_ok!(Currency::deposit(Asset::Ztg, &ALICE, 2 * SENTINEL_AMOUNT));
+        assert_ok!(Balances::reserve_named(&RESERVE_ID, &ALICE, SENTINEL_AMOUNT));
+        let balance_free_before_alice = Balances::free_balance(&ALICE);
+
+        // make sure it's in status proposed
+        let market = MarketCommons::market(&0);
+        assert_eq!(market.unwrap().status, MarketStatus::Proposed);
+
+        let balance_reserved_before_alice = Balances::reserved_balance_named(&RESERVE_ID, &ALICE);
+
+        // Now it should work from SUDO
+        assert_ok!(PredictionMarkets::reject_market(Origin::signed(SUDO), 0));
+
+        assert_noop!(
+            MarketCommons::market(&0),
+            zrml_market_commons::Error::<Runtime>::MarketDoesNotExist
+        );
+
+        // AdvisoryBond gets slashed after reject_market
+        // OracleBond gets unreserved after reject_market
+        // need to non-equal to see the difference between AdvisoryBond and OracleBond
+        let balance_reserved_after_alice = Balances::reserved_balance_named(&RESERVE_ID, &ALICE);
+        assert_eq!(
+            balance_reserved_after_alice,
+            balance_reserved_before_alice
+                - <Runtime as Config>::OracleBond::get()
+                - <Runtime as Config>::AdvisoryBond::get()
+        );
+        let balance_free_after_alice = Balances::free_balance(&ALICE);
+        assert_eq!(
+            balance_free_after_alice,
+            balance_free_before_alice + <Runtime as Config>::OracleBond::get()
         );
     });
 }


### PR DESCRIPTION
I am thinking about if we should either slash or unreserve the OracleBond when a market gets rejected (`reject_market` function). At the moment I decided for an unreserve.