### PR TITLE
Add code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,15 @@
+# When a part of the project is modified that is owned by a code owner, 
+# the code owner has to be included in the respective PR's reviewer list.
+# The code owner has the right to delegate the responsibility to review.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+/node/ @sea212
+/runtime/ @sea212
+/zrml/authorized/ @Chralt98
+/zrml/court/ @Chralt98
+/zrml/global-disputes/ @Chralt98
+/zrml/prediction-markets/ @maltekliemann
+/zrml/rikiddo/ @sea212
+/zrml/simple-disputes/ @Chralt98
+/zrml/styx/ @yornaath
+/zrml/swaps/ @maltekliemann


### PR DESCRIPTION
This PR adds code owners to this project. Code owners will be automatically selected as reviewers within PRs that modify parts of the project they own. Code owners are allowed to delegated their responsibility to review to someone else.

Initial code owners were determined by total involvement:
> /node/ @sea212
/runtime/ @sea212
/zrml/authorized/ @Chralt98
/zrml/court/ @Chralt98
/zrml/global-disputes/ @Chralt98
/zrml/prediction-markets/ @maltekliemann
/zrml/rikiddo/ @sea212
/zrml/simple-disputes/ @Chralt98
/zrml/styx/ @yornaath
/zrml/swaps/ @maltekliemann