### PR TITLE
Bump versions to v0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12410,7 +12410,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-node"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cfg-if 1.0.0",
  "clap",
@@ -12490,7 +12490,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-primitives"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arbitrary",
  "frame-support",
@@ -12508,7 +12508,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-runtime"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cfg-if 1.0.0",
  "cumulus-pallet-dmp-queue",
@@ -12613,7 +12613,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-authorized"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12630,7 +12630,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-court"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arrayvec 0.7.2",
  "frame-benchmarking",
@@ -12650,7 +12650,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-liquidity-mining"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12668,7 +12668,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-market-commons"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12684,7 +12684,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-orderbook-v1"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12713,7 +12713,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12759,7 +12759,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets-runtime-api"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12768,7 +12768,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-rikiddo"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arbitrary",
  "cfg-if 1.0.0",
@@ -12801,7 +12801,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-simple-disputes"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12818,7 +12818,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12856,7 +12856,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-rpc"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -12871,7 +12871,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-runtime-api"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -164,7 +164,7 @@ description = "An evolving blockchain for prediction markets and futarchy."
 edition = "2021"
 homepage = "https://zeitgeist.pm"
 name = "zeitgeist-node"
-version = "0.3.2"
+version = "0.3.3"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -32,4 +32,4 @@ std = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zeitgeist-primitives"
-version = "0.3.2"
+version = "0.3.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -330,7 +330,7 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zeitgeist-runtime"
-version = "0.3.2"
+version = "0.3.3"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/zrml/authorized/Cargo.toml
+++ b/zrml/authorized/Cargo.toml
@@ -37,4 +37,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-authorized"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/court/Cargo.toml
+++ b/zrml/court/Cargo.toml
@@ -40,4 +40,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-court"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/liquidity-mining/Cargo.toml
+++ b/zrml/liquidity-mining/Cargo.toml
@@ -39,4 +39,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-liquidity-mining"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/market-commons/Cargo.toml
+++ b/zrml/market-commons/Cargo.toml
@@ -30,4 +30,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-market-commons"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/orderbook-v1/Cargo.toml
+++ b/zrml/orderbook-v1/Cargo.toml
@@ -46,4 +46,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-orderbook-v1"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/prediction-markets/Cargo.toml
+++ b/zrml/prediction-markets/Cargo.toml
@@ -76,4 +76,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-prediction-markets"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/prediction-markets/runtime-api/Cargo.toml
+++ b/zrml/prediction-markets/runtime-api/Cargo.toml
@@ -15,4 +15,4 @@ std = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-prediction-markets-runtime-api"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/rikiddo/Cargo.toml
+++ b/zrml/rikiddo/Cargo.toml
@@ -41,4 +41,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-rikiddo"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/simple-disputes/Cargo.toml
+++ b/zrml/simple-disputes/Cargo.toml
@@ -37,4 +37,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-simple-disputes"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/swaps/Cargo.toml
+++ b/zrml/swaps/Cargo.toml
@@ -64,4 +64,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-swaps"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/swaps/rpc/Cargo.toml
+++ b/zrml/swaps/rpc/Cargo.toml
@@ -13,4 +13,4 @@ zrml-swaps-runtime-api = { default-features = false, features = ["std"], path = 
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-swaps-rpc"
-version = "0.3.2"
+version = "0.3.3"

--- a/zrml/swaps/runtime-api/Cargo.toml
+++ b/zrml/swaps/runtime-api/Cargo.toml
@@ -17,4 +17,4 @@ std = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-swaps-runtime-api"
-version = "0.3.2"
+version = "0.3.3"


### PR DESCRIPTION
Update Zeitgeist crate version from *v0.3.2* to *v0.3.3*. Reflect updates in *Cargo.lock*