### PR TITLE
Change Battery Station `ExitFee` parameter

### DIFF
--- a/runtime/battery-station/src/parameters.rs
+++ b/runtime/battery-station/src/parameters.rs
@@ -213,7 +213,7 @@ parameter_types! {
     // Swaps parameters
     /// A precentage from the withdrawal amount a liquidity provider wants to withdraw
     /// from a pool before the pool is closed.
-    pub const ExitFee: Balance = 3 * BASE / 1000; // 0.3%
+    pub const ExitFee: Balance = BASE / 10_000; // 0.01%
     /// Minimum number of assets.
     pub const MinAssets: u16 = 2;
     /// Maximum number of assets. `MaxCategories` plus one base asset.


### PR DESCRIPTION
Previously, the exit fee parameter of Battery Station was set to 0.3%, which is still fine, but not equal to the exit fee of the mainnet, which led to confusion when running live tests and experiments on Battery Station, so I suggest we set this parameter to the same value as on the mainnet.