### PR TITLE
Fix disputed market after resolve bug

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -349,7 +349,10 @@ mod pallet {
             let disputes = Disputes::<T>::get(market_id);
             let curr_block_num = <frame_system::Pallet<T>>::block_number();
             let market = T::MarketCommons::market(&market_id)?;
-            ensure!(market.status != MarketStatus::Resolved, Error::<T>::InvalidMarketStatus);
+            ensure!(
+                matches!(market.status, MarketStatus::Reported | MarketStatus::Disputed),
+                Error::<T>::InvalidMarketStatus
+            );
             let num_disputes: u32 = disputes.len().saturated_into();
             Self::validate_dispute(&disputes, &market, num_disputes, &outcome)?;
             CurrencyOf::<T>::reserve_named(

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -349,6 +349,7 @@ mod pallet {
             let disputes = Disputes::<T>::get(market_id);
             let curr_block_num = <frame_system::Pallet<T>>::block_number();
             let market = T::MarketCommons::market(&market_id)?;
+            ensure!(market.status != MarketStatus::Resolved, Error::<T>::InvalidMarketStatus);
             let num_disputes: u32 = disputes.len().saturated_into();
             Self::validate_dispute(&disputes, &market, num_disputes, &outcome)?;
             CurrencyOf::<T>::reserve_named(

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -1319,7 +1319,7 @@ fn it_resolves_a_disputed_market() {
 }
 
 #[test]
-fn check_dispute_after_market_resolve() {
+fn dispute_fails_after_market_resolve() {
     ExtBuilder::default().build().execute_with(|| {
         // Creates a permissionless market.
         simple_create_categorical_market::<Runtime>(

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -1345,13 +1345,12 @@ fn it_resolves_a_disputed_market() {
     });
 }
 
-#[test_case(MarketStatus::Active; "Active market")]
-#[test_case(MarketStatus::CollectingSubsidy; "CollectingSubsidy market")]
-#[test_case(MarketStatus::InsufficientSubsidy; "InsufficientSubsidy market")]
-#[test_case(MarketStatus::Closed; "Closed market")]
-#[test_case(MarketStatus::Proposed; "Proposed market")]
-#[test_case(MarketStatus::Resolved; "Resolved market")]
-#[test_case(MarketStatus::Suspended; "Suspended market")]
+#[test_case(MarketStatus::Active; "active")]
+#[test_case(MarketStatus::CollectingSubsidy; "collecting_subsidy")]
+#[test_case(MarketStatus::InsufficientSubsidy; "insufficient_subsidy")]
+#[test_case(MarketStatus::Closed; "closed")]
+#[test_case(MarketStatus::Proposed; "proposed")]
+#[test_case(MarketStatus::Resolved; "resolved")]
 fn dispute_fails_unless_reported_or_disputed_market(status: MarketStatus) {
     ExtBuilder::default().build().execute_with(|| {
         // Creates a permissionless market.


### PR DESCRIPTION
Fixes https://github.com/zeitgeistpm/zeitgeist/issues/367

There was no market state check in the `dispute` extrinsic other than `MarketStatus::Disputed` itself. I included the check of `MarketStatus::Resolved`, but I am not sure, if there is another check to make here.

Maybe the state has to be `MarketStatus::Reported` to call the extrinsic `dispute`. That would make the most sense regarding [this](https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/diagrams/market_state_diagram.png).