### PR TITLE
Adjust Advisory Committee voting ratios

### DIFF
--- a/node/src/chain_spec/battery_station.rs
+++ b/node/src/chain_spec/battery_station.rs
@@ -40,6 +40,7 @@ use {
         CollatorDeposit, DefaultBlocksPerRound, DefaultCollatorCommission,
         DefaultParachainBondReservePercent, EligibilityValue, PolkadotXcmConfig,
     },
+    zeitgeist_primitives::constants::ztg::STAKING_PTD,
     zeitgeist_primitives::constants::ztg::TOTAL_INITIAL_ZTG,
 };
 

--- a/node/src/chain_spec/battery_station.rs
+++ b/node/src/chain_spec/battery_station.rs
@@ -26,7 +26,7 @@ use sc_service::ChainType;
 use sp_core::crypto::UncheckedInto;
 use zeitgeist_primitives::{
     constants::{
-        ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD, STAKING_PTD},
+        ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD},
         BASE,
     },
     types::AccountId,

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -38,8 +38,8 @@ use zeitgeist_primitives::{
 use {
     super::battery_station::inflation_config,
     sp_runtime::Perbill,
-    zeitgeist_primitives::constants::{ztg::TOTAL_INITIAL_ZTG, BASE},
     zeitgeist_primitives::constants::ztg::STAKING_PTD,
+    zeitgeist_primitives::constants::{ztg::TOTAL_INITIAL_ZTG, BASE},
 };
 
 const INITIAL_BALANCE: Balance = Balance::MAX >> 4;

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -39,6 +39,7 @@ use {
     super::battery_station::inflation_config,
     sp_runtime::Perbill,
     zeitgeist_primitives::constants::{ztg::TOTAL_INITIAL_ZTG, BASE},
+    zeitgeist_primitives::constants::ztg::STAKING_PTD,
 };
 
 const INITIAL_BALANCE: Balance = Balance::MAX >> 4;

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -31,7 +31,7 @@ use battery_station_runtime::{
 use sc_service::ChainType;
 use sp_core::sr25519;
 use zeitgeist_primitives::{
-    constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD, STAKING_PTD},
+    constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD},
     types::Balance,
 };
 #[cfg(feature = "parachain")]

--- a/node/src/chain_spec/zeitgeist.rs
+++ b/node/src/chain_spec/zeitgeist.rs
@@ -33,6 +33,7 @@ use zeitgeist_primitives::constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PT
 use {
     super::{generate_inflation_config_function, Extensions},
     crate::KUSAMA_PARACHAIN_ID,
+    zeitgeist_primitives::constants::ztg::STAKING_PTD,
     zeitgeist_primitives::constants::ztg::TOTAL_INITIAL_ZTG,
     zeitgeist_runtime::{
         CollatorDeposit, DefaultBlocksPerRound, DefaultCollatorCommission,

--- a/node/src/chain_spec/zeitgeist.rs
+++ b/node/src/chain_spec/zeitgeist.rs
@@ -27,7 +27,7 @@ use sc_service::ChainType;
 use sp_core::crypto::UncheckedInto;
 use zeitgeist_runtime::parameters::SS58Prefix;
 
-use zeitgeist_primitives::constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD, STAKING_PTD};
+use zeitgeist_primitives::constants::ztg::{LIQUIDITY_MINING, LIQUIDITY_MINING_PTD};
 
 #[cfg(feature = "parachain")]
 use {

--- a/runtime/battery-station/src/lib.rs
+++ b/runtime/battery-station/src/lib.rs
@@ -35,6 +35,7 @@ pub use frame_system::{
 #[cfg(feature = "parachain")]
 pub use pallet_author_slot_filter::EligibilityValue;
 pub use pallet_balances::Call as BalancesCall;
+use pallet_collective::EnsureProportionMoreThan;
 
 #[cfg(feature = "parachain")]
 pub use crate::parachain_params::*;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -133,22 +133,23 @@ macro_rules! decl_common_types {
             EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
         >;
 
-        // More than 30%
+        // Advisory Committee vote proportions
+        // More than 33%
         type EnsureRootOrMoreThanThirtyPercentAdvisoryCommittee = EitherOfDiverse<
             EnsureRoot<AccountId>,
-            EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 3, 10>,
+            EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 1, 3>,
         >;
 
         // More than 50%
-        type EnsureRootOrMoreThanFiftyPercentAdvisoryCommittee = EitherOfDiverse<
+        type EnsureRootOrMoreThanHalfAdvisoryCommittee = EitherOfDiverse<
             EnsureRoot<AccountId>,
             EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 1, 2>,
         >;
 
-        // More than 70%
-        type EnsureRootOrMoreThanSeventyPercentAdvisoryCommittee = EitherOfDiverse<
+        // More than 66%
+        type EnsureRootOrMoreThanTwoThirdsAdvisoryCommittee = EitherOfDiverse<
             EnsureRoot<AccountId>,
-            EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 7, 10>,
+            EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 2, 3>,
         >;
 
         // At least 66%
@@ -930,8 +931,7 @@ macro_rules! impl_config_traits {
         impl parachain_info::Config for Runtime {}
 
         impl zrml_authorized::Config for Runtime {
-            type AuthorizedDisputeResolutionOrigin =
-                EnsureRootOrMoreThanFiftyPercentAdvisoryCommittee;
+            type AuthorizedDisputeResolutionOrigin = EnsureRootOrMoreThanHalfAdvisoryCommittee;
             type CorrectionPeriod = CorrectionPeriod;
             type DisputeResolution = zrml_prediction_markets::Pallet<Runtime>;
             type Event = Event;
@@ -1023,7 +1023,7 @@ macro_rules! impl_config_traits {
             type OracleBond = OracleBond;
             type OutsiderBond = OutsiderBond;
             type PalletId = PmPalletId;
-            type RejectOrigin = EnsureRootOrMoreThanSeventyPercentAdvisoryCommittee;
+            type RejectOrigin = EnsureRootOrMoreThanTwoThirdsAdvisoryCommittee;
             type RequestEditOrigin = EnsureRootOrMoreThanThirtyPercentAdvisoryCommittee;
             type ResolveOrigin = EnsureRoot<AccountId>;
             type AssetManager = AssetManager;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -133,13 +133,6 @@ macro_rules! decl_common_types {
             EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
         >;
 
-        // Advisory committee vote proportions
-        // More than 20%
-        type EnsureRootOrMoreThanTwentyPercentAdvisoryCommittee = EitherOfDiverse<
-            EnsureRoot<AccountId>,
-            EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 2, 10>,
-        >;
-
         // More than 30%
         type EnsureRootOrMoreThanThirtyPercentAdvisoryCommittee = EitherOfDiverse<
             EnsureRoot<AccountId>,
@@ -1031,7 +1024,7 @@ macro_rules! impl_config_traits {
             type OutsiderBond = OutsiderBond;
             type PalletId = PmPalletId;
             type RejectOrigin = EnsureRootOrMoreThanSeventyPercentAdvisoryCommittee;
-            type RequestEditOrigin = EnsureRootOrMoreThanTwentyPercentAdvisoryCommittee;
+            type RequestEditOrigin = EnsureRootOrMoreThanThirtyPercentAdvisoryCommittee;
             type ResolveOrigin = EnsureRoot<AccountId>;
             type AssetManager = AssetManager;
             #[cfg(feature = "parachain")]

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -134,13 +134,30 @@ macro_rules! decl_common_types {
         >;
 
         // Advisory committee vote proportions
-        // At least 50%
-        type EnsureRootOrHalfAdvisoryCommittee = EitherOfDiverse<
+        // More than 20%
+        type EnsureRootOrMoreThanTwentyPercentAdvisoryCommittee = EitherOfDiverse<
             EnsureRoot<AccountId>,
-            EnsureProportionAtLeast<AccountId, AdvisoryCommitteeInstance, 1, 2>,
+            EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 2, 10>,
         >;
 
-        // Technical committee vote proportions
+        // More than 30%
+        type EnsureRootOrMoreThanThirtyPercentAdvisoryCommittee = EitherOfDiverse<
+            EnsureRoot<AccountId>,
+            EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 3, 10>,
+        >;
+
+        // More than 50%
+        type EnsureRootOrMoreThanFiftyPercentAdvisoryCommittee = EitherOfDiverse<
+            EnsureRoot<AccountId>,
+            EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 1, 2>,
+        >;
+
+        // More than 70%
+        type EnsureRootOrMoreThanSeventyPercentAdvisoryCommittee = EitherOfDiverse<
+            EnsureRoot<AccountId>,
+            EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 7, 10>,
+        >;
+
         // At least 66%
         type EnsureRootOrTwoThirdsAdvisoryCommittee = EitherOfDiverse<
             EnsureRoot<AccountId>,
@@ -920,7 +937,8 @@ macro_rules! impl_config_traits {
         impl parachain_info::Config for Runtime {}
 
         impl zrml_authorized::Config for Runtime {
-            type AuthorizedDisputeResolutionOrigin = EnsureRootOrHalfAdvisoryCommittee;
+            type AuthorizedDisputeResolutionOrigin =
+                EnsureRootOrMoreThanFiftyPercentAdvisoryCommittee;
             type CorrectionPeriod = CorrectionPeriod;
             type DisputeResolution = zrml_prediction_markets::Pallet<Runtime>;
             type Event = Event;
@@ -980,13 +998,10 @@ macro_rules! impl_config_traits {
         impl zrml_prediction_markets::Config for Runtime {
             type AdvisoryBond = AdvisoryBond;
             type AdvisoryBondSlashPercentage = AdvisoryBondSlashPercentage;
-            type ApproveOrigin = EitherOfDiverse<
-                EnsureRoot<AccountId>,
-                pallet_collective::EnsureMember<AccountId, AdvisoryCommitteeInstance>
-            >;
+            type ApproveOrigin = EnsureRootOrMoreThanThirtyPercentAdvisoryCommittee;
             type Authorized = Authorized;
             type Court = Court;
-            type CloseOrigin = EnsureRootOrTwoThirdsAdvisoryCommittee;
+            type CloseOrigin = EnsureRoot<AccountId>;
             type DestroyOrigin = EnsureRootOrAllAdvisoryCommittee;
             type DisputeBond = DisputeBond;
             type DisputeFactor = DisputeFactor;
@@ -1015,11 +1030,8 @@ macro_rules! impl_config_traits {
             type OracleBond = OracleBond;
             type OutsiderBond = OutsiderBond;
             type PalletId = PmPalletId;
-            type RejectOrigin = EnsureRootOrHalfAdvisoryCommittee;
-            type RequestEditOrigin = EitherOfDiverse<
-                EnsureRoot<AccountId>,
-                pallet_collective::EnsureMember<AccountId, AdvisoryCommitteeInstance>,
-            >;
+            type RejectOrigin = EnsureRootOrMoreThanSeventyPercentAdvisoryCommittee;
+            type RequestEditOrigin = EnsureRootOrMoreThanTwentyPercentAdvisoryCommittee;
             type ResolveOrigin = EnsureRoot<AccountId>;
             type AssetManager = AssetManager;
             #[cfg(feature = "parachain")]

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -135,7 +135,7 @@ macro_rules! decl_common_types {
 
         // Advisory Committee vote proportions
         // More than 33%
-        type EnsureRootOrMoreThanThirtyPercentAdvisoryCommittee = EitherOfDiverse<
+        type EnsureRootOrMoreThanOneThirdAdvisoryCommittee = EitherOfDiverse<
             EnsureRoot<AccountId>,
             EnsureProportionMoreThan<AccountId, AdvisoryCommitteeInstance, 1, 3>,
         >;
@@ -991,7 +991,7 @@ macro_rules! impl_config_traits {
         impl zrml_prediction_markets::Config for Runtime {
             type AdvisoryBond = AdvisoryBond;
             type AdvisoryBondSlashPercentage = AdvisoryBondSlashPercentage;
-            type ApproveOrigin = EnsureRootOrMoreThanThirtyPercentAdvisoryCommittee;
+            type ApproveOrigin = EnsureRootOrMoreThanOneThirdAdvisoryCommittee;
             type Authorized = Authorized;
             type Court = Court;
             type CloseOrigin = EnsureRoot<AccountId>;
@@ -1024,7 +1024,7 @@ macro_rules! impl_config_traits {
             type OutsiderBond = OutsiderBond;
             type PalletId = PmPalletId;
             type RejectOrigin = EnsureRootOrMoreThanTwoThirdsAdvisoryCommittee;
-            type RequestEditOrigin = EnsureRootOrMoreThanThirtyPercentAdvisoryCommittee;
+            type RequestEditOrigin = EnsureRootOrMoreThanOneThirdAdvisoryCommittee;
             type ResolveOrigin = EnsureRoot<AccountId>;
             type AssetManager = AssetManager;
             #[cfg(feature = "parachain")]

--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -45,7 +45,7 @@ use frame_support::{
     weights::{constants::RocksDbWeight, ConstantMultiplier, IdentityFee},
 };
 use frame_system::EnsureRoot;
-use pallet_collective::{EnsureProportionAtLeast, PrimeDefaultVote};
+use pallet_collective::{EnsureProportionAtLeast, EnsureProportionMoreThan, PrimeDefaultVote};
 use pallet_transaction_payment::ChargeTransactionPayment;
 use sp_runtime::traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256};
 #[cfg(feature = "std")]


### PR DESCRIPTION
**Context.** We want to introduce community members to the committee and add a prime member to allow the committee to reach higher voting thresholds without too much delay, even if members are AFK.

The following changes are made to the Advisory Committee's voting:

- `approve_market` requires _more than_ 33.3...% of approval
- `reject_market` requires _more than_ 66.6...% of approval
- `request_edit` requires _more than_ 33.3...% of approval

This gives the following thresholds for low numbers of advisors. The numbers in parentheses specify the expected number of FT advisors and community advisors. The numbers are chosen so that the community can make autonomous decisions when there's at least three community members on the board (provided that the count of FT advisors doesn't change). Note that the number of votes required for approval/request of edit plus the number of votes required for rejection is larger than the number of advisors to prevent races.

| Number of advisors | `approve` (>33.3...%) | `reject_market` (>66.6...%) | `requests_edit` (>33.3...%) |
|--------------------|-----------|-----------------|-----------------|
| 4                  | 2 | 3 | 2 |
| 5 (4+1)            | 2 | 4 | 2 |
| 6 (4+2)            | 3 | 5 | 3 | 
| 7 (4+3)            | 3 | 5 | 3 | 
| 8 (4+4)            | 3 | 6 | 3 | 

The motion duration remains at three days. I think that's at the low end of the pain threshold. Anything higher than four days means that it takes the prime member too long to exercise their power. Anything below three days and the prime member is hard pressed to keep an eye on possible motions over weekends.

**Edit.** This market also denies the AC the ability to close market early, see the discussion below.