### PR TITLE
Filter dangerous calls

### DIFF
--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -101,8 +101,7 @@ impl Contains<Call> for IsCallable {
         #[cfg(feature = "parachain")]
         use cumulus_pallet_dmp_queue::Call::service_overweight;
         use frame_system::Call::{
-            kill_prefix, kill_storage, set_code, set_code_without_checks, 
-            set_storage,
+            kill_prefix, kill_storage, set_code, set_code_without_checks, set_storage,
         };
         use orml_currencies::Call::update_balance;
         use pallet_balances::Call::{force_transfer, set_balance};

--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -106,7 +106,6 @@ impl Contains<Call> for IsCallable {
         use orml_currencies::Call::update_balance;
         use pallet_balances::Call::{force_transfer, set_balance};
         use pallet_collective::Call::set_members;
-        use pallet_proxy::Call::{anonymous, kill_anonymous};
         use pallet_vesting::Call::force_vested_transfer;
 
         use zeitgeist_primitives::types::{

--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -98,6 +98,7 @@ pub struct IsCallable;
 // dispute mechanism.
 impl Contains<Call> for IsCallable {
     fn contains(call: &Call) -> bool {
+        #[cfg(feature = "parachain")]
         use cumulus_pallet_dmp_queue::Call::service_overweight;
         use frame_system::Call::{
             kill_prefix, kill_storage, set_code, set_code_without_checks, set_heap_pages,
@@ -153,6 +154,7 @@ impl Contains<Call> for IsCallable {
                 }
             }
             Call::Court(_) => false,
+            #[cfg(feature = "parachain")]
             Call::DmpQueue(inner_call) => {
                 match inner_call {
                     // Executing this call with a maliciously crafted XCM can halt the chain.

--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -101,7 +101,7 @@ impl Contains<Call> for IsCallable {
         #[cfg(feature = "parachain")]
         use cumulus_pallet_dmp_queue::Call::service_overweight;
         use frame_system::Call::{
-            kill_prefix, kill_storage, set_code, set_code_without_checks, set_heap_pages,
+            kill_prefix, kill_storage, set_code, set_code_without_checks, 
             set_storage,
         };
         use orml_currencies::Call::update_balance;

--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -118,20 +118,10 @@ impl Contains<Call> for IsCallable {
 
         #[allow(clippy::match_like_matches_macro)]
         match call {
-            Call::AdvisoryCommittee(inner_call) => {
-                match inner_call {
-                    // Membership is managed by the respective Membership instance
-                    set_members { .. } => false,
-                    _ => true,
-                }
-            }
-            Call::AssetManager(inner_call) => {
-                match inner_call {
-                    // See reason for "balances.set_balance"
-                    update_balance { .. } => false,
-                    _ => true,
-                }
-            }
+            // Membership is managed by the respective Membership instance
+            Call::AdvisoryCommittee(set_members { .. }) => false,
+            // See "balance.set_balance"
+            Call::AssetManager(update_balance { .. }) => false,
             Call::Balances(inner_call) => {
                 match inner_call {
                     // Balances should not be set. All newly generated tokens be minted by well
@@ -146,22 +136,11 @@ impl Contains<Call> for IsCallable {
                     _ => true,
                 }
             }
-            Call::Council(inner_call) => {
-                match inner_call {
-                    // Membership is managed by the respective Membership instance
-                    set_members { .. } => false,
-                    _ => true,
-                }
-            }
+            // Membership is managed by the respective Membership instance
+            Call::Council(set_members { .. }) => false,
             Call::Court(_) => false,
             #[cfg(feature = "parachain")]
-            Call::DmpQueue(inner_call) => {
-                match inner_call {
-                    // Executing this call with a maliciously crafted XCM can halt the chain.
-                    service_overweight { .. } => false,
-                    _ => true,
-                }
-            }
+            Call::DmpQueue(service_overweight { .. }) => false,
             Call::LiquidityMining(_) => false,
             Call::PredictionMarkets(inner_call) => {
                 match inner_call {
@@ -199,8 +178,6 @@ impl Contains<Call> for IsCallable {
                     set_code { .. } => false,
                     // See "setCode"
                     set_code_without_checks { .. } => false,
-                    // setHeapPages
-                    set_heap_pages { .. } => false,
                     // Setting the storage directly is a dangerous operation that can lead to an
                     // inconsistent state. There might be scenarios where this is helpful, however,
                     // a well reviewed migration is better suited for that.
@@ -208,20 +185,10 @@ impl Contains<Call> for IsCallable {
                     _ => true,
                 }
             }
-            Call::TechnicalCommittee(inner_call) => {
-                // Membership is managed by the respective Membership instance
-                match inner_call {
-                    set_members { .. } => false,
-                    _ => true,
-                }
-            }
-            Call::Vesting(inner_call) => {
-                match inner_call {
-                    // There should be no reason to force vested transfer.
-                    force_vested_transfer { .. } => false,
-                    _ => true,
-                }
-            }
+            // Membership is managed by the respective Membership instance
+            Call::TechnicalCommittee(set_members { .. }) => false,
+            // There should be no reason to force vested transfer.
+            Call::Vesting(force_vested_transfer { .. }) => false,
             _ => true,
         }
     }

--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -154,16 +154,6 @@ impl Contains<Call> for IsCallable {
                     _ => true,
                 }
             }
-            Call::Proxy(inner_call) => {
-                match inner_call {
-                    // Makes reserve inconsistent, see
-                    // https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270-L271
-                    anonymous { .. } => false,
-                    // See "anonymous"
-                    kill_anonymous { .. } => false,
-                    _ => true,
-                }
-            }
             Call::System(inner_call) => {
                 match inner_call {
                     // Some "waste" storage will never impact proper operation.


### PR DESCRIPTION
Filters potentially dangerous calls on Zeitgeist mainnet. I left out Battery Station because we only have the superuser there and might want to experiment with those functions.

To block:

`advisoryCommitteeCollective` && `council` && `technicalCommittee`
  - `setMembers` (mandatory) - Membership is managed by the respective Membership instance. Directly setting the members desynchronizes both pallets membership view.
  
`balances`:
  - `setBalance` (optional) - Balances should not be set. All newly generated tokens be minted by well know and approved processes, like staking. However, this could be used in some cases to fund system accounts like the parachain sorveign account in case something goes terribly wrong (like a hack that draws the funds from such an account, see Maganta hack). Invoking this function one can also easily mess up consistency in regards to reserved tokens and locks.
  - `forceTransfer` (optional) -- There should be no reason to force an account to transfer funds.
  
`assetManager`:
  - `updateBalance` (optional) - see reason for `balance.setBalance`
  
  
`dmpQueue`:
  - `serviceOverweight` (mandatory) - Executing this call with a maliciously crafted XCM can halt the chain.


`proxy`: 
  - `anonymous` (mandatory) - Makes `reserve` inconsistent, see https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270-L271
  - `kill_anonymous` (mandatory) - See `anonymous`


`system`:
  - `killPrefix` (mandatory) - Some "waste" storage will never impact proper operation. Cleaning up storage should be done by pallets or independent migrations.
  - `killStorage` (mandatory) - See `system.killPrefix`
  - `setCode` (mandatory) - A parachain uses parachain_system to enact and authorized a runtime upgrade. This ensure proper synchronization with the relay chain. Calling `setCode` will wreck the chain.
  - `setCodeWithoutChecks` (mandatory) - See `system.setCode`
  - `setStorage` (mandatory) -- Setting the storage directly is a dangerous operation that can lead to an inconsistent state. There might be scenarios where this is helpful, however, a well reviewed migration is better suited for that.
   
   
`vesting`:
  - `forceVestedTransfer` (optional) - There should be no reason to force vested transfer.