### PR TITLE
Improve logging of try-runtime makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,24 @@ check:
 check-dummy:
 	BUILD_DUMMY_WASM_BINARY= cargo check
 
+# Pseudo private target is invoked by public targets for different chains
+--try-runtime:
+	RUST_LOG=runtime=trace,try-runtime::cli=trace,executor=trace \
+		cargo run \
+		--features=parachain,try-runtime \
+		--bin=zeitgeist \
+		try-runtime \
+		--execution=Native \
+		--chain=${TRYRUNTIME_CHAIN} \
+		on-runtime-upgrade \
+		live \
+		--uri=${TRYRUNTIME_URL}
+
 try-runtime-upgrade-battery-station:
-	cargo run --bin=zeitgeist --features=parachain,try-runtime try-runtime --execution=Native on-runtime-upgrade live --uri wss://bsr.zeitgeist.pm:443
+	@$(MAKE) TRYRUNTIME_CHAIN="battery_station" TRYRUNTIME_URL="wss://bsr.zeitgeist.pm:443" -- --try-runtime
 
 try-runtime-upgrade-zeitgeist:
-	cargo run --bin=zeitgeist --features=parachain,try-runtime try-runtime --execution=Native on-runtime-upgrade live --uri wss://zeitgeist-rpc.dwellir.com
+	@$(MAKE) TRYRUNTIME_CHAIN="zeitgeist" TRYRUNTIME_URL="wss://zeitgeist-rpc.dwellir.com:443" -- --try-runtime
 
 build:
 	SKIP_WASM_BUILD= cargo build

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ check-dummy:
 	BUILD_DUMMY_WASM_BINARY= cargo check
 
 try-runtime-upgrade-battery-station:
-	cargo run --release --bin=zeitgeist --features=parachain,try-runtime try-runtime on-runtime-upgrade live --uri wss://bsr.zeitgeist.pm:443
+	cargo run --bin=zeitgeist --features=parachain,try-runtime try-runtime --execution=Native on-runtime-upgrade live --uri wss://bsr.zeitgeist.pm:443
 
 try-runtime-upgrade-zeitgeist:
-	cargo run --release --bin=zeitgeist --features=parachain,try-runtime try-runtime on-runtime-upgrade live --uri wss://zeitgeist-rpc.dwellir.com
+	cargo run --bin=zeitgeist --features=parachain,try-runtime try-runtime --execution=Native on-runtime-upgrade live --uri wss://zeitgeist-rpc.dwellir.com
 
 build:
 	SKIP_WASM_BUILD= cargo build

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ check-dummy:
 --try-runtime:
 	RUST_LOG=runtime=trace,try-runtime::cli=trace,executor=trace \
 		cargo run \
-		--features=parachain,try-runtime \
 		--bin=zeitgeist \
+		--features=parachain,try-runtime \
 		try-runtime \
 		--execution=Native \
 		--chain=${TRYRUNTIME_CHAIN} \
@@ -29,10 +29,10 @@ check-dummy:
 		--uri=${TRYRUNTIME_URL}
 
 try-runtime-upgrade-battery-station:
-	@$(MAKE) TRYRUNTIME_CHAIN="battery_station" TRYRUNTIME_URL="wss://bsr.zeitgeist.pm:443" -- --try-runtime
+	@$(MAKE) TRYRUNTIME_CHAIN="battery_station_staging" TRYRUNTIME_URL="wss://bsr.zeitgeist.pm:443" -- --try-runtime
 
 try-runtime-upgrade-zeitgeist:
-	@$(MAKE) TRYRUNTIME_CHAIN="zeitgeist" TRYRUNTIME_URL="wss://zeitgeist-rpc.dwellir.com:443" -- --try-runtime
+	@$(MAKE) TRYRUNTIME_CHAIN="zeitgeist_staging" TRYRUNTIME_URL="wss://zeitgeist-rpc.dwellir.com:443" -- --try-runtime
 
 build:
 	SKIP_WASM_BUILD= cargo build


### PR DESCRIPTION
Using native execution leads to more specific error descriptions and a backtrace that pinpoints the line that caused the error