### PR TITLE
Use reasonable storage fee

### DIFF
--- a/docs/changelog_for_devs.md
+++ b/docs/changelog_for_devs.md
@@ -14,6 +14,7 @@ APIs/RPC interface.
 
 ## v0.3.9
 
+[#1011]: https://github.com/zeitgeistpm/zeitgeist/pull/1011
 [#937]: https://github.com/zeitgeistpm/zeitgeist/pull/937
 [#903]: https://github.com/zeitgeistpm/zeitgeist/pull/903
 
@@ -21,6 +22,9 @@ APIs/RPC interface.
 
 - ⚠️ Add `outsider` field to `MarketBonds` struct. In particular, the `Market`
   struct's layout has changed ([#903]).
+- Adjust `deposit` function used to calculate storage fees for the following
+  pallets: identity, multisig, preimage, proxy. The cost of adding a identity
+  reduced from a minimum of 125 ZTG to a minimum of 1.5243 ZTG ([#1011])
 
 ### Fixed
 

--- a/docs/changelog_for_devs.md
+++ b/docs/changelog_for_devs.md
@@ -23,7 +23,7 @@ APIs/RPC interface.
 - ⚠️ Add `outsider` field to `MarketBonds` struct. In particular, the `Market`
   struct's layout has changed ([#903]).
 - Adjust `deposit` function used to calculate storage fees for the following
-  pallets: identity, multisig, preimage, proxy. The cost of adding a identity
+  pallets: identity, multisig, preimage, proxy. The cost of adding an identity
   reduced from a minimum of 125 ZTG to a minimum of 1.5243 ZTG ([#1011])
 
 ### Fixed

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -42,8 +42,10 @@ pub const CENT: Balance = BASE / 100; // 100_000_000
 pub const MILLI: Balance = CENT / 10; //  10_000_000
 pub const MICRO: Balance = MILLI / 1000; // 10_000
 
+/// Storage cost per byte and item.
+// Approach: Achieve same cost per item and bytes in relation to total supply as on Polkadot.
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
-    items as Balance * 20 * BASE + (bytes as Balance) * 100 * MILLI
+    items as Balance * 150 * CENT + (bytes as Balance) * 75 * MICRO
 }
 
 // Rikiddo and TokensConfig

--- a/runtime/battery-station/src/parameters.rs
+++ b/runtime/battery-station/src/parameters.rs
@@ -119,9 +119,9 @@ parameter_types! {
 
     // Identity
     /// The amount held on deposit for a registered identity
-    pub const BasicDeposit: Balance = 8 * BASE;
+    pub const BasicDeposit: Balance = deposit(1, 258);
     /// The amount held on deposit per additional field for a registered identity.
-    pub const FieldDeposit: Balance = 256 * CENT;
+    pub const FieldDeposit: Balance = deposit(0, 66);
     /// Maximum number of additional fields that may be stored in an ID. Needed to bound the I/O
     /// required to access an identity, but can be pretty high.
     pub const MaxAdditionalFields: u32 = 64;

--- a/runtime/battery-station/src/parameters.rs
+++ b/runtime/battery-station/src/parameters.rs
@@ -133,7 +133,7 @@ parameter_types! {
     /// The amount held on deposit for a registered subaccount. This should account for the fact
     /// that one storage item's value will increase by the size of an account ID, and there will
     /// be another trie item whose value is the size of an account ID plus 32 bytes.
-    pub const SubAccountDeposit: Balance = 2 * BASE;
+    pub const SubAccountDeposit: Balance = deposit(1, 53);
 
     // Liquidity Mining parameters
     /// Pallet identifier, mainly used for named balance reserves.

--- a/runtime/zeitgeist/src/parameters.rs
+++ b/runtime/zeitgeist/src/parameters.rs
@@ -119,9 +119,9 @@ parameter_types! {
 
     // Identity
     /// The amount held on deposit for a registered identity
-    pub const BasicDeposit: Balance = 100 * BASE;
+    pub const BasicDeposit: Balance = deposit(1, 258);
     /// The amount held on deposit per additional field for a registered identity.
-    pub const FieldDeposit: Balance = 25 * BASE;
+    pub const FieldDeposit: Balance = deposit(0, 66);
     /// Maximum number of additional fields that may be stored in an ID. Needed to bound the I/O
     /// required to access an identity, but can be pretty high.
     pub const MaxAdditionalFields: u32 = 16;

--- a/runtime/zeitgeist/src/parameters.rs
+++ b/runtime/zeitgeist/src/parameters.rs
@@ -133,7 +133,7 @@ parameter_types! {
     /// The amount held on deposit for a registered subaccount. This should account for the fact
     /// that one storage item's value will increase by the size of an account ID, and there will
     /// be another trie item whose value is the size of an account ID plus 32 bytes.
-    pub const SubAccountDeposit: Balance = 20 * BASE;
+    pub const SubAccountDeposit: Balance = deposit(1, 53);
 
     // Liquidity Mining parameters
     /// Pallet identifier, mainly used for named balance reserves. DO NOT CHANGE.


### PR DESCRIPTION
During the integration of the contracts pallet it became evident to me that currently the chain overcharges ZTG for storage in certain pallets. A function `deposit` exists that is used to calculate the total fee in ZTG per storage key and bytes associated to it.

With the previous configuration, using up the total supply of ZTG would only allow to store 100 MB of bytes, not considering the costs per item. The cost per byte and items in ZTG in relation to the total ZTG supply was aligned with the cost of DOT in relation to the DOT supply used in [Polkadot](https://github.com/paritytech/polkadot/blob/97930a8b2cc211ecfb80f289c4c578a9157e6dc4/runtime/polkadot/constants/src/lib.rs#L36-L38). 

In addition to the `deposit` adjustment, `pallet-identity` now also uses the `deposit` function to determine the storage fee. It is aligned to the one used in [Polkadot](https://github.com/paritytech/polkadot/blob/97930a8b2cc211ecfb80f289c4c578a9157e6dc4/runtime/polkadot/src/lib.rs#L618C2-L619), effectively reducing the storage fee to register an identity from a minimum of 125 ZTG to a minimum of 1.5243 ZTG.

Affected pallets:
  - MultiSig, [no storage migration required](https://github.com/paritytech/substrate/blob/polkadot-v0.9.32/frame/multisig/src/lib.rs#L110-L111)
  - Identity, [no storage migration required](https://github.com/paritytech/substrate/blob/polkadot-v0.9.32/frame/identity/src/types.rs#L385-L386)
  - Preimage, [no storage migration required](https://github.com/paritytech/substrate/blob/5ea6d95309aaccfa399c5f72e5a14a4b7c6c4ca1/frame/preimage/src/lib.rs#L65-L70)
  - Proxy, [no storage migration required](https://github.com/paritytech/substrate/blob/polkadot-v0.9.32/frame/proxy/src/lib.rs#L565-L566)