### PR TITLE
Make `MaxMarketLifetime` a constant

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -1650,6 +1650,7 @@ mod pallet {
         type MaxRejectReasonLen: Get<u32>;
 
         /// The maximum allowed duration of a market from creation to market close in blocks.
+        #[pallet::constant]
         type MaxMarketLifetime: Get<Self::BlockNumber>;
 
         /// The maximum number of bytes allowed as edit reason.


### PR DESCRIPTION
This fixed an oversight from the PR introducing the `MaxMarketLifetime` config parameter.