### PR TITLE
[PM] Set market end when admin closes the market

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -326,6 +326,7 @@ mod pallet {
             let open_ids_len = Self::clear_auto_open(&market_id)?;
             let close_ids_len = Self::clear_auto_close(&market_id)?;
             Self::close_market(&market_id)?;
+            Self::set_market_end(&market_id)?;
             // The CloseOrigin should not pay fees for providing this service
             Ok((
                 Some(T::WeightInfo::admin_move_market_to_closed(open_ids_len, close_ids_len)),
@@ -2301,6 +2302,25 @@ mod pallet {
             Self::deposit_event(Event::MarketClosed(*market_id));
             total_weight = total_weight.saturating_add(T::DbWeight::get().writes(1));
             Ok(total_weight)
+        }
+
+        pub(crate) fn set_market_end(market_id: &MarketIdOf<T>) -> Result<Weight, DispatchError> {
+            <zrml_market_commons::Pallet<T>>::mutate_market(market_id, |market| {
+                market.period = match market.period {
+                    MarketPeriod::Block(ref range) => {
+                        let current_block = <frame_system::Pallet<T>>::block_number();
+                        MarketPeriod::Block(range.start..current_block)
+                    }
+                    MarketPeriod::Timestamp(ref range) => {
+                        let current_time_frame = Self::calculate_time_frame_of_moment(
+                            <zrml_market_commons::Pallet<T>>::now(),
+                        );
+                        MarketPeriod::Timestamp(range.start..current_time_frame)
+                    }
+                };
+                Ok(())
+            })?;
+            Ok(T::DbWeight::get().reads_writes(1, 1))
         }
 
         /// Handle market state transitions at the end of its active phase.

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -2354,10 +2354,8 @@ mod pallet {
                         MarketPeriod::Block(range.start..current_block)
                     }
                     MarketPeriod::Timestamp(ref range) => {
-                        let current_time_frame = Self::calculate_time_frame_of_moment(
-                            <zrml_market_commons::Pallet<T>>::now(),
-                        );
-                        MarketPeriod::Timestamp(range.start..current_time_frame)
+                        let now = <zrml_market_commons::Pallet<T>>::now();
+                        MarketPeriod::Timestamp(range.start..now)
                     }
                 };
                 Ok(())

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -104,7 +104,11 @@ fn admin_move_market_to_closed_successfully_closes_market_and_sets_end() {
         run_blocks(7);
         let now = frame_system::Pallet::<Runtime>::block_number();
         let end = 42;
-        simple_create_categorical_market(MarketCreation::Permissionless, now..end, ScoringRule::CPMM);
+        simple_create_categorical_market(
+            MarketCreation::Permissionless,
+            now..end,
+            ScoringRule::CPMM,
+        );
         run_blocks(3);
         let market_id = 0;
         assert_ok!(PredictionMarkets::admin_move_market_to_closed(Origin::signed(SUDO), market_id));

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -21,7 +21,7 @@
 use crate::{
     default_dispute_bond, mock::*, Config, Disputes, Error, Event, LastTimeFrame, MarketIdsForEdit,
     MarketIdsPerCloseBlock, MarketIdsPerDisputeBlock, MarketIdsPerOpenBlock,
-    MarketIdsPerReportBlock,
+    MarketIdsPerReportBlock, TimeFrame,
 };
 use core::ops::{Range, RangeInclusive};
 use frame_support::{
@@ -104,7 +104,7 @@ fn simple_create_scalar_market(
 }
 
 #[test]
-fn admin_move_market_to_closed_successfully_closes_market_and_sets_end() {
+fn admin_move_market_to_closed_successfully_closes_market_and_sets_end_blocknumber() {
     ExtBuilder::default().build().execute_with(|| {
         run_blocks(7);
         let now = frame_system::Pallet::<Runtime>::block_number();
@@ -122,6 +122,47 @@ fn admin_move_market_to_closed_successfully_closes_market_and_sets_end() {
         assert_eq!(market.status, MarketStatus::Closed);
         let new_end = now + 3;
         assert_eq!(market.period, MarketPeriod::Block(now..new_end));
+        assert_ne!(new_end, end);
+        System::assert_last_event(Event::MarketClosed(market_id).into());
+    });
+}
+
+#[test]
+fn admin_move_market_to_closed_successfully_closes_market_and_sets_end_timestamp() {
+    ExtBuilder::default().build().execute_with(|| {
+        let start_block = 7;
+        set_timestamp_for_on_initialize(start_block * MILLISECS_PER_BLOCK as u64);
+        run_blocks(start_block);
+        let start = <zrml_market_commons::Pallet<Runtime>>::now();
+
+        let end = start + 42.saturated_into::<TimeFrame>() * MILLISECS_PER_BLOCK as u64;
+        assert_ok!(PredictionMarkets::create_market(
+            Origin::signed(ALICE),
+            Asset::Ztg,
+            BOB,
+            MarketPeriod::Timestamp(start..end),
+            get_deadlines(),
+            gen_metadata(2),
+            MarketCreation::Permissionless,
+            MarketType::Categorical(<Runtime as crate::Config>::MinCategories::get()),
+            MarketDisputeMechanism::SimpleDisputes,
+            ScoringRule::CPMM
+        ));
+        let market_id = 0;
+        let market = MarketCommons::market(&market_id).unwrap();
+        assert_eq!(market.period, MarketPeriod::Timestamp(start..end));
+
+        let shift_blocks = 3;
+        let shift = shift_blocks * MILLISECS_PER_BLOCK as u64;
+        // millisecs per block is substracted inside the function
+        set_timestamp_for_on_initialize(start + shift + MILLISECS_PER_BLOCK as u64);
+        run_blocks(shift_blocks);
+
+        assert_ok!(PredictionMarkets::admin_move_market_to_closed(Origin::signed(SUDO), market_id));
+        let market = MarketCommons::market(&market_id).unwrap();
+        assert_eq!(market.status, MarketStatus::Closed);
+        let new_end = start + shift;
+        assert_eq!(market.period, MarketPeriod::Timestamp(start..new_end));
         assert_ne!(new_end, end);
         System::assert_last_event(Event::MarketClosed(market_id).into());
     });


### PR DESCRIPTION
Fixes #942

This is related to @TvrtkoM 's [comment on Discord](https://discord.com/channels/737780518313000960/817041223201587230/1062655318363996192).

> Really good point. The error is based on the actual market period end, which was put in by the market creator. Because you used adminMoveMarketToClosed this end was not edited to be at the time of the call to adminMoveMarketToClosed. To be able to report, you currently need to wait until the real market end time is reached.

> The question, when solving the problem is: Should we modify the MarketPeriod(range.end) to be at the time the market close was set by the admin or should we rather leave it unmodified and add another storage field.

I decided to modify the end, because I see no negative consequences at the moment.

This allows to [report the market directly](https://github.com/zeitgeistpm/zeitgeist/blob/e991d9edbc76db6f2ecc2780a7caf4a4702cff6a/zrml/prediction-markets/src/lib.rs#L1169-L1174) after closing it as an admin.