### PR TITLE
Use argument in init.sh to avoid usage of sudo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . /zeitgeist
 RUN apt-get update && \
     apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold"
 
-RUN ./scripts/init.sh
+RUN ./scripts/init.sh nosudo
 
 RUN . "$HOME/.cargo/env" && cargo build --profile "$PROFILE" --features "$FEATURES"
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+# Initializes a build environment.
+# Passing one argument results in avoiding the usage of sudo for privileged commands.
+
 set -e
 
 echo "*** Initializing build environment"
 
-# No sudo during docker build
-if [ -f /.dockerenv ]; then
+if [ -n "$1" ]; then
    apt-get update && \
    apt-get install -y build-essential clang curl libssl-dev protobuf-compiler
 else

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -7,7 +7,7 @@ set -e
 
 echo "*** Initializing build environment"
 
-if [ -n "$1" ]; then
+if [ "$1" == "nosudo" ]; then
    apt-get update && \
    apt-get install -y build-essential clang curl libssl-dev protobuf-compiler
 else

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Initializes a build environment.
-# Passing one argument results in avoiding the usage of sudo for privileged commands.
+# Passing "nosudo" in the first argument results in avoiding the usage of sudo for privileged commands.
 
 set -e
 


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
Instead of relying on the ([seemingly unreliable](https://github.com/zeitgeistpm/zeitgeist/actions/runs/5347848379/jobs/9697515500#step:7:1295)) `/.dockerenv` file to determine a docker build requirement within `scripts/init.sh`, an optional argument is now used.

### What important points should reviewers know?
This PR is a result of a failed workflow.

### Is there something left for follow-up PRs?
No.

### What alternative implementations were considered?
None.

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->
[A previous PR](https://github.com/zeitgeistpm/zeitgeist/pull/1009) attempted to fix this already. While the solution worked until now, it seems it is not 100% reliable.

### References
None.
