### PR TITLE
Move slashed funds from reject proposals to treasury

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -870,7 +870,7 @@ macro_rules! impl_config_traits {
             type Currency = Balances;
             type Event = Event;
             type MaxApprovals = MaxApprovals;
-            type OnSlash = ();
+            type OnSlash = Treasury;
             type PalletId = TreasuryPalletId;
             type ProposalBond = ProposalBond;
             type ProposalBondMinimum = ProposalBondMinimum;


### PR DESCRIPTION
The treasury pallet has one occasion during which slashing can occur: When a proposal is rejected. Those funds are currently not handled and simply burned.
This PR moves the slashed tokens into the treasury, where the funds are burned as well in case they are not used.