### PR TITLE
Remove `report_todo` option

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,4 +3,3 @@ format_strings = true
 imports_granularity = "Crate"
 use_small_heuristics = "Max"
 version = "Two"
-report_todo = "Unnumbered"


### PR DESCRIPTION
The `report_todo` was removed: https://github.com/rust-lang/rustfmt/pull/5357

I think `clippy` will have a similar feature in the future.