### PR TITLE
Fix and test invalid outcome ranges

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -593,6 +593,7 @@ mod pallet {
             if scoring_rule == ScoringRule::RikiddoSigmoidFeeMarketEma {
                 Self::ensure_market_start_is_in_time(&period)?;
             }
+            ensure!(outcome_range.start() < outcome_range.end(), <Error<T>>::InvalidOutcomeRange);
 
             // Require sha3-384 as multihash. TODO(#608) The irrefutable `if let` is a workaround
             // for a compiler error. Link an issue for this!
@@ -1276,6 +1277,8 @@ mod pallet {
         ZeroAmount,
         /// Market period is faulty (too short, outside of limits)
         InvalidMarketPeriod,
+        /// Outcome range of scalar market is empty
+        InvalidOutcomeRange,
     }
 
     #[pallet::event]

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1277,7 +1277,7 @@ mod pallet {
         ZeroAmount,
         /// Market period is faulty (too short, outside of limits)
         InvalidMarketPeriod,
-        /// Outcome range of scalar market is empty
+        /// The outcome range of the scalar market is invalid.
         InvalidOutcomeRange,
     }
 

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -3,7 +3,7 @@
 use crate::{
     mock::*, Config, Error, Event, MarketIdsPerDisputeBlock, MarketIdsPerReportBlock, RESERVE_ID,
 };
-use core::ops::Range;
+use core::ops::{Range, RangeInclusive};
 use frame_support::{
     assert_err, assert_noop, assert_ok,
     dispatch::{DispatchError, DispatchResult},
@@ -63,6 +63,26 @@ fn simple_create_scalar_market<T: crate::Config>(
         MarketDisputeMechanism::SimpleDisputes,
         scoring_rule
     ));
+}
+
+#[test_case(654..=321; "low greater than high")]
+#[test_case(555..=555; "low equal to high")]
+fn create_scalar_market_fails_on_invalid_range(range: RangeInclusive<u128>) {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            PredictionMarkets::create_scalar_market(
+                Origin::signed(ALICE),
+                BOB,
+                MarketPeriod::Block(123..456),
+                gen_metadata(2),
+                MarketCreation::Permissionless,
+                range,
+                MarketDisputeMechanism::SimpleDisputes,
+                ScoringRule::CPMM,
+            ),
+            crate::Error::<Runtime>::InvalidOutcomeRange
+        );
+    });
 }
 
 #[test]

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -65,8 +65,8 @@ fn simple_create_scalar_market<T: crate::Config>(
     ));
 }
 
-#[test_case(654..=321; "low greater than high")]
-#[test_case(555..=555; "low equal to high")]
+#[test_case(654..=321; "empty range")]
+#[test_case(555..=555; "one element as range")]
 fn create_scalar_market_fails_on_invalid_range(range: RangeInclusive<u128>) {
     ExtBuilder::default().build().execute_with(|| {
         assert_noop!(


### PR DESCRIPTION
It's currently possible to use a `range` with `range.end() <= range.start()` in `create_scalar_market`. This doesn't cause any serious errors (SHORT _always_ redeems for 1 ZTG, LONG for 0 ZTG), but obviously we don't want this situation.

We now check for this case in `create_scalar_markets`.