### PR TITLE
Add tests for `admin_move_market_to_resolved`

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -267,7 +267,7 @@ mod pallet {
             let market = T::MarketCommons::market(&market_id)?;
             ensure!(
                 market.status == MarketStatus::Reported || market.status == MarketStatus::Disputed,
-                "not reported nor disputed"
+                Error::<T>::InvalidMarketStatus,
             );
             Self::clear_auto_resolve(&market_id)?;
             let market = T::MarketCommons::market(&market_id)?;


### PR DESCRIPTION
This is kind of important to include, since it shows that, unlike [zeitgeistpm/runtime-audit-2](https://github.com/zeitgeistpm/runtime-audit-2/issues/2) claims, `admin_move_market_to_resolved` correctly emits an event.