### PR TITLE
Downgrade author-mapping and parachain-staking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.2",
  "tracing",
 ]
 
@@ -3192,7 +3192,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.20.4",
+ "rustls 0.20.5",
  "rustls-native-certs 0.6.2",
  "tokio",
  "tokio-rustls 0.23.4",
@@ -3516,7 +3516,7 @@ dependencies = [
  "log",
  "tokio",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "unicase",
 ]
 
@@ -3564,7 +3564,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-rustls 0.23.4",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.2",
  "tracing",
  "webpki-roots 0.22.3",
 ]
@@ -5206,9 +5206,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "owning_ref"
@@ -5257,7 +5257,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/purestake/moonbeam?rev=b0a04975df9d287fbdfa2666a402e0f05672bec1#b0a04975df9d287fbdfa2666a402e0f05672bec1"
+source = "git+https://github.com/zeitgeistpm/moonbeam?branch=downgrade-staking-and-mapping#3c80eb3d61f8dfb057e2242318c2d7bfee1b7a39"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5267,7 +5267,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "session-keys-primitives",
  "sp-runtime",
  "sp-std",
 ]
@@ -6209,7 +6208,7 @@ dependencies = [
 [[package]]
 name = "parachain-staking"
 version = "3.0.0"
-source = "git+https://github.com/purestake/moonbeam?rev=b0a04975df9d287fbdfa2666a402e0f05672bec1#b0a04975df9d287fbdfa2666a402e0f05672bec1"
+source = "git+https://github.com/zeitgeistpm/moonbeam?branch=downgrade-staking-and-mapping#3c80eb3d61f8dfb057e2242318c2d7bfee1b7a39"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8141,9 +8140,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -8505,9 +8504,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "a024a432ae760ab3bff924ad91ce1cfa52cb57ed16e1ef32d0d249cfee1a6c13"
 dependencies = [
  "log",
  "ring",
@@ -9814,11 +9813,6 @@ checksum = "e44969a61f5d316be20a42ff97816efb3b407a924d06824c3d8a49fa8450de0e"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "session-keys-primitives"
-version = "0.1.0"
-source = "git+https://github.com/purestake/moonbeam?rev=b0a04975df9d287fbdfa2666a402e0f05672bec1#b0a04975df9d287fbdfa2666a402e0f05672bec1"
 
 [[package]]
 name = "sha-1"
@@ -11256,7 +11250,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.4",
+ "rustls 0.20.5",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -11274,9 +11268,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -11288,9 +11282,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ members = [
     "zrml/swaps/runtime-api",
 ]
 resolver = "2"
+
+[patch."https://github.com/purestake/moonbeam"]
+pallet-author-mapping = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "downgrade-staking-and-mapping" }
+parachain-staking = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "downgrade-staking-and-mapping" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -60,7 +60,7 @@ cumulus-relay-chain-rpc-interface = { branch = "moonbeam-polkadot-v0.9.19", git 
 nimbus-consensus = { branch = "moonbeam-polkadot-v0.9.19", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
 nimbus-primitives = { branch = "moonbeam-polkadot-v0.9.19", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
 pallet-author-inherent = { branch = "moonbeam-polkadot-v0.9.19", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
-parachain-staking = { rev = "b0a04975df9d287fbdfa2666a402e0f05672bec1", git = "https://github.com/purestake/moonbeam", optional = true }
+parachain-staking = { rev = "78db06c0203f61b35059304f7194ed5c10dcfda8", git = "https://github.com/purestake/moonbeam", optional = true }
 parity-scale-codec = { optional = true, version = "3.0.0" }
 sc-chain-spec = { branch = "moonbeam-polkadot-v0.9.19", git = "https://github.com/purestake/substrate", optional = true }
 sc-network = { branch = "moonbeam-polkadot-v0.9.19", git = "https://github.com/purestake/substrate", optional = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -60,10 +60,10 @@ parachain-info = { branch = "moonbeam-polkadot-v0.9.19", default-features = fals
 
 nimbus-primitives = { branch = "moonbeam-polkadot-v0.9.19", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
 pallet-author-inherent = { branch = "moonbeam-polkadot-v0.9.19", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
-pallet-author-mapping = { rev = "b0a04975df9d287fbdfa2666a402e0f05672bec1", default-features = false, git = "https://github.com/purestake/moonbeam", optional = true }
+pallet-author-mapping = { rev = "78db06c0203f61b35059304f7194ed5c10dcfda8", default-features = false, git = "https://github.com/purestake/moonbeam", optional = true }
 pallet-author-slot-filter = { branch = "moonbeam-polkadot-v0.9.19", default-features = false, git = "https://github.com/purestake/nimbus", optional = true }
 pallet-crowdloan-rewards = { branch = "moonbeam-polkadot-v0.9.19", default-features = false, git = "https://github.com/purestake/crowdloan-rewards", optional = true }
-parachain-staking = { rev = "b0a04975df9d287fbdfa2666a402e0f05672bec1", default-features = false, git = "https://github.com/purestake/moonbeam", optional = true }
+parachain-staking = { rev = "78db06c0203f61b35059304f7194ed5c10dcfda8", default-features = false, git = "https://github.com/purestake/moonbeam", optional = true }
 
 # Polkadot
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -71,27 +71,13 @@ pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 
 type Address = sp_runtime::MultiAddress<AccountId, ()>;
 
-#[cfg(not(feature = "parachain"))]
 type Executive = frame_executive::Executive<
     Runtime,
     Block,
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (zrml_authorized::migrations::MigrateAuthorizedStorage<Runtime>,),
->;
-#[cfg(feature = "parachain")]
-type Executive = frame_executive::Executive<
-    Runtime,
-    Block,
-    frame_system::ChainContext<Runtime>,
-    Runtime,
-    AllPalletsWithSystem,
-    (
-        pallet_author_mapping::migrations::AddKeysToRegistrationInfo<Runtime>,
-        parachain_staking::migrations::SplitDelegatorStateIntoDelegationScheduledRequests<Runtime>,
-        zrml_authorized::migrations::MigrateAuthorizedStorage<Runtime>,
-    ),
+    zrml_authorized::migrations::MigrateAuthorizedStorage<Runtime>,
 >;
 
 type Header = generic::Header<BlockNumber, BlakeTwo256>;
@@ -464,7 +450,6 @@ impl pallet_author_mapping::Config for Runtime {
     type DepositAmount = CollatorDeposit;
     type DepositCurrency = Balances;
     type Event = Event;
-    type Keys = NimbusId;
     type WeightInfo = weights::pallet_author_mapping::WeightInfo<Runtime>;
 }
 
@@ -541,8 +526,6 @@ impl parachain_staking::Config for Runtime {
     type MinDelegatorStk = MinDelegatorStk;
     type MinSelectedCandidates = MinSelectedCandidates;
     type MonetaryGovernanceOrigin = EnsureRoot<AccountId>;
-    type OnCollatorPayout = ();
-    type OnNewRound = ();
     type RevokeDelegationDelay = RevokeDelegationDelay;
     type RewardPaymentDelay = RewardPaymentDelay;
     type WeightInfo = parachain_staking::weights::SubstrateWeight<Runtime>;

--- a/runtime/src/weights/pallet_author_mapping.rs
+++ b/runtime/src/weights/pallet_author_mapping.rs
@@ -30,39 +30,27 @@ use frame_support::{
 /// Weight functions for pallet_author_mapping (automatically generated)
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_author_mapping::weights::WeightInfo for WeightInfo<T> {
-    // Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    fn add_association() -> Weight {
-        (72_930_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
-    // Storage: AuthorMapping MappingWithDeposit (r:2 w:2)
-    fn update_association() -> Weight {
-        (45_930_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
-    // Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    fn clear_association() -> Weight {
-        (61_640_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
-    // Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    #[rustfmt::skip]
-    fn register_keys() -> Weight {
-        (33_600_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
-    // Storage: AuthorMapping MappingWithDeposit (r:2 w:2)
-    #[rustfmt::skip]
-    fn set_keys() -> Weight {
-        (25_578_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
+	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	#[rustfmt::skip]
+	fn add_association() -> Weight {
+		(34_696_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: AuthorMapping MappingWithDeposit (r:2 w:2)
+	#[rustfmt::skip]
+	fn update_association() -> Weight {
+		(26_877_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	#[rustfmt::skip]
+	fn clear_association() -> Weight {
+		(36_253_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
 }

--- a/runtime/src/weights/pallet_author_mapping.rs
+++ b/runtime/src/weights/pallet_author_mapping.rs
@@ -30,25 +30,25 @@ use frame_support::{
 /// Weight functions for pallet_author_mapping (automatically generated)
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_author_mapping::weights::WeightInfo for WeightInfo<T> {
-	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
-	// Storage: System Account (r:1 w:1)
+    // Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
+    // Storage: System Account (r:1 w:1)
 	#[rustfmt::skip]
-	fn add_association() -> Weight {
+    fn add_association() -> Weight {
 		(34_696_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
-	// Storage: AuthorMapping MappingWithDeposit (r:2 w:2)
+    // Storage: AuthorMapping MappingWithDeposit (r:2 w:2)
 	#[rustfmt::skip]
-	fn update_association() -> Weight {
+    fn update_association() -> Weight {
 		(26_877_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
-	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
-	// Storage: System Account (r:1 w:1)
+    // Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
+    // Storage: System Account (r:1 w:1)
 	#[rustfmt::skip]
-	fn clear_association() -> Weight {
+    fn clear_association() -> Weight {
 		(36_253_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))

--- a/runtime/src/weights/parachain_staking.rs
+++ b/runtime/src/weights/parachain_staking.rs
@@ -27,310 +27,346 @@ use core::marker::PhantomData;
 /// Weight functions for parachain_staking (automatically generated)
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> parachain_staking::weights::WeightInfo for WeightInfo<T> {
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    fn hotfix_remove_delegation_requests(x: u32, ) -> Weight {
-        (0 as Weight)
-            // Standard Error: 47_000
-            .saturating_add((12_887_000 as Weight).saturating_mul(x as Weight))
-            .saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
-            .saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(x as Weight)))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:4 w:0)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    fn hotfix_update_candidate_pool_value(x: u32, ) -> Weight {
-        (0 as Weight)
-            // Standard Error: 319_000
-            .saturating_add((42_074_000 as Weight).saturating_mul(x as Weight))
-            .saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking InflationConfig (r:1 w:1)
-    fn set_staking_expectations() -> Weight {
-        (32_380_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking InflationConfig (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    fn set_inflation() -> Weight {
-        (92_220_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking ParachainBondInfo (r:1 w:1)
-    fn set_parachain_bond_account() -> Weight {
-        (31_960_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking ParachainBondInfo (r:1 w:1)
-    fn set_parachain_bond_reserve_percent() -> Weight {
-        (30_310_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking TotalSelected (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    fn set_total_selected() -> Weight {
-        (36_820_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking CollatorCommission (r:1 w:1)
-    fn set_collator_commission() -> Weight {
-        (29_310_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking Round (r:1 w:1)
-    // Storage: ParachainStaking TotalSelected (r:1 w:0)
-    // Storage: ParachainStaking InflationConfig (r:1 w:1)
-    fn set_blocks_per_round() -> Weight {
-        (99_640_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(3 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking DelegatorState (r:1 w:0)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    // Storage: ParachainStaking Total (r:1 w:1)
-    // Storage: ParachainStaking TopDelegations (r:0 w:1)
-    // Storage: ParachainStaking BottomDelegations (r:0 w:1)
-    fn join_candidates(x: u32, ) -> Weight {
-        (102_042_000 as Weight)
-            // Standard Error: 2_000
-            .saturating_add((244_000 as Weight).saturating_mul(x as Weight))
-            .saturating_add(T::DbWeight::get().reads(5 as Weight))
-            .saturating_add(T::DbWeight::get().writes(6 as Weight))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    fn schedule_leave_candidates(x: u32, ) -> Weight {
-        (77_604_000 as Weight)
-            // Standard Error: 2_000
-            .saturating_add((218_000 as Weight).saturating_mul(x as Weight))
-            .saturating_add(T::DbWeight::get().reads(3 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    // Storage: ParachainStaking TopDelegations (r:1 w:1)
-    // Storage: System Account (r:2 w:2)
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    // Storage: ParachainStaking BottomDelegations (r:1 w:1)
-    // Storage: ParachainStaking Total (r:1 w:1)
-    fn execute_leave_candidates(x: u32, ) -> Weight {
-        (0 as Weight)
-            // Standard Error: 123_000
-            .saturating_add((39_111_000 as Weight).saturating_mul(x as Weight))
-            .saturating_add(T::DbWeight::get().reads(4 as Weight))
-            .saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(x as Weight)))
-            .saturating_add(T::DbWeight::get().writes(3 as Weight))
-            .saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(x as Weight)))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    fn cancel_leave_candidates(x: u32, ) -> Weight {
-        (76_774_000 as Weight)
-            // Standard Error: 2_000
-            .saturating_add((222_000 as Weight).saturating_mul(x as Weight))
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    fn go_offline() -> Weight {
-        (46_530_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    fn go_online() -> Weight {
-        (45_670_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    // Storage: ParachainStaking Total (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    fn candidate_bond_more() -> Weight {
-        (78_380_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(4 as Weight))
-            .saturating_add(T::DbWeight::get().writes(4 as Weight))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    fn schedule_candidate_bond_less() -> Weight {
-        (45_050_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    // Storage: System Account (r:1 w:1)
-    // Storage: ParachainStaking Total (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    fn execute_candidate_bond_less() -> Weight {
-        (90_760_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(5 as Weight))
-            .saturating_add(T::DbWeight::get().writes(4 as Weight))
-    }
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    fn cancel_candidate_bond_less() -> Weight {
-        (38_270_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: System Account (r:1 w:1)
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking TopDelegations (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    // Storage: ParachainStaking Total (r:1 w:1)
-    fn delegate(x: u32, y: u32, ) -> Weight {
-        (155_486_000 as Weight)
-            // Standard Error: 20_000
-            .saturating_add((371_000 as Weight).saturating_mul(x as Weight))
-            // Standard Error: 7_000
-            .saturating_add((340_000 as Weight).saturating_mul(y as Weight))
-            .saturating_add(T::DbWeight::get().reads(6 as Weight))
-            .saturating_add(T::DbWeight::get().writes(6 as Weight))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    fn schedule_leave_delegators() -> Weight {
-        (47_370_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking TopDelegations (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    // Storage: ParachainStaking Total (r:1 w:1)
-    fn execute_leave_delegators(x: u32, ) -> Weight {
-        (0 as Weight)
-            // Standard Error: 232_000
-            .saturating_add((67_829_000 as Weight).saturating_mul(x as Weight))
-            .saturating_add(T::DbWeight::get().reads(3 as Weight))
-            .saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(x as Weight)))
-            .saturating_add(T::DbWeight::get().writes(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(x as Weight)))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    fn cancel_leave_delegators() -> Weight {
-        (39_960_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    fn schedule_revoke_delegation() -> Weight {
-        (48_210_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    // Storage: ParachainStaking TopDelegations (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    // Storage: ParachainStaking Total (r:1 w:1)
-    fn delegator_bond_more() -> Weight {
-        (139_590_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(6 as Weight))
-            .saturating_add(T::DbWeight::get().writes(6 as Weight))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    fn schedule_delegator_bond_less() -> Weight {
-        (47_480_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(2 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: ParachainStaking TopDelegations (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    // Storage: ParachainStaking Total (r:1 w:1)
-    fn execute_revoke_delegation() -> Weight {
-        (117_780_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(7 as Weight))
-            .saturating_add(T::DbWeight::get().writes(6 as Weight))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    // Storage: ParachainStaking Round (r:1 w:0)
-    // Storage: ParachainStaking CandidateInfo (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    // Storage: ParachainStaking TopDelegations (r:1 w:1)
-    // Storage: ParachainStaking CandidatePool (r:1 w:1)
-    // Storage: ParachainStaking Total (r:1 w:1)
-    fn execute_delegator_bond_less() -> Weight {
-        (108_230_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(7 as Weight))
-            .saturating_add(T::DbWeight::get().writes(6 as Weight))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    fn cancel_revoke_delegation() -> Weight {
-        (42_690_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking DelegatorState (r:1 w:1)
-    fn cancel_delegator_bond_less() -> Weight {
-        (50_800_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-    // Storage: ParachainStaking Round (r:1 w:1)
-    // Storage: ParachainStaking Points (r:1 w:0)
-    // Storage: ParachainStaking Staked (r:1 w:2)
-    // Storage: ParachainStaking InflationConfig (r:1 w:0)
-    // Storage: ParachainStaking ParachainBondInfo (r:1 w:0)
-    // Storage: System Account (r:302 w:301)
-    // Storage: ParachainStaking CollatorCommission (r:1 w:0)
-    // Storage: ParachainStaking CandidatePool (r:1 w:0)
-    // Storage: ParachainStaking TotalSelected (r:1 w:0)
-    // Storage: ParachainStaking CandidateInfo (r:9 w:0)
-    // Storage: ParachainStaking TopDelegations (r:9 w:0)
-    // Storage: ParachainStaking Total (r:1 w:0)
-    // Storage: ParachainStaking AwardedPts (r:2 w:1)
-    // Storage: ParachainStaking AtStake (r:1 w:10)
-    // Storage: ParachainStaking SelectedCandidates (r:0 w:1)
-    // Storage: ParachainStaking DelayedPayouts (r:0 w:1)
-    fn round_transition_on_initialize(x: u32, y: u32, ) -> Weight {
-        (0 as Weight)
-            // Standard Error: 1_790_000
-            .saturating_add((88_392_000 as Weight).saturating_mul(x as Weight))
-            // Standard Error: 6_000
-            .saturating_add((624_000 as Weight).saturating_mul(y as Weight))
-            .saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
-    }
-    // Storage: ParachainStaking DelayedPayouts (r:1 w:0)
-    // Storage: ParachainStaking Points (r:1 w:0)
-    // Storage: ParachainStaking AwardedPts (r:2 w:1)
-    // Storage: ParachainStaking AtStake (r:1 w:1)
-    // Storage: System Account (r:1 w:1)
-    fn pay_one_collator_reward(y: u32, ) -> Weight {
-        (12_443_000 as Weight)
-            // Standard Error: 126_000
-            .saturating_add((30_393_000 as Weight).saturating_mul(y as Weight))
-            .saturating_add(T::DbWeight::get().reads(6 as Weight))
-            .saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(y as Weight)))
-            .saturating_add(T::DbWeight::get().writes(3 as Weight))
-            .saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(y as Weight)))
-    }
-    // Storage: ParachainStaking Round (r:1 w:0)
-    fn base_on_initialize() -> Weight {
-        (8_420_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-    }
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	#[rustfmt::skip]
+	fn hotfix_remove_delegation_requests(x: u32, ) -> Weight {
+		(0 as Weight)
+			// Standard Error: 5_000
+			.saturating_add((7_270_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(x as Weight)))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:4 w:0)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	#[rustfmt::skip]
+	fn hotfix_update_candidate_pool_value(x: u32, ) -> Weight {
+		(0 as Weight)
+			// Standard Error: 174_000
+			.saturating_add((24_976_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking InflationConfig (r:1 w:1)
+	#[rustfmt::skip]
+	fn set_staking_expectations() -> Weight {
+		(19_066_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking InflationConfig (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	#[rustfmt::skip]
+	fn set_inflation() -> Weight {
+		(55_185_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking ParachainBondInfo (r:1 w:1)
+	#[rustfmt::skip]
+	fn set_parachain_bond_account() -> Weight {
+		(18_702_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking ParachainBondInfo (r:1 w:1)
+	#[rustfmt::skip]
+	fn set_parachain_bond_reserve_percent() -> Weight {
+		(18_068_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking TotalSelected (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	#[rustfmt::skip]
+	fn set_total_selected() -> Weight {
+		(20_989_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking CollatorCommission (r:1 w:1)
+	#[rustfmt::skip]
+	fn set_collator_commission() -> Weight {
+		(17_218_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking Round (r:1 w:1)
+	// Storage: ParachainStaking TotalSelected (r:1 w:0)
+	// Storage: ParachainStaking InflationConfig (r:1 w:1)
+	#[rustfmt::skip]
+	fn set_blocks_per_round() -> Weight {
+		(60_675_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking DelegatorState (r:1 w:0)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	// Storage: ParachainStaking Total (r:1 w:1)
+	// Storage: ParachainStaking TopDelegations (r:0 w:1)
+	// Storage: ParachainStaking BottomDelegations (r:0 w:1)
+	#[rustfmt::skip]
+	fn join_candidates(x: u32, ) -> Weight {
+		(65_336_000 as Weight)
+			// Standard Error: 1_000
+			.saturating_add((117_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	#[rustfmt::skip]
+	fn schedule_leave_candidates(x: u32, ) -> Weight {
+		(53_788_000 as Weight)
+			// Standard Error: 1_000
+			.saturating_add((102_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	// Storage: ParachainStaking TopDelegations (r:1 w:1)
+	// Storage: System Account (r:2 w:2)
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	// Storage: ParachainStaking BottomDelegations (r:1 w:1)
+	// Storage: ParachainStaking Total (r:1 w:1)
+	#[rustfmt::skip]
+	fn execute_leave_candidates(x: u32, ) -> Weight {
+		(11_502_000 as Weight)
+			// Standard Error: 10_000
+			.saturating_add((21_626_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(x as Weight)))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	#[rustfmt::skip]
+	fn cancel_leave_candidates(x: u32, ) -> Weight {
+		(60_402_000 as Weight)
+			// Standard Error: 2_000
+			.saturating_add((90_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	#[rustfmt::skip]
+	fn go_offline() -> Weight {
+		(28_307_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	#[rustfmt::skip]
+	fn go_online() -> Weight {
+		(28_102_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	// Storage: ParachainStaking Total (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	#[rustfmt::skip]
+	fn candidate_bond_more() -> Weight {
+		(46_424_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	#[rustfmt::skip]
+	fn schedule_candidate_bond_less() -> Weight {
+		(26_422_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	// Storage: System Account (r:1 w:1)
+	// Storage: ParachainStaking Total (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	#[rustfmt::skip]
+	fn execute_candidate_bond_less() -> Weight {
+		(55_036_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+	}
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	#[rustfmt::skip]
+	fn cancel_candidate_bond_less() -> Weight {
+		(23_130_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: System Account (r:1 w:1)
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking TopDelegations (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	// Storage: ParachainStaking Total (r:1 w:1)
+	#[rustfmt::skip]
+	fn delegate(x: u32, y: u32, ) -> Weight {
+		(90_567_000 as Weight)
+			// Standard Error: 3_000
+			.saturating_add((310_000 as Weight).saturating_mul(x as Weight))
+			// Standard Error: 1_000
+			.saturating_add((204_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add(T::DbWeight::get().reads(6 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	#[rustfmt::skip]
+	fn schedule_leave_delegators() -> Weight {
+		(27_353_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking TopDelegations (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	// Storage: ParachainStaking Total (r:1 w:1)
+	#[rustfmt::skip]
+	fn execute_leave_delegators(x: u32, ) -> Weight {
+		(0 as Weight)
+			// Standard Error: 76_000
+			.saturating_add((39_542_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(x as Weight)))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	#[rustfmt::skip]
+	fn cancel_leave_delegators() -> Weight {
+		(24_218_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	#[rustfmt::skip]
+	fn schedule_revoke_delegation() -> Weight {
+		(28_053_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	// Storage: ParachainStaking TopDelegations (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	// Storage: ParachainStaking Total (r:1 w:1)
+	#[rustfmt::skip]
+	fn delegator_bond_more() -> Weight {
+		(64_504_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(6 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	#[rustfmt::skip]
+	fn schedule_delegator_bond_less() -> Weight {
+		(29_017_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: ParachainStaking TopDelegations (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	// Storage: ParachainStaking Total (r:1 w:1)
+	#[rustfmt::skip]
+	fn execute_revoke_delegation() -> Weight {
+		(78_531_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	// Storage: ParachainStaking Round (r:1 w:0)
+	// Storage: ParachainStaking CandidateInfo (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	// Storage: ParachainStaking TopDelegations (r:1 w:1)
+	// Storage: ParachainStaking CandidatePool (r:1 w:1)
+	// Storage: ParachainStaking Total (r:1 w:1)
+	#[rustfmt::skip]
+	fn execute_delegator_bond_less() -> Weight {
+		(71_044_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	#[rustfmt::skip]
+	fn cancel_revoke_delegation() -> Weight {
+		(25_288_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking DelegatorState (r:1 w:1)
+	#[rustfmt::skip]
+	fn cancel_delegator_bond_less() -> Weight {
+		(30_562_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	// Storage: ParachainStaking Round (r:1 w:1)
+	// Storage: ParachainStaking Points (r:1 w:0)
+	// Storage: ParachainStaking Staked (r:1 w:2)
+	// Storage: ParachainStaking InflationConfig (r:1 w:0)
+	// Storage: ParachainStaking ParachainBondInfo (r:1 w:0)
+	// Storage: System Account (r:302 w:301)
+	// Storage: ParachainStaking CollatorCommission (r:1 w:0)
+	// Storage: ParachainStaking CandidatePool (r:1 w:0)
+	// Storage: ParachainStaking TotalSelected (r:1 w:0)
+	// Storage: ParachainStaking CandidateInfo (r:9 w:0)
+	// Storage: ParachainStaking TopDelegations (r:9 w:0)
+	// Storage: ParachainStaking Total (r:1 w:0)
+	// Storage: ParachainStaking AwardedPts (r:2 w:1)
+	// Storage: ParachainStaking AtStake (r:1 w:10)
+	// Storage: ParachainStaking SelectedCandidates (r:0 w:1)
+	// Storage: ParachainStaking DelayedPayouts (r:0 w:1)
+	#[rustfmt::skip]
+	fn round_transition_on_initialize(x: u32, y: u32, ) -> Weight {
+		(0 as Weight)
+			// Standard Error: 827_000
+			.saturating_add((65_228_000 as Weight).saturating_mul(x as Weight))
+			// Standard Error: 2_000
+			.saturating_add((208_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add(T::DbWeight::get().reads(194 as Weight))
+			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(T::DbWeight::get().writes(188 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(x as Weight)))
+	}
+	// Storage: ParachainStaking DelayedPayouts (r:1 w:0)
+	// Storage: ParachainStaking Points (r:1 w:0)
+	// Storage: ParachainStaking AwardedPts (r:2 w:1)
+	// Storage: ParachainStaking AtStake (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	#[rustfmt::skip]
+	fn pay_one_collator_reward(y: u32, ) -> Weight {
+		(43_761_000 as Weight)
+			// Standard Error: 10_000
+			.saturating_add((17_111_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add(T::DbWeight::get().reads(6 as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(y as Weight)))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(y as Weight)))
+	}
+	// Storage: ParachainStaking Round (r:1 w:0)
+	#[rustfmt::skip]
+	fn base_on_initialize() -> Weight {
+		(4_892_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+	}
 }


### PR DESCRIPTION
We planned to use the latest `author-mapping` and `parachain-staking` pallets. Unfortunately the migration of `author-mapping` leads to a corrupted storage. It was identified that the nimbus key is not migrated to the new storage.
Upgrading those pallets is not critical and should be postponed to a later release.