### PR TITLE
Remove all external pallets from filters

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -275,9 +275,7 @@ std = [
     "zrml-swaps-runtime-api/std",
     "zrml-swaps/std",
 ]
-txfilter = [
-    "log"
-]
+txfilter = []
 try-runtime = [
     "frame-executive/try-runtime",
     "frame-try-runtime",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -328,7 +328,7 @@ cfg_if::cfg_if! {
                     | Call::XcmpQueue(_) => true,
 
                     // Prohibited calls:
-                    | Call::Authorized(_)
+                    Call::Authorized(_)
                     | Call::Court(_)
                     | Call::LiquidityMining(_)
                     | Call::Swaps(_)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -365,7 +365,7 @@ cfg_if::cfg_if! {
                     | Call::Vesting(_) => true,
 
                     // Prohibited calls:
-                    | Call::Authorized(_)
+                    Call::Authorized(_)
                     | Call::Court(_)
                     | Call::LiquidityMining(_)
                     | Call::Swaps(_)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -298,41 +298,41 @@ cfg_if::cfg_if! {
             fn contains(call: &Call) -> bool {
                 match call {
                     // Allowed calls:
-                    Call::System(_)
-                    | Call::Sudo(_)
-                    | Call::Timestamp(_)
+                    Call::AdvisoryCommittee(_)
+                    | Call::AdvisoryCommitteeMembership(_)
                     | Call::AuthorInherent(_)
                     | Call::AuthorMapping(_)
+                    | Call::Balances(_)
+                    | Call::Council(_)
+                    | Call::CouncilMembership(_)
+                    | Call::Crowdloan(_)
+                    | Call::Currency(_)
+                    | Call::Democracy(_)
                     | Call::DmpQueue(_)
+                    | Call::Identity(_)
+                    | Call::MultiSig(_)
+                    | Call::ParachainStaking(_)
                     | Call::ParachainSystem(_)
                     | Call::PolkadotXcm(_)
+                    | Call::Preimage(_)
+                    | Call::Proxy(_)
+                    | Call::Scheduler(_)
+                    | Call::Sudo(_)
+                    | Call::System(_)
+                    | Call::TechnicalCommittee(_)
+                    | Call::TechnicalCommitteeMembership(_)
+                    | Call::Timestamp(_)
+                    | Call::Treasury(_)
+                    | Call::Utility(_)
+                    | Call::Vesting(_)
                     | Call::XcmpQueue(_) => true,
 
                     // Prohibited calls:
-                    Call::ParachainStaking(_)
-                    | Call::Crowdloan(_)
-                    | Call::Balances(_)
-                    | Call::Treasury(_)
-                    | Call::AdvisoryCommittee(_)
-                    | Call::AdvisoryCommitteeMembership(_)
-                    | Call::Council(_)
-                    | Call::CouncilMembership(_)
-                    | Call::TechnicalCommittee(_)
-                    | Call::TechnicalCommitteeMembership(_)
-                    | Call::MultiSig(_)
-                    | Call::Democracy(_)
-                    | Call::Scheduler(_)
-                    | Call::Preimage(_)
-                    | Call::Identity(_)
-                    | Call::Utility(_)
-                    | Call::Proxy(_)
-                    | Call::Currency(_)
                     | Call::Authorized(_)
                     | Call::Court(_)
                     | Call::LiquidityMining(_)
                     | Call::Swaps(_)
-                    | Call::PredictionMarkets(_)
-                    | Call::Vesting(_) => false,
+                    | Call::PredictionMarkets(_) => false,
                 }
             }
         }
@@ -342,50 +342,54 @@ cfg_if::cfg_if! {
             fn contains(call: &Call) -> bool {
                 match call {
                     // Allowed calls:
-                    Call::System(_) | Call::Grandpa(_) | Call::Sudo(_) | Call::Timestamp(_) => true,
-
-                    // Prohibited calls:
-                    Call::Balances(_)
-                    | Call::Treasury(_)
-                    | Call::AdvisoryCommittee(_)
+                    Call::AdvisoryCommittee(_)
                     | Call::AdvisoryCommitteeMembership(_)
+                    | Call::Balances(_)
                     | Call::Council(_)
                     | Call::CouncilMembership(_)
+                    | Call::Currency(_)
+                    | Call::Democracy(_)
+                    | Call::Grandpa(_)
+                    | Call::Identity(_)
+                    | Call::MultiSig(_)
+                    | Call::Preimage(_)
+                    | Call::Proxy(_)
+                    | Call::Scheduler(_)
+                    | Call::Sudo(_)
+                    | Call::System(_)
                     | Call::TechnicalCommittee(_)
                     | Call::TechnicalCommitteeMembership(_)
-                    | Call::MultiSig(_)
-                    | Call::Democracy(_)
-                    | Call::Scheduler(_)
-                    | Call::Preimage(_)
-                    | Call::Identity(_)
+                    | Call::Timestamp(_)
+                    | Call::Treasury(_)
                     | Call::Utility(_)
-                    | Call::Proxy(_)
-                    | Call::Currency(_)
+                    | Call::Vesting(_) => true,
+
+                    // Prohibited calls:
                     | Call::Authorized(_)
                     | Call::Court(_)
                     | Call::LiquidityMining(_)
                     | Call::Swaps(_)
-                    | Call::PredictionMarkets(_)
-                    | Call::Vesting(_) => false,
+                    | Call::PredictionMarkets(_) => false,
                 }
             }
         }
     // Unrestricted (no "txfilter" feature) chains.
-    // Currently disables Rikiddo and Court markets as well as LiquidityMining.
+    // Currently disables Rikiddo and markets using Court or SimpleDisputes dispute mechanism.
     // Will be relaxed for testnet once runtimes are separated.
     } else {
         impl Contains<Call> for IsCallable {
             fn contains(call: &Call) -> bool {
                 use zrml_prediction_markets::Call::{create_market, create_cpmm_market_and_deploy_assets};
+                use zeitgeist_primitives::types::{ScoringRule::RikiddoSigmoidFeeMarketEma, MarketDisputeMechanism::{Court, SimpleDisputes}};
 
                 match call {
                     Call::PredictionMarkets(inner_call) => {
                         match inner_call {
                             // Disable Rikiddo markets
-                            create_market { scoring_rule: ScoringRule::RikiddoSigmoidFeeMarketEma, .. } => false,
-                            // Disable Court dispute resolution mechanism
-                            create_market { mdm: MarketDisputeMechanism::Court, .. } => false,
-                            create_cpmm_market_and_deploy_assets { mdm: MarketDisputeMechanism::Court, .. } => false,
+                            create_market { scoring_rule: RikiddoSigmoidFeeMarketEma, .. } => false,
+                            // Disable Court & SimpleDisputes dispute resolution mechanism
+                            create_market { mdm: Court | SimpleDisputes, .. } => false,
+                            create_cpmm_market_and_deploy_assets { mdm: Court | SimpleDisputes, .. } => false,
                             _ => true
                         }
                     }


### PR DESCRIPTION
closes #639 #657 

This PR removes all external pallet from the call filters when compiling with the `txfilter` feature. After applying the changes in this PR, only the Zeitgeist protocol remains disabled (prediction markets, swaps, etc.)
In addition, this PR also forbids the creation of markets using the `SimpleDisputes` dispute mechanism when building without the `txfilter` feature.

The filters were tested locally. It is not possible to transitively execute filtered calls, i.e. executing a function of prediction markets is not possible by indirectly invoking it through the `utility` or `democracy` pallet.