### PR TITLE
Reduce advised market slash percentage to zero

### DIFF
--- a/runtime/battery-station/src/parameters.rs
+++ b/runtime/battery-station/src/parameters.rs
@@ -142,7 +142,7 @@ parameter_types! {
     /// (Slashable) Bond that is provided for creating an advised market that needs approval.
     /// Slashed in case the market is rejected.
     pub const AdvisoryBond: Balance = 25 * CENT;
-    pub const AdvisoryBondSlashPercentage: Percent = Percent::from_percent(10);
+    pub const AdvisoryBondSlashPercentage: Percent = Percent::from_percent(0);
     /// (Slashable) Bond that is provided for disputing the outcome.
     /// Slashed in case the final outcome does not match the dispute for which the `DisputeBond`
     /// was deposited.

--- a/runtime/zeitgeist/src/parameters.rs
+++ b/runtime/zeitgeist/src/parameters.rs
@@ -142,7 +142,7 @@ parameter_types! {
     /// (Slashable) Bond that is provided for creating an advised market that needs approval.
     /// Slashed in case the market is rejected.
     pub const AdvisoryBond: Balance = 200 * BASE;
-    pub const AdvisoryBondSlashPercentage: Percent = Percent::from_percent(10);
+    pub const AdvisoryBondSlashPercentage: Percent = Percent::from_percent(0);
     /// (Slashable) Bond that is provided for disputing the outcome.
     /// Slashed in case the final outcome does not match the dispute for which the `DisputeBond`
     /// was deposited.


### PR DESCRIPTION
Apologies for the zig-zag on this issue. We had a discussion in the SDK meeting yesterday during which we decided to make rejection cost-free until we have a properly functioning edit process.