### PR TITLE
Include integration tests in runtime only if `test` feature is set

### DIFF
--- a/runtime/battery-station/src/lib.rs
+++ b/runtime/battery-station/src/lib.rs
@@ -78,7 +78,6 @@ use sp_runtime::{
 use nimbus_primitives::CanAuthor;
 use sp_version::RuntimeVersion;
 
-#[cfg(feature = "parachain")]
 #[cfg(test)]
 pub mod integration_tests;
 #[cfg(feature = "parachain")]


### PR DESCRIPTION
Integration tests are also included in Battery Station Runtime if only `parachain` feature is set. They should only be included if `test` feature is set.