### PR TITLE
Move ZBS/ZTG dust into the treasury

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -589,7 +589,7 @@ macro_rules! impl_config_traits {
         impl pallet_balances::Config for Runtime {
             type AccountStore = System;
             type Balance = Balance;
-            type DustRemoval = ();
+            type DustRemoval = Treasury;
             type Event = Event;
             type ExistentialDeposit = ExistentialDeposit;
             type MaxLocks = MaxLocks;


### PR DESCRIPTION
Whenever an account is killed due to not meeting the existential deposit requirements, the remaining funds (dust) are moved into the treasury.