### PR TITLE
Set maximum for the market period

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10766,6 +10766,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6344589a99d3971d6fa4e8314dbcbeca2df6273a6b642e46906971779159af1f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "test-runtime-constants"
 version = "0.9.17"
 source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.17#66cb46bb3a7bd7295d1eb39a391559bc6efb2a22"
@@ -12396,6 +12409,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "substrate-fixed 0.5.8",
+ "test-case",
  "zeitgeist-primitives",
  "zrml-authorized",
  "zrml-court",

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -74,8 +74,7 @@ parameter_types! {
     pub const MinSubsidyPeriod: Moment = 60_000;
     // 2_678_400_000 = 31 days.
     pub const MaxSubsidyPeriod: Moment = 2_678_400_000;
-    // TODO Exact requirements: MaxPeriod + ReportingPeriod + MaxDisputes * DisputePeriod <
-    // u64::MAX.
+    // Requirements: MaxPeriod + ReportingPeriod + MaxDisputes * DisputePeriod < u64::MAX.
     pub const MaxMarketPeriod: Moment = u64::MAX / 2;
     pub const OracleBond: Balance = 50 * CENT;
     pub const PmPalletId: PalletId = PalletId(*b"zge/pred");

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -74,6 +74,9 @@ parameter_types! {
     pub const MinSubsidyPeriod: Moment = 60_000;
     // 2_678_400_000 = 31 days.
     pub const MaxSubsidyPeriod: Moment = 2_678_400_000;
+    // TODO Exact requirements: MaxPeriod + ReportingPeriod + MaxDisputes * DisputePeriod <
+    // u64::MAX.
+    pub const MaxMarketPeriod: Moment = u64::MAX / 2;
     pub const OracleBond: Balance = 50 * CENT;
     pub const PmPalletId: PalletId = PalletId(*b"zge/pred");
     pub const ReportingPeriod: u32 = BLOCKS_PER_DAY as _;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -878,6 +878,7 @@ impl zrml_prediction_markets::Config for Runtime {
     type MaxCategories = MaxCategories;
     type MaxDisputes = MaxDisputes;
     type MaxSubsidyPeriod = MaxSubsidyPeriod;
+    type MaxMarketPeriod = MaxMarketPeriod;
     type MinCategories = MinCategories;
     type MinSubsidyPeriod = MinSubsidyPeriod;
     type OracleBond = OracleBond;

--- a/zrml/prediction-markets/Cargo.toml
+++ b/zrml/prediction-markets/Cargo.toml
@@ -30,6 +30,7 @@ zrml-swaps = { optional = true, path = "../swaps" }
 
 [dev-dependencies]
 zrml-prediction-markets = { features = ["mock"], path = "." }
+test-case = "2.0.2"
 
 [features]
 default = ["std"]

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1142,6 +1142,9 @@ mod pallet {
         #[pallet::constant]
         type MaxDisputes: Get<u32>;
 
+        /// The maximum allowed timepoint for the market period (timestamp or blocknumber).
+        type MaxMarketPeriod: Get<u64>;
+
         /// Shares
         type Shares: ZeitgeistMultiReservableCurrency<
             Self::AccountId,

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1508,7 +1508,7 @@ mod pallet {
         ) -> DispatchResult {
             let verify = |start: u64, end: u64| -> DispatchResult {
                 ensure!(start < end, Error::<T>::InvalidMarketPeriod);
-                ensure!(end < T::MaxMarketPeriod::get(), Error::<T>::InvalidMarketPeriod);
+                ensure!(end <= T::MaxMarketPeriod::get(), Error::<T>::InvalidMarketPeriod);
                 Ok(())
             };
             match period {

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -359,6 +359,7 @@ mod pallet {
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
             Self::ensure_market_is_active(&period)?;
+            Self::ensure_market_period_is_valid(&period)?;
 
             ensure!(categories >= T::MinCategories::get(), <Error<T>>::NotEnoughCategories);
             ensure!(categories <= T::MaxCategories::get(), <Error<T>>::TooManyCategories);
@@ -541,8 +542,7 @@ mod pallet {
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
             Self::ensure_market_is_active(&period)?;
-
-            ensure!(outcome_range.start() < outcome_range.end(), "Invalid range provided.");
+            Self::ensure_market_period_is_valid(&period)?;
 
             if scoring_rule == ScoringRule::RikiddoSigmoidFeeMarketEma {
                 Self::ensure_market_start_is_in_time(&period)?;
@@ -1216,7 +1216,7 @@ mod pallet {
         InvalidMarketStatus,
         /// An amount was illegally specified as zero.
         ZeroAmount,
-        /// Market period is faulty (exceeds maximum, or is empty)
+        /// Market period is faulty (too short, outside of limits)
         InvalidMarketPeriod,
     }
 
@@ -1500,6 +1500,25 @@ mod pallet {
                 },
                 Error::<T>::MarketIsNotActive
             );
+            Ok(())
+        }
+
+        fn ensure_market_period_is_valid(
+            period: &MarketPeriod<T::BlockNumber, MomentOf<T>>,
+        ) -> DispatchResult {
+            let verify = |start: u64, end: u64| -> DispatchResult {
+                ensure!(start < end, Error::<T>::InvalidMarketPeriod);
+                ensure!(end < T::MaxMarketPeriod::get(), Error::<T>::InvalidMarketPeriod);
+                Ok(())
+            };
+            match period {
+                MarketPeriod::Block(ref range) => {
+                    verify(range.start.saturated_into(), range.end.saturated_into())
+                }
+                MarketPeriod::Timestamp(ref range) => {
+                    verify(range.start.saturated_into(), range.end.saturated_into())
+                }
+            }?;
             Ok(())
         }
 

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1216,6 +1216,8 @@ mod pallet {
         InvalidMarketStatus,
         /// An amount was illegally specified as zero.
         ZeroAmount,
+        /// Market period is faulty (exceeds maximum, or is empty)
+        InvalidMarketPeriod,
     }
 
     #[pallet::event]

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -923,14 +923,19 @@ mod pallet {
                 let mut should_check_origin = false;
                 match market.period {
                     MarketPeriod::Block(ref range) => {
-                        if current_block <= range.end + T::ReportingPeriod::get().into() {
+                        if current_block
+                            <= range.end.saturating_add(T::ReportingPeriod::get().into())
+                        {
                             should_check_origin = true;
                         }
                     }
                     MarketPeriod::Timestamp(ref range) => {
                         let rp_moment: MomentOf<T> = T::ReportingPeriod::get().into();
-                        let reporting_period_in_ms = rp_moment * MILLISECS_PER_BLOCK.into();
-                        if T::MarketCommons::now() <= range.end + reporting_period_in_ms {
+                        let reporting_period_in_ms =
+                            rp_moment.saturating_mul(MILLISECS_PER_BLOCK.into());
+                        if T::MarketCommons::now()
+                            <= range.end.saturating_add(reporting_period_in_ms)
+                        {
                             should_check_origin = true;
                         }
                     }

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -24,7 +24,7 @@ use zeitgeist_primitives::{
         MaxCategories, MaxDisputes, MaxInRatio, MaxOutRatio, MaxReserves, MaxSubsidyPeriod,
         MaxTotalWeight, MaxWeight, MinAssets, MinCategories, MinLiquidity, MinSubsidy,
         MinSubsidyPeriod, MinWeight, MinimumPeriod, OracleBond, PmPalletId, ReportingPeriod,
-        SimpleDisputesPalletId, StakeWeight, SwapsPalletId, ValidityBond, BASE,
+        SimpleDisputesPalletId, StakeWeight, SwapsPalletId, ValidityBond, BASE, MaxMarketPeriod
     },
     types::{
         AccountIdTest, Amount, Asset, Balance, BasicCurrencyAdapter, BlockNumber, BlockTest,
@@ -89,6 +89,7 @@ impl crate::Config for Runtime {
     type MaxCategories = MaxCategories;
     type MaxDisputes = MaxDisputes;
     type MaxSubsidyPeriod = MaxSubsidyPeriod;
+    type MaxMarketPeriod = MaxMarketPeriod;
     type MinCategories = MinCategories;
     type MinSubsidyPeriod = MinSubsidyPeriod;
     type OracleBond = OracleBond;

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -1021,7 +1021,7 @@ fn start_subsidy_creates_pool_and_starts_subsidy() {
         // Create advised categorical market using Rikiddo.
         simple_create_categorical_market::<Runtime>(
             MarketCreation::Advised,
-            1337..1337,
+            1337..1338,
             ScoringRule::RikiddoSigmoidFeeMarketEma,
         );
         let market_id = 0;

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -286,6 +286,124 @@ fn it_does_not_allow_to_buy_a_complete_set_on_pending_advised_market() {
 }
 
 #[test]
+fn create_categorical_market_fails_if_market_begin_is_equal_to_end() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            PredictionMarkets::create_categorical_market(
+                Origin::signed(ALICE),
+                BOB,
+                MarketPeriod::Block(3..3),
+                gen_metadata(0),
+                MarketCreation::Permissionless,
+                3,
+                MarketDisputeMechanism::Authorized(CHARLIE),
+                ScoringRule::CPMM,
+            ),
+            crate::Error::<Runtime>::InvalidMarketPeriod,
+        );
+    });
+}
+
+#[test]
+fn create_categorical_market_fails_if_market_begin_is_greater_than_end() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            PredictionMarkets::create_categorical_market(
+                Origin::signed(ALICE),
+                BOB,
+                MarketPeriod::Block(2..1),
+                gen_metadata(0),
+                MarketCreation::Permissionless,
+                3,
+                MarketDisputeMechanism::Authorized(CHARLIE),
+                ScoringRule::CPMM,
+            ),
+            crate::Error::<Runtime>::InvalidMarketPeriod,
+        );
+    });
+}
+
+#[test]
+fn create_categorical_market_fails_if_market_end_exceeds_limit() {
+    ExtBuilder::default().build().execute_with(|| {
+        let begin = 0;
+        let end = <Runtime as Config>::MaxMarketPeriod::get() + 1;
+        assert_noop!(
+            PredictionMarkets::create_categorical_market(
+                Origin::signed(ALICE),
+                BOB,
+                MarketPeriod::Block(begin..end),
+                gen_metadata(0),
+                MarketCreation::Permissionless,
+                3,
+                MarketDisputeMechanism::Authorized(CHARLIE),
+                ScoringRule::CPMM,
+            ),
+            crate::Error::<Runtime>::InvalidMarketPeriod,
+        );
+    });
+}
+
+#[test]
+fn create_scalar_market_fails_if_market_begin_is_equal_to_end() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            PredictionMarkets::create_scalar_market(
+                Origin::signed(ALICE),
+                BOB,
+                MarketPeriod::Block(3..3),
+                gen_metadata(0),
+                MarketCreation::Permissionless,
+                123..=456,
+                MarketDisputeMechanism::Authorized(CHARLIE),
+                ScoringRule::CPMM,
+            ),
+            crate::Error::<Runtime>::InvalidMarketPeriod,
+        );
+    });
+}
+
+#[test]
+fn create_scalar_market_fails_if_market_begin_is_greater_than_end() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            PredictionMarkets::create_scalar_market(
+                Origin::signed(ALICE),
+                BOB,
+                MarketPeriod::Block(2..1),
+                gen_metadata(0),
+                MarketCreation::Permissionless,
+                123..=456,
+                MarketDisputeMechanism::Authorized(CHARLIE),
+                ScoringRule::CPMM,
+            ),
+            crate::Error::<Runtime>::InvalidMarketPeriod,
+        );
+    });
+}
+
+#[test]
+fn create_scalar_market_fails_if_market_end_exceeds_limit() {
+    ExtBuilder::default().build().execute_with(|| {
+        let begin = 0;
+        let end = <Runtime as Config>::MaxMarketPeriod::get() + 1;
+        assert_noop!(
+            PredictionMarkets::create_scalar_market(
+                Origin::signed(ALICE),
+                BOB,
+                MarketPeriod::Block(begin..end),
+                gen_metadata(0),
+                MarketCreation::Permissionless,
+                123..=456,
+                MarketDisputeMechanism::Authorized(CHARLIE),
+                ScoringRule::CPMM,
+            ),
+            crate::Error::<Runtime>::InvalidMarketPeriod,
+        );
+    });
+}
+
+#[test]
 fn it_does_not_allow_zero_amounts_in_buy_complete_set() {
     ExtBuilder::default().build().execute_with(|| {
         simple_create_categorical_market::<Runtime>(


### PR DESCRIPTION
This fixes zeitgeistpm/runtime-audit-2#14 and fixes #480.

The idea is as follows: We implement a `MaxMarketPeriod` constant, which `period.start` and `period.end` may not exceed. And while we're at it, we're also requiring that `period.end > period.start`.

The `MaxMarketPeriod` constant is set to `u64::max() / 2` (recall that `BlockNumber` and `Moment` are both `u64`). Just to give you an idea of the scope: When using `BlockNumber`, this gives us `3509654504130` years, and when using  `Moment` we get `292471208` years (divide by `12000ms`).

It takes a little bit of explaining why this fixes zeitgeistpm/runtime-audit-2#14. The problem is that `report` adds the report period to the market end time, potentially causing an overflow. This is, of course, still possible now, but only if you configure the report period to be larger than `u64::max() / 2 - 1`. Long-term, we may want to add integration tests that do a sanity check like "`MaxMarketPeriod + ReportPeriod + MaxDisputes * DisputePeriod` doesn't overflow".

Anyways, I don't see how I could write a test that checks that the behavior exposed in the audit is no longer possible, because my solution is to prevent the chain from ever reaching that invalid state.

By the way, the type of `MaxMarketPeriod` is `Moment`. This isn't exactly ideal, because `MaxMarketPeriod` is also applied to the `Block` variant of `MarketPeriod`, which has type `BlockNumber`. I've opened an issue a while ago suggesting that we should probably get rid of one of the `MarketPeriod` variants: #616