### PR TITLE
Add orml-tokens calls to runtime's call enum

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -292,7 +292,7 @@ macro_rules! create_runtime {
 
                 // Third-party
                 AssetManager: orml_currencies::{Call, Pallet, Storage} = 40,
-                Tokens: orml_tokens::{Config<T>, Event<T>, Pallet, Storage} = 41,
+                Tokens: orml_tokens::{Call, Config<T>, Event<T>, Pallet, Storage} = 41,
 
                 // Zeitgeist
                 MarketCommons: zrml_market_commons::{Pallet, Storage} = 50,


### PR DESCRIPTION
It is currently not possible to interact with the tokens pallet via calls. The governance body is unable to utilize those calls. In addition to that, the sudo account cannot be used to generate tokens to test features (such as testing market with fakedot).