### PR TITLE
Use `which` instead of `whereis` in format.sh script.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-04-13"
+channel = "nightly-2022-05-15"
 components = ["clippy", "rustfmt"]
 profile = "minimal"
 targets = ["wasm32-unknown-unknown"]

--- a/scripts/tests/format.sh
+++ b/scripts/tests/format.sh
@@ -63,13 +63,14 @@ taplo_fmt() {
 }
 
 # install taplo if it isn't already
-has_taplo=$(whereis taplo)
-if [[ ${has_taplo} = "taplo: " ]]; then
-    cargo install taplo-cli 2>/dev/null
+has_taplo=$(which taplo)
+if [ $? -eq 1 ]; then
+    echo "Installing taplo ..."
+    cargo install taplo-cli
 fi
 # install rustfmt if it isn't already
-has_rustfmt=$(whereis rustfmt)
-if [[ ${has_rustfmt} = "rustfmt: " ]]; then
+has_rustfmt=$(which rustfmt)
+if [ $? -eq 1 ]; then
     rustup component add rustfmt
 fi
 


### PR DESCRIPTION
Update nighlty version to 2022-05-15 (rust 1.62).

Fixes https://github.com/zeitgeistpm/zeitgeist/issues/772