### PR TITLE
Fix block timeout when starting a new chain from genesis

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1943,8 +1943,10 @@ mod pallet {
             // If we are at genesis the timestamp is 0. No market can exist, we skip the evaluation.
             // Without this check, new chains starting from genesis will hang up, since the loop
             // below will run over an interval of 0 to the current time frame.
+            // We check the block number and the timestamp, since technically the timestamp is
+            // undefined at genesis.
             let current_time_frame = Self::calculate_time_frame_of_moment(T::MarketCommons::now());
-            if current_time_frame == 0u64 {
+            if current_time_frame == 0 || now == T::BlockNumber::zero() {
                 return Ok(());
             }
 

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1930,17 +1930,23 @@ mod pallet {
                 Market<T::AccountId, T::BlockNumber, MomentOf<T>>,
             ) -> DispatchResult,
         {
+            // If we are at genesis the timestamp is 0. No market can exist, we skip the evaluation.
+            // Without this check, new chains starting from genesis will hang up, since the loop
+            // below will run over an interval of 0 to the current time frame.
+            let current_time_frame = Self::calculate_time_frame_of_moment(T::MarketCommons::now());
+            if current_time_frame == 0u64 { return Ok(()) }
+
             for market_id in MarketIdsPerCloseBlock::<T>::get(&now).iter() {
                 let market = T::MarketCommons::market(market_id)?;
                 mutation(market_id, market)?;
             }
-            MarketIdsPerCloseBlock::<T>::remove(&now);
 
-            let current_time_frame = Self::calculate_time_frame_of_moment(T::MarketCommons::now());
+            MarketIdsPerCloseBlock::<T>::remove(&now);
             // On first pass, we use current_time - 1 to ensure that the chain doesn't try to check
             // all time frames since epoch.
             let last_time_frame =
                 LastTimeFrame::<T>::get().unwrap_or_else(|| current_time_frame.saturating_sub(1));
+
             for time_frame in last_time_frame.saturating_add(1)..=current_time_frame {
                 for market_id in MarketIdsPerCloseTimeFrame::<T>::get(&time_frame).iter() {
                     let market = T::MarketCommons::market(market_id)?;
@@ -1948,6 +1954,7 @@ mod pallet {
                 }
                 MarketIdsPerCloseTimeFrame::<T>::remove(&time_frame);
             }
+
             LastTimeFrame::<T>::set(Some(current_time_frame));
             Ok(())
         }

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1923,7 +1923,10 @@ mod pallet {
             Ok(())
         }
 
-        pub(crate) fn market_close_manager<F>(now: T::BlockNumber, mut mutation: F) -> DispatchResult
+        pub(crate) fn market_close_manager<F>(
+            now: T::BlockNumber,
+            mut mutation: F,
+        ) -> DispatchResult
         where
             F: FnMut(
                 &MarketIdOf<T>,
@@ -1941,7 +1944,9 @@ mod pallet {
             // Without this check, new chains starting from genesis will hang up, since the loop
             // below will run over an interval of 0 to the current time frame.
             let current_time_frame = Self::calculate_time_frame_of_moment(T::MarketCommons::now());
-            if current_time_frame == 0u64 { return Ok(()) }
+            if current_time_frame == 0u64 {
+                return Ok(());
+            }
 
             // On first pass, we use current_time - 1 to ensure that the chain doesn't try to check
             // all time frames since epoch.

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -888,7 +888,7 @@ fn on_market_close_successfully_auto_closes_multiple_markets_after_stall() {
 }
 
 #[test]
-fn market_close_manager_will_skip_the_genesis_block_with_timestamp_zero() {
+fn market_close_manager_skips_the_genesis_block_with_timestamp_zero() {
     // We ensure that a timestamp of zero will not be stored at genesis into LastTimeFrame storage.
     let end: Moment = (5 * MILLISECS_PER_BLOCK).into();
     ExtBuilder::default().build().execute_with(|| {
@@ -903,9 +903,13 @@ fn market_close_manager_will_skip_the_genesis_block_with_timestamp_zero() {
             vec![<Runtime as zrml_swaps::Config>::MinWeight::get(); 4],
         ));
 
-        let noop_mutation = |_: &crate::MarketIdOf<Runtime>, _: Market<<Runtime as frame_system::Config>::AccountId, <Runtime as frame_system::Config>::BlockNumber, crate::MomentOf<Runtime>>| -> DispatchResult {
-            Ok(())
-        };
+        let noop_mutation = |_: &crate::MarketIdOf<Runtime>,
+                             _: Market<
+            <Runtime as frame_system::Config>::AccountId,
+            <Runtime as frame_system::Config>::BlockNumber,
+            crate::MomentOf<Runtime>,
+        >|
+         -> DispatchResult { Ok(()) };
 
         assert_ok!(PredictionMarkets::market_close_manager(0, noop_mutation));
         assert_eq!(LastTimeFrame::<Runtime>::get(), None);
@@ -913,7 +917,10 @@ fn market_close_manager_will_skip_the_genesis_block_with_timestamp_zero() {
         Timestamp::set_timestamp(end);
 
         assert_ok!(PredictionMarkets::market_close_manager(1, noop_mutation));
-        assert_eq!(LastTimeFrame::<Runtime>::get(), Some(Timestamp::now() / crate::TimeFrame::from(MILLISECS_PER_BLOCK)));
+        assert_eq!(
+            LastTimeFrame::<Runtime>::get(),
+            Some(Timestamp::now() / crate::TimeFrame::from(MILLISECS_PER_BLOCK))
+        );
     });
 }
 

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -933,7 +933,6 @@ fn market_close_manager_skips_the_genesis_block_with_timestamp_zero() {
             Some(Timestamp::now() / crate::TimeFrame::from(MILLISECS_PER_BLOCK))
         );
         assert!(LastTimeFrame::<Runtime>::get() != Some(0));
-        println!("{:?}", LastTimeFrame::<Runtime>::get())
     });
 }
 

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -911,16 +911,24 @@ fn market_close_manager_skips_the_genesis_block_with_timestamp_zero() {
         >|
          -> DispatchResult { Ok(()) };
 
+        // Blocknumber = 0 and timestamp = 0
+        assert_eq!(Timestamp::get(), 0);
         assert_ok!(PredictionMarkets::market_close_manager(0, noop_mutation));
         assert_eq!(LastTimeFrame::<Runtime>::get(), None);
 
+        // Blocknumer = 0 and timestamp != 0
         Timestamp::set_timestamp(end);
+        assert_ok!(PredictionMarkets::market_close_manager(0, noop_mutation));
+        assert_eq!(LastTimeFrame::<Runtime>::get(), None);
 
-        assert_ok!(PredictionMarkets::market_close_manager(1, noop_mutation));
+        // Blocknumer != 0 and timestamp != 0
+        run_to_block(1);
+        assert_ok!(PredictionMarkets::market_close_manager(0, noop_mutation));
         assert_eq!(
             LastTimeFrame::<Runtime>::get(),
             Some(Timestamp::now() / crate::TimeFrame::from(MILLISECS_PER_BLOCK))
         );
+        assert!(LastTimeFrame::<Runtime>::get() != Some(0));
     });
 }
 

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -916,19 +916,24 @@ fn market_close_manager_skips_the_genesis_block_with_timestamp_zero() {
         assert_ok!(PredictionMarkets::market_close_manager(0, noop_mutation));
         assert_eq!(LastTimeFrame::<Runtime>::get(), None);
 
+        // Blocknumber != 0 and timestamp = 0
+        assert_eq!(Timestamp::get(), 0);
+        assert_ok!(PredictionMarkets::market_close_manager(1, noop_mutation));
+        assert_eq!(LastTimeFrame::<Runtime>::get(), None);
+
         // Blocknumer = 0 and timestamp != 0
         Timestamp::set_timestamp(end);
         assert_ok!(PredictionMarkets::market_close_manager(0, noop_mutation));
         assert_eq!(LastTimeFrame::<Runtime>::get(), None);
 
         // Blocknumer != 0 and timestamp != 0
-        run_to_block(1);
-        assert_ok!(PredictionMarkets::market_close_manager(0, noop_mutation));
+        assert_ok!(PredictionMarkets::market_close_manager(1, noop_mutation));
         assert_eq!(
             LastTimeFrame::<Runtime>::get(),
             Some(Timestamp::now() / crate::TimeFrame::from(MILLISECS_PER_BLOCK))
         );
         assert!(LastTimeFrame::<Runtime>::get() != Some(0));
+        println!("{:?}", LastTimeFrame::<Runtime>::get())
     });
 }
 


### PR DESCRIPTION
closes #683 , the strategy is described in that issue and as comments in the code.

I decided to execute the timestamp check after the block-end-time based markets were processed, although logically the check would make more sense before those markets have been evaluated, since when the timestamp is still `0` we are still in the genesis block and no markets can exist. However, moving this check before the block-end-time based markets were processed will result in a massive amount of tests failing and in that the tester is always responsible to set the timestamp although it is irrelevant in the respective tests.