### PR TITLE
Disallow `inline_table_expand` in taplo

### DIFF
--- a/taplo.toml
+++ b/taplo.toml
@@ -1,6 +1,7 @@
 [formatting]
 align_comments = false
 array_auto_collapse = false
-array_auto_expand = false
+column_width = 100
 indent_string = "    "
+inline_table_expand = false
 reorder_keys = true


### PR DESCRIPTION
Fixes #774. This prevents long tables from getting split into multiple lines in an awkward manner.

I've kept the `array_auto_collapse = false` option, as it frequently collapses short lists of features.