### PR TITLE
Expose AuthorFilter Call enum

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -232,7 +232,7 @@ macro_rules! create_zeitgeist_runtime_with_additional_pallets {
             // Consensus
             ParachainStaking: parachain_staking::{Call, Config<T>, Event<T>, Pallet, Storage} = 110,
             AuthorInherent: pallet_author_inherent::{Call, Inherent, Pallet, Storage} = 111,
-            AuthorFilter: pallet_author_slot_filter::{Config, Event, Pallet, Storage} = 112,
+            AuthorFilter: pallet_author_slot_filter::{Config, Call, Event, Pallet, Storage} = 112,
             AuthorMapping: pallet_author_mapping::{Call, Config<T>, Event<T>, Pallet, Storage} = 113,
 
             // XCM

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -232,7 +232,7 @@ macro_rules! create_zeitgeist_runtime_with_additional_pallets {
             // Consensus
             ParachainStaking: parachain_staking::{Call, Config<T>, Event<T>, Pallet, Storage} = 110,
             AuthorInherent: pallet_author_inherent::{Call, Inherent, Pallet, Storage} = 111,
-            AuthorFilter: pallet_author_slot_filter::{Config, Call, Event, Pallet, Storage} = 112,
+            AuthorFilter: pallet_author_slot_filter::{Call, Config, Event, Pallet, Storage} = 112,
             AuthorMapping: pallet_author_mapping::{Call, Config<T>, Event<T>, Pallet, Storage} = 113,
 
             // XCM

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -320,6 +320,7 @@ cfg_if::cfg_if! {
                     Call::AdvisoryCommittee(_)
                     | Call::AdvisoryCommitteeMembership(_)
                     | Call::AuthorInherent(_)
+                    | Call::AuthorFilter(_)
                     | Call::AuthorMapping(_)
                     | Call::Balances(_)
                     | Call::Council(_)


### PR DESCRIPTION
Closes #697 

We have to set the `eligibleCount` of the `author_slot_filter` pallet to `1` to give every collator even chances of collation and to significantly reduce the number of forks and reorgs. To do so, root has to call a dispatchable of the `author_slot_filter` pallet. Unfortunately the `Call` enum of the `author_slot_filter` pallet is not exposed in the runtime, rendering setting this value through governance impossible.