### PR TITLE
Update crate and runtime version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,7 @@ checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "battery-station-runtime"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "cfg-if 1.0.0",
  "common-runtime",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "cfg-if 1.0.0",
  "cumulus-pallet-xcmp-queue",
@@ -12836,7 +12836,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-node"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "battery-station-runtime",
  "cfg-if 1.0.0",
@@ -12921,7 +12921,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-primitives"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "arbitrary",
  "frame-support",
@@ -12939,7 +12939,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-runtime"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "cfg-if 1.0.0",
  "common-runtime",
@@ -13059,7 +13059,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-authorized"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13076,7 +13076,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-court"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "arrayvec 0.7.2",
  "frame-benchmarking",
@@ -13096,7 +13096,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-global-disputes"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13116,7 +13116,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-liquidity-mining"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13134,7 +13134,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-market-commons"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -13150,7 +13150,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-orderbook-v1"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13179,7 +13179,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13230,7 +13230,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets-runtime-api"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -13239,7 +13239,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-rikiddo"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "arbitrary",
  "cfg-if 1.0.0",
@@ -13272,7 +13272,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-simple-disputes"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13289,7 +13289,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-styx"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13305,7 +13305,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13347,7 +13347,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-rpc"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13360,7 +13360,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-runtime-api"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -177,7 +177,7 @@ description = "An evolving blockchain for prediction markets and futarchy."
 edition = "2021"
 homepage = "https://zeitgeist.pm"
 name = "zeitgeist-node"
-version = "0.3.8"
+version = "0.3.9"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -34,4 +34,4 @@ with-global-disputes = []
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zeitgeist-primitives"
-version = "0.3.8"
+version = "0.3.9"

--- a/runtime/battery-station/Cargo.toml
+++ b/runtime/battery-station/Cargo.toml
@@ -408,7 +408,7 @@ with-global-disputes = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "battery-station-runtime"
-version = "0.3.8"
+version = "0.3.9"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/battery-station/src/lib.rs
+++ b/runtime/battery-station/src/lib.rs
@@ -91,10 +91,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("zeitgeist"),
     impl_name: create_runtime_str!("zeitgeist"),
     authoring_version: 1,
-    spec_version: 45,
+    spec_version: 46,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 20,
+    transaction_version: 21,
     state_version: 1,
 };
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -77,7 +77,7 @@ with-global-disputes = []
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "common-runtime"
-version = "0.3.8"
+version = "0.3.9"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/zeitgeist/Cargo.toml
+++ b/runtime/zeitgeist/Cargo.toml
@@ -398,7 +398,7 @@ with-global-disputes = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zeitgeist-runtime"
-version = "0.3.8"
+version = "0.3.9"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -90,10 +90,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("zeitgeist"),
     impl_name: create_runtime_str!("zeitgeist"),
     authoring_version: 1,
-    spec_version: 45,
+    spec_version: 46,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 20,
+    transaction_version: 21,
     state_version: 1,
 };
 

--- a/zrml/authorized/Cargo.toml
+++ b/zrml/authorized/Cargo.toml
@@ -38,4 +38,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-authorized"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/court/Cargo.toml
+++ b/zrml/court/Cargo.toml
@@ -41,4 +41,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-court"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/global-disputes/Cargo.toml
+++ b/zrml/global-disputes/Cargo.toml
@@ -45,4 +45,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-global-disputes"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/liquidity-mining/Cargo.toml
+++ b/zrml/liquidity-mining/Cargo.toml
@@ -40,4 +40,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-liquidity-mining"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/market-commons/Cargo.toml
+++ b/zrml/market-commons/Cargo.toml
@@ -31,4 +31,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-market-commons"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/orderbook-v1/Cargo.toml
+++ b/zrml/orderbook-v1/Cargo.toml
@@ -47,4 +47,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-orderbook-v1"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/prediction-markets/Cargo.toml
+++ b/zrml/prediction-markets/Cargo.toml
@@ -98,4 +98,4 @@ with-global-disputes = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-prediction-markets"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/prediction-markets/runtime-api/Cargo.toml
+++ b/zrml/prediction-markets/runtime-api/Cargo.toml
@@ -15,4 +15,4 @@ std = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-prediction-markets-runtime-api"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/rikiddo/Cargo.toml
+++ b/zrml/rikiddo/Cargo.toml
@@ -42,4 +42,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-rikiddo"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/simple-disputes/Cargo.toml
+++ b/zrml/simple-disputes/Cargo.toml
@@ -38,4 +38,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-simple-disputes"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/styx/Cargo.toml
+++ b/zrml/styx/Cargo.toml
@@ -36,4 +36,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-styx"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/swaps/Cargo.toml
+++ b/zrml/swaps/Cargo.toml
@@ -65,4 +65,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-swaps"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/swaps/rpc/Cargo.toml
+++ b/zrml/swaps/rpc/Cargo.toml
@@ -11,4 +11,4 @@ zrml-swaps-runtime-api = { default-features = false, features = ["std"], path = 
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-swaps-rpc"
-version = "0.3.8"
+version = "0.3.9"

--- a/zrml/swaps/runtime-api/Cargo.toml
+++ b/zrml/swaps/runtime-api/Cargo.toml
@@ -17,4 +17,4 @@ std = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-swaps-runtime-api"
-version = "0.3.8"
+version = "0.3.9"


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
Adjusts `RuntimeVersion` based on changes since last release.

### What important points should reviewers know?
The labels `i:spec_changed`, `i:transactions-changed` and `i:authorship-interface-changed` in closed PRs since the last release indicate a version bump in the `RuntimeVersion`.

### Is there something left for follow-up PRs?
No.

### What alternative implementations were considered?
No.

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->
[Previous version update PR.](https://github.com/zeitgeistpm/zeitgeist/pull/932)

### References
None
