### PR TITLE
Fix name collision

### DIFF
--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -103,7 +103,7 @@ pub struct IsCallable;
 // Currently disables Court, Rikiddo and creation of markets using Court or SimpleDisputes
 // dispute mechanism.
 impl Contains<RuntimeCall> for IsCallable {
-    fn contains(call: &RuntimeCall) -> bool {
+    fn contains(runtime_call: &RuntimeCall) -> bool {
         #[cfg(feature = "parachain")]
         use cumulus_pallet_dmp_queue::Call::service_overweight;
         use frame_system::Call::{
@@ -127,7 +127,7 @@ impl Contains<RuntimeCall> for IsCallable {
         };
 
         #[allow(clippy::match_like_matches_macro)]
-        match call {
+        match runtime_call {
             // Membership is managed by the respective Membership instance
             RuntimeCall::AdvisoryCommittee(set_members { .. }) => false,
             // See "balance.set_balance"


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
Building the Zeitgeist runtime with srtool results in the following error:
>   error[E0423]: expected value, found struct variant `call`
     --> /build/runtime/zeitgeist/src/lib.rs:130:15
      |
  130 |         match call {
      |               ^^^^ you might want to surround a struct literal with parentheses: `(call { /* fields */ })`?
>
>  For more information about this error, try `rustc --explain E0423`.

The rust compiler used in the docker container is unable to distinguish `call`, which represents the `RuntimeCall` that is currently being process and `call`, which represents a dispatchable from `pallet-contracts`.

This PR assign unique names.

### What important points should reviewers know?
None.

### Is there something left for follow-up PRs?
No. 

### What alternative implementations were considered?
- Renaming the contracts call variant.

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->
No.

### References
None.
