### PR TITLE
Use secret token for CodeCov

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ runner.temp }}/zeitgeist-test-coverage.lcov
           fail_ci_if_error: true
           flags: tests


### PR DESCRIPTION
https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository

We need to edit our repository settings, so that we have an encrypted secret token named `CODECOV_TOKEN` with a CodeCov token string.