### PR TITLE
Fix order of arguments in `get_spot_price`

### DIFF
--- a/zrml/swaps/rpc/src/lib.rs
+++ b/zrml/swaps/rpc/src/lib.rs
@@ -61,8 +61,8 @@ where
         pool_id: PoolId,
         asset_in: Asset<MarketId>,
         asset_out: Asset<MarketId>,
-        at: Option<BlockHash>,
         with_fees: bool,
+        at: Option<BlockHash>,
     ) -> RpcResult<SerdeWrapper<Balance>>;
 
     #[method(name = "swaps_getSpotPrices")]
@@ -71,8 +71,8 @@ where
         pool_id: PoolId,
         asset_in: Asset<MarketId>,
         asset_out: Asset<MarketId>,
-        blocks: Vec<BlockNumber>,
         with_fees: bool,
+        blocks: Vec<BlockNumber>,
     ) -> RpcResult<Vec<SerdeWrapper<Balance>>>;
 }
 
@@ -162,8 +162,8 @@ where
         pool_id: PoolId,
         asset_in: Asset<MarketId>,
         asset_out: Asset<MarketId>,
-        at: Option<<Block as BlockT>::Hash>,
         with_fees: bool,
+        at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<SerdeWrapper<Balance>> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
@@ -183,8 +183,8 @@ where
         pool_id: PoolId,
         asset_in: Asset<MarketId>,
         asset_out: Asset<MarketId>,
-        blocks: Vec<NumberFor<Block>>,
         with_fees: bool,
+        blocks: Vec<NumberFor<Block>>,
     ) -> RpcResult<Vec<SerdeWrapper<Balance>>> {
         let api = self.client.runtime_api();
         blocks


### PR DESCRIPTION
The problem is that polkadot-js doesn't play well with optional parameters followed by non-optional parameters. In fact, the Rpc calls cannot be used with polkadot-js (they do still work when using websocat).

Anyways, reordering the parameters here to ensure that they can be used by the SDK.