### PR TITLE
Separate tests into two jobs: standalone and parachain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,8 +85,8 @@ jobs:
       
       - run: ./scripts/benchmarks/quick_check.sh
 
-  tests:
-    name: Tests
+  test_standalone:
+    name: Test standalone build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -113,7 +113,37 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Tests
-        run: ./scripts/tests/test.sh
+        run: ./scripts/tests/test_standalone.sh
+
+  test_parachain:
+    name: Test parachain build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install build tools
+        run: ./scripts/init.sh
+
+      # No disk space: https://github.com/zeitgeistpm/zeitgeist/actions/runs/5085081984/jobs/9144298675?pr=1006
+      # Workaround: https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+      - name: Free up disk space on GitHub hosted runners
+        run: |
+          # Ensure context is GitHub hosted runner
+          # https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
+          if [[ "${{ runner.name }}" == "GitHub Actions"* ]]; then
+            echo "Freeing up space in GitHub hosted runner"
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf /opt/ghc
+            sudo rm -rf "/usr/local/share/boost"
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          fi
+      
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Tests
+        run: ./scripts/tests/test_parachain.sh
 
   fuzz:
     name: Fuzz

--- a/scripts/tests/all-sequencial.sh
+++ b/scripts/tests/all-sequencial.sh
@@ -4,8 +4,9 @@
 #
 # IMPORTANT: CI verifies most of the following scripts in parallel
 
-. "$(dirname "$0")/test.sh" --source-only
 . "$(dirname "$0")/clippy.sh" --source-only
-. "$(dirname "$0")/parachain.sh" --source-only
 . "$(dirname "$0")/standalone.sh" --source-only
+. "$(dirname "$0")/parachain.sh" --source-only
+. "$(dirname "$0")/test_standalone.sh" --source-only
+. "$(dirname "$0")/test_parachain.sh" --source-only
 . "$(dirname "$0")/fuzz.sh" --source-only

--- a/scripts/tests/test_parachain.sh
+++ b/scripts/tests/test_parachain.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
-# Tests: Run tests on all crates
+# Tests: Run tests on all crates using a parachain build
 
 set -euxo pipefail
 
 . "$(dirname "$0")/aux-functions.sh" --source-only
-
-# Test standalone
-test_package_with_feature "." "default,runtime-benchmarks" ""
 
 # Test parachain
 test_package_with_feature "." "default,parachain,runtime-benchmarks" ""

--- a/scripts/tests/test_standalone.sh
+++ b/scripts/tests/test_standalone.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Tests: Run tests on all crates using a standalone build
+
+set -euxo pipefail
+
+. "$(dirname "$0")/aux-functions.sh" --source-only
+
+# Test standalone
+test_package_with_feature "." "default,runtime-benchmarks" ""


### PR DESCRIPTION
### What does it do?
It potentially fixes an "out of disk space" error in the pipeline

### What important points should reviewers know?
The fix separates the standalone and parachain tests into their respective workflow jobs, thus providing a whole instance for each case. 

### Is there something left for follow-up PRs?
No

### What alternative implementations were considered?
None

### Are there relevant PRs or issues?
https://github.com/zeitgeistpm/zeitgeist/pull/1006)](https://github.com/zeitgeistpm/zeitgeist/pull/1006

### References
None
