### PR TITLE
Gensis: User proper inflation config and eligiblity ratio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object 0.30.3",
  "rustc-demangle",
 ]

--- a/node/src/chain_spec/battery_station.rs
+++ b/node/src/chain_spec/battery_station.rs
@@ -25,7 +25,7 @@ use sc_service::ChainType;
 use sp_core::crypto::UncheckedInto;
 use zeitgeist_primitives::{
     constants::{
-        ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD},
+        ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD, STAKING_PTD},
         BASE,
     },
     types::AccountId,
@@ -69,9 +69,9 @@ fn additional_chain_spec_staging_battery_station(
         )],
         collator_commission: DefaultCollatorCommission::get(),
         inflation_info: inflation_config(
-            Perbill::from_perthousand(20),
-            Perbill::from_perthousand(35),
-            Perbill::from_perthousand(50),
+            STAKING_PTD * Perbill::from_percent(40),
+            STAKING_PTD * Perbill::from_percent(70),
+            STAKING_PTD,
             TOTAL_INITIAL_ZTG * BASE,
         ),
         nominations: vec![],

--- a/node/src/chain_spec/battery_station.rs
+++ b/node/src/chain_spec/battery_station.rs
@@ -33,12 +33,13 @@ use zeitgeist_primitives::{
 
 #[cfg(feature = "parachain")]
 use {
-    super::{Extensions, DEFAULT_COLLATOR_INFLATION_INFO},
+    super::{generate_inflation_config_function, Extensions},
     crate::BATTERY_STATION_PARACHAIN_ID,
     battery_station_runtime::{
         CollatorDeposit, DefaultBlocksPerRound, DefaultCollatorCommission,
         DefaultParachainBondReservePercent, EligibilityValue, PolkadotXcmConfig,
     },
+    zeitgeist_primitives::constants::ztg::TOTAL_INITIAL_ZTG,
 };
 
 cfg_if::cfg_if! {
@@ -67,7 +68,7 @@ fn additional_chain_spec_staging_battery_station(
             DEFAULT_STAKING_AMOUNT_BATTERY_STATION,
         )],
         collator_commission: DefaultCollatorCommission::get(),
-        inflation_info: DEFAULT_COLLATOR_INFLATION_INFO,
+        inflation_info: inflation_config(Perbill::from_percent(5), TOTAL_INITIAL_ZTG * BASE),
         nominations: vec![],
         parachain_bond_reserve_percent: DefaultParachainBondReservePercent::get(),
         parachain_id,
@@ -92,7 +93,7 @@ fn endowed_accounts_staging_battery_station() -> Vec<EndowedAccountWithBalance> 
     vec![
         // 5D2L4ghyiYE8p2z7VNJo9JYwRuc8uzPWtMBqdVyvjRcsnw4P
         EndowedAccountWithBalance(
-            hex!["2a6c61a907556e4c673880b5767dd4be08339ee7f2a58d5137d0c19ca9570a5c"].into(),
+            root_key_staging_battery_station(),
             DEFAULT_INITIAL_BALANCE_BATTERY_STATION,
         ),
         // 5EeeZVU4SiPG6ZRY7o8aDcav2p2mZMdu3ZLzbREWuHktYdhX
@@ -113,7 +114,6 @@ fn root_key_staging_battery_station() -> AccountId {
     hex!["2a6c61a907556e4c673880b5767dd4be08339ee7f2a58d5137d0c19ca9570a5c"].into()
 }
 
-#[inline]
 pub(super) fn get_wasm() -> Result<&'static [u8], String> {
     battery_station_runtime::WASM_BINARY.ok_or_else(|| "WASM binary is not available".to_string())
 }
@@ -124,6 +124,9 @@ generate_generic_genesis_function!(
         key: Some(root_key_staging_battery_station()),
     },
 );
+
+#[cfg(feature = "parachain")]
+generate_inflation_config_function!(battery_station_runtime);
 
 pub fn battery_station_staging_config() -> Result<BatteryStationChainSpec, String> {
     let wasm = get_wasm()?;

--- a/node/src/chain_spec/battery_station.rs
+++ b/node/src/chain_spec/battery_station.rs
@@ -68,7 +68,12 @@ fn additional_chain_spec_staging_battery_station(
             DEFAULT_STAKING_AMOUNT_BATTERY_STATION,
         )],
         collator_commission: DefaultCollatorCommission::get(),
-        inflation_info: inflation_config(Perbill::from_percent(5), TOTAL_INITIAL_ZTG * BASE),
+        inflation_info: inflation_config(
+            Perbill::from_parts(20),
+            Perbill::from_parts(35),
+            Perbill::from_parts(50),
+            TOTAL_INITIAL_ZTG * BASE,
+        ),
         nominations: vec![],
         parachain_bond_reserve_percent: DefaultParachainBondReservePercent::get(),
         parachain_id,

--- a/node/src/chain_spec/battery_station.rs
+++ b/node/src/chain_spec/battery_station.rs
@@ -69,9 +69,9 @@ fn additional_chain_spec_staging_battery_station(
         )],
         collator_commission: DefaultCollatorCommission::get(),
         inflation_info: inflation_config(
-            Perbill::from_parts(20),
-            Perbill::from_parts(35),
-            Perbill::from_parts(50),
+            Perbill::from_perthousand(20),
+            Perbill::from_perthousand(35),
+            Perbill::from_perthousand(50),
             TOTAL_INITIAL_ZTG * BASE,
         ),
         nominations: vec![],

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -36,6 +36,7 @@ use zeitgeist_primitives::{
 #[cfg(feature = "parachain")]
 use {
     super::battery_station::inflation_config,
+    sp_runtime::Perbill,
     zeitgeist_primitives::constants::{ztg::TOTAL_INITIAL_ZTG, BASE},
 };
 
@@ -80,7 +81,9 @@ pub fn dev_config() -> Result<BatteryStationChainSpec, String> {
                     )],
                     collator_commission: DefaultCollatorCommission::get(),
                     inflation_info: inflation_config(
-                        sp_runtime::Perbill::from_percent(5),
+                        Perbill::from_parts(20),
+                        Perbill::from_parts(35),
+                        Perbill::from_parts(50),
                         TOTAL_INITIAL_ZTG * BASE,
                     ),
                     nominations: vec![],

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -30,7 +30,7 @@ use battery_station_runtime::{
 use sc_service::ChainType;
 use sp_core::sr25519;
 use zeitgeist_primitives::{
-    constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD},
+    constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD, STAKING_PTD},
     types::Balance,
 };
 #[cfg(feature = "parachain")]
@@ -81,9 +81,9 @@ pub fn dev_config() -> Result<BatteryStationChainSpec, String> {
                     )],
                     collator_commission: DefaultCollatorCommission::get(),
                     inflation_info: inflation_config(
-                        Perbill::from_perthousand(20),
-                        Perbill::from_perthousand(35),
-                        Perbill::from_perthousand(50),
+                        STAKING_PTD * Perbill::from_percent(40),
+                        STAKING_PTD * Perbill::from_percent(70),
+                        STAKING_PTD,
                         TOTAL_INITIAL_ZTG * BASE,
                     ),
                     nominations: vec![],

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -81,9 +81,9 @@ pub fn dev_config() -> Result<BatteryStationChainSpec, String> {
                     )],
                     collator_commission: DefaultCollatorCommission::get(),
                     inflation_info: inflation_config(
-                        Perbill::from_parts(20),
-                        Perbill::from_parts(35),
-                        Perbill::from_parts(50),
+                        Perbill::from_perthousand(20),
+                        Perbill::from_perthousand(35),
+                        Perbill::from_perthousand(50),
                         TOTAL_INITIAL_ZTG * BASE,
                     ),
                     nominations: vec![],

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -22,7 +22,6 @@ use super::{
     get_account_id_from_seed, get_from_seed, token_properties, AdditionalChainSpec,
     EndowedAccountWithBalance,
 };
-
 #[cfg(feature = "parachain")]
 use battery_station_runtime::{
     DefaultBlocksPerRound, DefaultCollatorCommission, DefaultParachainBondReservePercent,
@@ -33,6 +32,11 @@ use sp_core::sr25519;
 use zeitgeist_primitives::{
     constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD},
     types::Balance,
+};
+#[cfg(feature = "parachain")]
+use {
+    super::battery_station::inflation_config,
+    zeitgeist_primitives::constants::{ztg::TOTAL_INITIAL_ZTG, BASE},
 };
 
 const INITIAL_BALANCE: Balance = Balance::MAX >> 4;
@@ -75,7 +79,10 @@ pub fn dev_config() -> Result<BatteryStationChainSpec, String> {
                         super::battery_station::DEFAULT_STAKING_AMOUNT_BATTERY_STATION,
                     )],
                     collator_commission: DefaultCollatorCommission::get(),
-                    inflation_info: crate::chain_spec::DEFAULT_COLLATOR_INFLATION_INFO,
+                    inflation_info: inflation_config(
+                        sp_runtime::Perbill::from_percent(5),
+                        TOTAL_INITIAL_ZTG * BASE,
+                    ),
                     nominations: vec![],
                     parachain_bond_reserve_percent: DefaultParachainBondReservePercent::get(),
                     parachain_id: crate::BATTERY_STATION_PARACHAIN_ID.into(),

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -51,7 +51,9 @@ cfg_if::cfg_if! {
                 use sp_runtime::Perbill;
 
                 pub(super) fn inflation_config(
-                    annual_inflation: Perbill,
+                    annual_inflation_min: Perbill,
+                    annual_inflation_ideal: Perbill,
+                    annual_inflation_max: Perbill,
                     total_supply: zeitgeist_primitives::types::Balance
                 ) -> pallet_parachain_staking::inflation::InflationInfo<zeitgeist_primitives::types::Balance> {
                     fn to_round_inflation(annual: pallet_parachain_staking::inflation::Range<Perbill>) -> pallet_parachain_staking::inflation::Range<Perbill> {
@@ -67,17 +69,16 @@ cfg_if::cfg_if! {
                         )
                     }
                     let annual = pallet_parachain_staking::inflation::Range {
-                        min: annual_inflation,
-                        ideal: annual_inflation,
-                        max: annual_inflation,
+                        min: annual_inflation_min,
+                        ideal: annual_inflation_ideal,
+                        max: annual_inflation_max,
                     };
-                    let total_max = annual_inflation.mul_floor(total_supply);
                     pallet_parachain_staking::inflation::InflationInfo {
                         // staking expectations
                         expect: pallet_parachain_staking::inflation::Range {
-                            min: Perbill::from_percent(20).mul_floor(total_max),
-                            ideal: Perbill::from_percent(50).mul_floor(total_max),
-                            max: total_max
+                            min: Perbill::from_percent(5).mul_floor(total_supply),
+                            ideal: Perbill::from_percent(10).mul_floor(total_supply),
+                            max: Perbill::from_percent(15).mul_floor(total_supply),
                         },
                         // annual inflation
                         annual,

--- a/node/src/chain_spec/zeitgeist.rs
+++ b/node/src/chain_spec/zeitgeist.rs
@@ -17,8 +17,10 @@
 
 #![cfg(feature = "with-zeitgeist-runtime")]
 
-use super::{AdditionalChainSpec, EndowedAccountWithBalance};
-use crate::chain_spec::{generate_generic_genesis_function, telemetry_endpoints, token_properties};
+use super::{
+    generate_generic_genesis_function, telemetry_endpoints, token_properties, AdditionalChainSpec,
+    EndowedAccountWithBalance,
+};
 use hex_literal::hex;
 use sc_service::ChainType;
 use sp_core::crypto::UncheckedInto;
@@ -28,8 +30,9 @@ use zeitgeist_primitives::constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PT
 
 #[cfg(feature = "parachain")]
 use {
-    super::{Extensions, DEFAULT_COLLATOR_INFLATION_INFO},
+    super::{generate_inflation_config_function, Extensions},
     crate::KUSAMA_PARACHAIN_ID,
+    zeitgeist_primitives::constants::ztg::TOTAL_INITIAL_ZTG,
     zeitgeist_runtime::{
         CollatorDeposit, DefaultBlocksPerRound, DefaultCollatorCommission,
         DefaultParachainBondReservePercent, EligibilityValue, MinCollatorStk, PolkadotXcmConfig,
@@ -74,6 +77,8 @@ fn endowed_accounts_staging_zeitgeist() -> Vec<EndowedAccountWithBalance> {
 fn additional_chain_spec_staging_zeitgeist(
     parachain_id: cumulus_primitives_core::ParaId,
 ) -> AdditionalChainSpec {
+    use zeitgeist_primitives::constants::BASE;
+
     AdditionalChainSpec {
         blocks_per_round: DefaultBlocksPerRound::get(),
         candidates: vec![
@@ -97,7 +102,7 @@ fn additional_chain_spec_staging_zeitgeist(
             ),
         ],
         collator_commission: DefaultCollatorCommission::get(),
-        inflation_info: DEFAULT_COLLATOR_INFLATION_INFO,
+        inflation_info: inflation_config(Perbill::from_percent(5), TOTAL_INITIAL_ZTG * BASE),
         nominations: vec![],
         parachain_bond_reserve_percent: DefaultParachainBondReservePercent::get(),
         parachain_id,
@@ -118,12 +123,14 @@ fn additional_chain_spec_staging_zeitgeist() -> AdditionalChainSpec {
     }
 }
 
-#[inline]
 pub(super) fn get_wasm() -> Result<&'static [u8], String> {
     zeitgeist_runtime::WASM_BINARY.ok_or_else(|| "WASM binary is not available".to_string())
 }
 
 generate_generic_genesis_function!(zeitgeist_runtime,);
+
+#[cfg(feature = "parachain")]
+generate_inflation_config_function!(zeitgeist_runtime);
 
 pub fn zeitgeist_staging_config() -> Result<ZeitgeistChainSpec, String> {
     let wasm = get_wasm()?;

--- a/node/src/chain_spec/zeitgeist.rs
+++ b/node/src/chain_spec/zeitgeist.rs
@@ -103,9 +103,9 @@ fn additional_chain_spec_staging_zeitgeist(
         ],
         collator_commission: DefaultCollatorCommission::get(),
         inflation_info: inflation_config(
-            Perbill::from_parts(20),
-            Perbill::from_parts(35),
-            Perbill::from_parts(50),
+            Perbill::from_perthousand(20),
+            Perbill::from_perthousand(35),
+            Perbill::from_perthousand(50),
             TOTAL_INITIAL_ZTG * BASE,
         ),
         nominations: vec![],

--- a/node/src/chain_spec/zeitgeist.rs
+++ b/node/src/chain_spec/zeitgeist.rs
@@ -102,7 +102,12 @@ fn additional_chain_spec_staging_zeitgeist(
             ),
         ],
         collator_commission: DefaultCollatorCommission::get(),
-        inflation_info: inflation_config(Perbill::from_percent(5), TOTAL_INITIAL_ZTG * BASE),
+        inflation_info: inflation_config(
+            Perbill::from_parts(20),
+            Perbill::from_parts(35),
+            Perbill::from_parts(50),
+            TOTAL_INITIAL_ZTG * BASE,
+        ),
         nominations: vec![],
         parachain_bond_reserve_percent: DefaultParachainBondReservePercent::get(),
         parachain_id,

--- a/node/src/chain_spec/zeitgeist.rs
+++ b/node/src/chain_spec/zeitgeist.rs
@@ -26,7 +26,7 @@ use sc_service::ChainType;
 use sp_core::crypto::UncheckedInto;
 use zeitgeist_runtime::parameters::SS58Prefix;
 
-use zeitgeist_primitives::constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD};
+use zeitgeist_primitives::constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD, STAKING_PTD};
 
 #[cfg(feature = "parachain")]
 use {
@@ -103,9 +103,9 @@ fn additional_chain_spec_staging_zeitgeist(
         ],
         collator_commission: DefaultCollatorCommission::get(),
         inflation_info: inflation_config(
-            Perbill::from_perthousand(20),
-            Perbill::from_perthousand(35),
-            Perbill::from_perthousand(50),
+            STAKING_PTD * Perbill::from_percent(40),
+            STAKING_PTD * Perbill::from_percent(70),
+            STAKING_PTD,
             TOTAL_INITIAL_ZTG * BASE,
         ),
         nominations: vec![],

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -29,6 +29,7 @@ use crate::types::{Balance, BlockNumber};
 use frame_support::{parameter_types, PalletId};
 
 // Definitions for time
+pub const BLOCKS_PER_YEAR: BlockNumber = (BLOCKS_PER_DAY * 36525) / 100;
 pub const BLOCKS_PER_DAY: BlockNumber = BLOCKS_PER_HOUR * 24;
 pub const MILLISECS_PER_BLOCK: u32 = 12000;
 pub const BLOCKS_PER_MINUTE: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/primitives/src/constants/ztg.rs
+++ b/primitives/src/constants/ztg.rs
@@ -22,10 +22,10 @@ use sp_runtime::Perbill;
 /// Total ZTG amount for community incentives.
 pub const COMMUNITY_INCENTIVES: u128 = 2_000_000;
 
-/// Total ZTG amount for collators
+/// Total ZTG amount for collators.
 pub const COLLATORS: u128 = 0;
 
-/// Total ZTG amount for liquidity mining
+/// Total ZTG amount for liquidity mining.
 pub const LIQUIDITY_MINING: u128 = 0;
 
 /// Total ZTG amount for parachain lease.
@@ -46,10 +46,19 @@ pub const TEAM_AND_ADVISORS: u128 = 15_000_000;
 /// Total ZTG amount for Zeitgesit foundation.
 pub const ZEITGEIST_FOUNDATION: u128 = 22_000_000;
 
+/// Total ZTG amount at genesis.
+pub const TOTAL_INITIAL_ZTG: u128 = COMMUNITY_INCENTIVES
+    + PARACHAIN_LEASE
+    + PUBLIC_SALE
+    + SEED_SALE
+    + STRATEGIC_SALE
+    + TEAM_AND_ADVISORS
+    + ZEITGEIST_FOUNDATION;
+
 // Inflation
 
 /// Perthousand liquidity mining inflation. 2%
-pub const LIQUIDITY_MINING_PTD: Perbill = Perbill::from_perthousand(20);
+pub const LIQUIDITY_MINING_PTD: Perbill = Perbill::from_perthousand(0);
 
 /// Perthousand collator staking inflation. 1.5%
-pub const STAKING_PTD: Perbill = Perbill::from_perthousand(15);
+pub const STAKING_PTD: Perbill = Perbill::from_perthousand(50);

--- a/primitives/src/constants/ztg.rs
+++ b/primitives/src/constants/ztg.rs
@@ -57,8 +57,8 @@ pub const TOTAL_INITIAL_ZTG: u128 = COMMUNITY_INCENTIVES
 
 // Inflation
 
-/// Perthousand liquidity mining inflation. 2%
+/// Perthousand liquidity mining inflation. 0%
 pub const LIQUIDITY_MINING_PTD: Perbill = Perbill::from_perthousand(0);
 
-/// Perthousand collator staking inflation. 1.5%
+/// Perthousand collator staking inflation. 5%
 pub const STAKING_PTD: Perbill = Perbill::from_perthousand(50);


### PR DESCRIPTION
Applies proper configuration for `parachain-staking` at genesis.
The inflation config initialization is adjusted in respect to [one pr from moonbeam](https://github.com/PureStake/moonbeam/pull/232) and [the latest state of the code](https://github.com/PureStake/moonbeam/blob/master/node/service/src/chain_spec/moonbeam.rs#L190-L217). The new code properly derives per-round inflation based on annual inflation **and expected staking amounts**. The total inflation based on expected staking amounts now looks like that:
1. If 5% or less of the total supply are staked, the inflation caused by collation and delegation rewards is 2%
2. Between 5% and 15%, the inflation [...] is 3.5%
3. For more than 15%, the inflation [...] is 5%

The changes allow allow to configure different `InflationConfig` for each network. This won't affect the running networks and can be readjusted once a new network is about to be spawned.

Besides that, the `EligibilityRatio` is set to `1`, meaning that only one collator is selected per block (unless he timeouts). Anything else can lead to network congestion.