### PR TITLE
Remove `MarketCommons::report`

### DIFF
--- a/zrml/market-commons/src/lib.rs
+++ b/zrml/market-commons/src/lib.rs
@@ -27,7 +27,7 @@ mod pallet {
         traits::{AtLeast32Bit, CheckedAdd, MaybeSerializeDeserialize, Member},
         ArithmeticError, DispatchError,
     };
-    use zeitgeist_primitives::types::{Market, PoolId, Report};
+    use zeitgeist_primitives::types::{Market, PoolId};
 
     /// The current storage version.
     const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
@@ -66,8 +66,6 @@ mod pallet {
         /// It is not possible to fetch the latest market ID when
         /// no market has been created.
         NoMarketHasBeenCreated,
-        /// Market does not have a report
-        NoReport,
     }
 
     #[pallet::hooks]
@@ -151,13 +149,6 @@ mod pallet {
             }
             <Markets<T>>::remove(market_id);
             Ok(())
-        }
-
-        fn report(
-            market: &Market<Self::AccountId, Self::BlockNumber, Self::Moment>,
-        ) -> Result<&Report<Self::AccountId, Self::BlockNumber>, DispatchError> {
-            let report = market.report.as_ref().ok_or(Error::<T>::NoReport)?;
-            Ok(report)
         }
 
         // MarketPool

--- a/zrml/market-commons/src/market_commons_pallet_api.rs
+++ b/zrml/market-commons/src/market_commons_pallet_api.rs
@@ -6,7 +6,7 @@ use frame_support::{
 };
 use parity_scale_codec::MaxEncodedLen;
 use sp_runtime::traits::AtLeast32Bit;
-use zeitgeist_primitives::types::{Market, PoolId, Report};
+use zeitgeist_primitives::types::{Market, PoolId};
 
 /// Simple disputes - Pallet Api
 pub trait MarketCommonsPalletApi {
@@ -46,11 +46,6 @@ pub trait MarketCommonsPalletApi {
 
     /// Removes a market from the storage.
     fn remove_market(market_id: &Self::MarketId) -> DispatchResult;
-
-    /// If any, returns all information regarding the account that reported an outcome.
-    fn report(
-        market: &Market<Self::AccountId, Self::BlockNumber, Self::Moment>,
-    ) -> Result<&Report<Self::AccountId, Self::BlockNumber>, DispatchError>;
 
     // MarketPool
 

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1685,7 +1685,7 @@ mod pallet {
             let mut total_weight = 0;
             let disputes = Disputes::<T>::get(market_id);
 
-            let report = T::MarketCommons::report(market)?;
+            let report = market.report.as_ref().ok_or(Error::<T>::MarketIsNotReported)?;
 
             let resolved_outcome = match market.status {
                 MarketStatus::Reported => {
@@ -1707,7 +1707,7 @@ mod pallet {
                         CurrencyOf::<T>::resolve_creating(&report.by, imbalance);
                     }
 
-                    T::MarketCommons::report(market)?.outcome.clone()
+                    report.outcome.clone()
                 }
                 MarketStatus::Disputed => {
                     // Try to get the outcome of the MDM. If the MDM failed to resolve, default to


### PR DESCRIPTION
This PR removes the `report` function from the `MarketCommonsApi`:

Reason for removal:

- It's used exactly twice in the entire code (one of these uses seems redundant)
- It's purpose if strongly related to the `prediction-markets` pallet, _not_ `market-commons`
- It returns the `market-commons`-specific error `NoReport`; but the `prediction-markets` pallet has its own error `MarketIsNotReported` - so now we can also remove the essentially duplicate `NoReport` error