### PR TITLE
Add badblocks feature

### DIFF
--- a/node/src/chain_spec/battery_station.rs
+++ b/node/src/chain_spec/battery_station.rs
@@ -160,6 +160,7 @@ pub fn battery_station_staging_config() -> Result<BatteryStationChainSpec, Strin
         #[cfg(feature = "parachain")]
         crate::chain_spec::Extensions {
             relay_chain: "rococo".into(),
+            bad_blocks: None,
             parachain_id: BATTERY_STATION_PARACHAIN_ID,
         },
         #[cfg(not(feature = "parachain"))]

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -124,6 +124,7 @@ pub fn dev_config() -> Result<BatteryStationChainSpec, String> {
         #[cfg(feature = "parachain")]
         crate::chain_spec::Extensions {
             relay_chain: "rococo-dev".into(),
+            bad_blocks: None,
             parachain_id: crate::BATTERY_STATION_PARACHAIN_ID,
         },
         #[cfg(not(feature = "parachain"))]

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -228,6 +228,8 @@ pub struct Extensions {
     pub parachain_id: u32,
     /// The relay chain of the Parachain.
     pub relay_chain: String,
+        /// Known bad block hashes.
+	pub bad_blocks: sc_client_api::BadBlocks<polkadot_primitives::v2::Block>,
 }
 
 #[cfg(feature = "parachain")]

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -228,8 +228,8 @@ pub struct Extensions {
     pub parachain_id: u32,
     /// The relay chain of the Parachain.
     pub relay_chain: String,
-        /// Known bad block hashes.
-	pub bad_blocks: sc_client_api::BadBlocks<polkadot_primitives::v2::Block>,
+    /// Known bad block hashes.
+    pub bad_blocks: sc_client_api::BadBlocks<polkadot_primitives::v2::Block>,
 }
 
 #[cfg(feature = "parachain")]

--- a/node/src/chain_spec/zeitgeist.rs
+++ b/node/src/chain_spec/zeitgeist.rs
@@ -164,6 +164,7 @@ pub fn zeitgeist_staging_config() -> Result<ZeitgeistChainSpec, String> {
         #[cfg(feature = "parachain")]
         crate::chain_spec::Extensions {
             relay_chain: "kusama".into(),
+            bad_blocks: None,
             parachain_id: KUSAMA_PARACHAIN_ID,
         },
         #[cfg(not(feature = "parachain"))]


### PR DESCRIPTION
Enables specifying [`bad_blocks`](https://substrate.stackexchange.com/questions/283/how-to-revert-a-bricked-chain-due-to-bad-setcode/435#435) within the chainspec to blacklist specific block hashes. This is a preparation for the eventuality that the migration to Polkadot fails and a recovery is going to be necessary.