### PR TITLE
Remove toolchain: input so that rust-toolchain file will be used

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,10 +33,10 @@ jobs:
         uses: actions/checkout@v2
         if: github.event_name == 'workflow_dispatch'
 
-# TODO(#XXX): `rustup show` installs the rustc version specified in the `rust-toolchain` file
-# according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due to the
-# lack of support of `rust-toolchain` files with TOML syntax:
-# https://github.com/actions-rs/toolchain/issues/126.
+      # TODO(#839): `rustup show` installs the rustc version specified in the `rust-toolchain` file
+      # according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due
+      # to the lack of support of `rust-toolchain` files with TOML syntax:
+      # https://github.com/actions-rs/toolchain/issues/126.
       - name: Install rust toolchain
         run: rustup show
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           target: wasm32-unknown-unknown
           default: true
           override: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,13 +34,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          target: wasm32-unknown-unknown
-          default: true
-          override: true
-          profile: minimal
-          components: rustfmt, clippy
+        run: rustup show
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,6 +33,10 @@ jobs:
         uses: actions/checkout@v2
         if: github.event_name == 'workflow_dispatch'
 
+# TODO(#XXX): `rustup show` installs the rustc version specified in the `rust-toolchain` file
+# according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due to the
+# lack of support of `rust-toolchain` files with TOML syntax:
+# https://github.com/actions-rs/toolchain/issues/126.
       - name: Install rust toolchain
         run: rustup show
 

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -14,6 +14,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      # TODO(#839): `rustup show` installs the rustc version specified in the `rust-toolchain` file
+      # according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due
+      # to the lack of support of `rust-toolchain` files with TOML syntax:
+      # https://github.com/actions-rs/toolchain/issues/126.
       - name: Install rust toolchain
         run: rustup show
 

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           target: wasm32-unknown-unknown
           default: true
           override: true

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -15,12 +15,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          target: wasm32-unknown-unknown
-          default: true
-          override: true
-          profile: minimal
-          components: rustfmt, clippy
+        run: rustup show
 
       - run: ./scripts/runtime-upgrade/test_runtime_upgrade.sh ${{ github.event.inputs.block }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      # TODO(#839): `rustup show` installs the rustc version specified in the `rust-toolchain` file
+      # according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due
+      # to the lack of support of `rust-toolchain` files with TOML syntax:
+      # https://github.com/actions-rs/toolchain/issues/126.
       - name: Install rust toolchain
         run: rustup show
         

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,13 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          target: wasm32-unknown-unknown
-          default: true
-          override: true
-          profile: minimal
-          components: rustfmt
+        run: rustup show
         
       - uses: actions-rs/install@v0.1
         with:
@@ -49,13 +43,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          target: wasm32-unknown-unknown
-          default: true
-          override: true
-          profile: minimal
-          components: rustfmt, clippy
+        run: rustup show
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
@@ -71,13 +59,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          target: wasm32-unknown-unknown
-          default: true
-          override: true
-          profile: minimal
-          components: rustfmt, clippy
+        run: rustup show
 
       - uses: actions-rs/install@v0.1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           target: wasm32-unknown-unknown
           default: true
           override: true
@@ -52,7 +51,6 @@ jobs:
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           target: wasm32-unknown-unknown
           default: true
           override: true
@@ -75,7 +73,6 @@ jobs:
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           target: wasm32-unknown-unknown
           default: true
           override: true


### PR DESCRIPTION
As  per https://github.com/marketplace/actions/rust-toolchain#the-toolchain-file
May close https://github.com/zeitgeistpm/zeitgeist/issues/780
As per discussion on https://lightrun.com/answers/actions-rs-toolchain-support-new-toml-format-for-rust-toolchain currently actions-rs has some issues using toolchain files. So used suggested solution there.