### PR TITLE
Add Zeitgeist endpoint to try-runtime target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,11 @@ check:
 check-dummy:
 	BUILD_DUMMY_WASM_BINARY= cargo check
 
-try-runtime-upgrade:
+try-runtime-upgrade-battery-station:
 	cargo run --release --bin=zeitgeist --features=parachain,try-runtime try-runtime on-runtime-upgrade live --uri wss://bsr.zeitgeist.pm:443
+
+try-runtime-upgrade-zeitgeist:
+	cargo run --release --bin=zeitgeist --features=parachain,try-runtime try-runtime on-runtime-upgrade live --uri wss://zeitgeist-rpc.dwellir.com
 
 build:
 	SKIP_WASM_BUILD= cargo build


### PR DESCRIPTION
As Zeitgeist attracts users, it becomes more and more important to run the `try-runtime` tests against the mainnet, rather than the testnet, so I'm putting a new target into the Makefile for that purpose.