### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,9 +17,6 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Install ProtoBuf Compiler
-        run: |
-          sudo apt-get install protobuf-compiler
       # Ensure that at most one benchmark worklow runs across all workflows
       - name: Turnstyle
         uses: softprops/turnstyle@v1
@@ -36,12 +33,8 @@ jobs:
         uses: actions/checkout@v2
         if: github.event_name == 'workflow_dispatch'
 
-      # TODO(#839): `rustup show` installs the rustc version specified in the `rust-toolchain` file
-      # according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due
-      # to the lack of support of `rust-toolchain` files with TOML syntax:
-      # https://github.com/actions-rs/toolchain/issues/126.
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install build tools
+        run: ./scripts/init.sh
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -11,17 +11,10 @@ jobs:
     name: Test migration
     runs-on: ubuntu-latest
     steps:
-      - name: Install ProtoBuf Compiler
-        run: |
-          sudo apt-get install protobuf-compiler
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # TODO(#839): `rustup show` installs the rustc version specified in the `rust-toolchain` file
-      # according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due
-      # to the lack of support of `rust-toolchain` files with TOML syntax:
-      # https://github.com/actions-rs/toolchain/issues/126.
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install build tools
+        run: ./scripts/init.sh
 
       - run: ./scripts/runtime-upgrade/test_runtime_upgrade.sh ${{ github.event.inputs.block }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,18 +14,11 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - name: Install ProtoBuf Compiler
-        run: |
-          sudo apt-get install protobuf-compiler
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # TODO(#839): `rustup show` installs the rustc version specified in the `rust-toolchain` file
-      # according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due
-      # to the lack of support of `rust-toolchain` files with TOML syntax:
-      # https://github.com/actions-rs/toolchain/issues/126.
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install build tools
+        run: ./scripts/init.sh
         
       - uses: actions-rs/install@v0.1
         with:
@@ -48,32 +41,27 @@ jobs:
           "standalone"
         ]
     steps:
-      - name: Install ProtoBuf Compiler
-        run: |
-          sudo apt-get install protobuf-compiler
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install build tools
+        run: ./scripts/init.sh
 
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
 
       - name: Checks
         run: ./scripts/tests/${{ matrix.scripts }}.sh
+
   benchmark:
     name: Quick check benchmarks
     runs-on: ubuntu-latest
     steps:
-      - name: Install ProtoBuf Compiler
-        run: |
-          sudo apt-get install protobuf-compiler
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install build tools
+        run: ./scripts/init.sh
       
       - run: ./scripts/benchmarks/quick_check.sh
 
@@ -81,14 +69,11 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Install ProtoBuf Compiler
-        run: |
-          sudo apt-get install protobuf-compiler
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install build tools
+        run: ./scripts/init.sh
 
       - uses: actions-rs/install@v0.1
         with:
@@ -115,14 +100,11 @@ jobs:
     name: Fuzz
     runs-on: ubuntu-latest
     steps:
-      - name: Install ProtoBuf Compiler
-        run: |
-          sudo apt-get install protobuf-compiler
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install build tools
+        run: ./scripts/init.sh
 
       - uses: actions-rs/install@v0.1
         with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -10,18 +10,12 @@ jobs:
     name: Test Try Runtime
     runs-on: ubuntu-latest
     steps:
-      - name: Install ProtoBuf Compiler
-        run: |
-          sudo apt-get install protobuf-compiler
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # TODO(#839): `rustup show` installs the rustc version specified in the `rust-toolchain` file
-      # according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due
-      # to the lack of support of `rust-toolchain` files with TOML syntax:
-      # https://github.com/actions-rs/toolchain/issues/126.
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install build tools
+        run: ./scripts/init.sh
+
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
 
@@ -30,18 +24,12 @@ jobs:
     name: Test Try Runtime
     runs-on: ubuntu-latest
     steps:
-      - name: Install ProtoBuf Compiler
-        run: |
-          sudo apt-get install protobuf-compiler
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # TODO(#839): `rustup show` installs the rustc version specified in the `rust-toolchain` file
-      # according to https://rust-lang.github.io/rustup/overrides.html. We don't use actions-rs due
-      # to the lack of support of `rust-toolchain` files with TOML syntax:
-      # https://github.com/actions-rs/toolchain/issues/126.
-      - name: Install rust toolchain
-        run: rustup show
+      - name: Install build tools
+        run: ./scripts/init.sh
+        
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-05-28"
+channel = "nightly-2022-09-24"
 components = ["clippy", "rustfmt", "llvm-tools-preview"]
 profile = "minimal"
 targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-09-24"
+channel = "nightly-2022-05-28"
 components = ["clippy", "rustfmt", "llvm-tools-preview"]
 profile = "minimal"
 targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-05-28"
+channel = "nightly-2023-05-28"
 components = ["clippy", "rustfmt", "llvm-tools-preview"]
 profile = "minimal"
 targets = ["wasm32-unknown-unknown"]

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-echo "*** Initializing WASM build environment"
+echo "*** Initializing build environment"
 
-if [ -z $CI_PROJECT_NAME ] ; then
-   rustup update nightly-2022-04-13
-   rustup update stable
-fi
+sudo apt-get update && \
+   sudo apt-get install -y build-essential clang curl libssl-dev protobuf-compiler
 
-rustup target add wasm32-unknown-unknown --toolchain nightly-2022-04-13
+curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+   source "$HOME/.cargo/env" && \
+   rustup show

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -4,9 +4,15 @@ set -e
 
 echo "*** Initializing build environment"
 
-sudo apt-get update && \
+# No sudo during docker build
+if [ -f /.dockerenv ]; then
+   apt-get update && \
+   apt-get install -y build-essential clang curl libssl-dev protobuf-compiler
+else
+   sudo apt-get update && \
    sudo apt-get install -y build-essential clang curl libssl-dev protobuf-compiler
+fi
 
 curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-   source "$HOME/.cargo/env" && \
+   . "$HOME/.cargo/env" && \
    rustup show


### PR DESCRIPTION
A dependency is missing in the dockerfile: https://github.com/zeitgeistpm/zeitgeist/actions/runs/5089309589/jobs/9146777074

This PR unifies the build dependency process within `./scripts/init.sh` and updates all workflows and the Dockerfile to use `./scripts/init.sh`. The script always installs the rust toolchain based on the `rust-toolchain` file, which was previously not the case in every context. Lastly, the docker image was updated to use a minimal version of Ubuntu Jammy (update from 18.04 LTS to 22.04).