### PR TITLE
Use crystal ball logo in logs

### DIFF
--- a/node/src/service/service_parachain.rs
+++ b/node/src/service/service_parachain.rs
@@ -234,7 +234,7 @@ where
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
 ///
 /// This is the actual implementation that is abstract over the executor and the runtime api.
-#[sc_tracing::logging::prefix_logs_with("🌔 Zeitgeist Parachain")]
+#[sc_tracing::logging::prefix_logs_with("🔮 Zeitgeist Parachain")]
 async fn do_new_full<RuntimeApi, Executor, BIC>(
     parachain_config: Configuration,
     polkadot_config: Configuration,


### PR DESCRIPTION
Closes #569 

Instead of going through the effort of teaching `sc_tracing` to use an `ico` that's generated from a Zeitgeist logo `png`, I have decided to use the crystal ball (represents predictions).