### PR TITLE
Use updated Rococo bootnodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,13 +500,13 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm",
+ "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "parachain-info",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-runtime-parachains",
- "rococo-runtime",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "rococo-runtime 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "scale-info",
  "session-keys-primitives",
  "sp-api",
@@ -525,10 +525,10 @@ dependencies = [
  "substrate-fixed",
  "substrate-wasm-builder",
  "test-case",
- "xcm",
- "xcm-builder",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "xcm-emulator",
- "xcm-executor",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "zeitgeist-primitives",
  "zrml-authorized",
  "zrml-court",
@@ -1462,10 +1462,10 @@ dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sc-client-api",
  "sp-api",
  "sp-consensus",
@@ -1484,7 +1484,7 @@ dependencies = [
  "dyn-clone",
  "futures 0.3.25",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
@@ -1528,9 +1528,9 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-primitives",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
@@ -1550,10 +1550,10 @@ dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "parity-scale-codec",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "rand 0.8.5",
  "sc-client-api",
  "sc-consensus",
@@ -1575,7 +1575,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "parking_lot 0.12.1",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sc-client-api",
  "sc-consensus",
  "sc-service",
@@ -1600,7 +1600,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -1618,7 +1618,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "polkadot-parachain",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "scale-info",
  "sp-core",
  "sp-externalities",
@@ -1655,7 +1655,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -1673,8 +1673,8 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -1683,9 +1683,9 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.32#6abd385ce49f7feb882218646410feb063404b77"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sp-api",
  "sp-runtime",
  "sp-std",
@@ -1739,9 +1739,9 @@ dependencies = [
  "parity-scale-codec",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-builder",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -1755,7 +1755,7 @@ dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "polkadot-cli",
- "polkadot-client",
+ "polkadot-client 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "polkadot-service",
  "sc-cli",
  "sc-client-api",
@@ -1779,7 +1779,7 @@ dependencies = [
  "futures 0.3.25",
  "jsonrpsee-core",
  "parity-scale-codec",
- "polkadot-overseer",
+ "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "polkadot-service",
  "sc-client-api",
  "sp-api",
@@ -1823,7 +1823,7 @@ source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.32#6abd
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
@@ -3665,7 +3665,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex-literal",
- "kusama-runtime-constants",
+ "kusama-runtime-constants 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -3712,12 +3712,12 @@ dependencies = [
  "pallet-utility",
  "pallet-vesting",
  "pallet-whitelist",
- "pallet-xcm",
- "pallet-xcm-benchmarks",
+ "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -3742,9 +3742,107 @@ dependencies = [
  "sp-version",
  "static_assertions",
  "substrate-wasm-builder",
- "xcm",
- "xcm-builder",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "kusama-runtime"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "beefy-primitives",
+ "bitvec",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "hex-literal",
+ "kusama-runtime-constants 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "log",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-bags-list",
+ "pallet-balances",
+ "pallet-bounties",
+ "pallet-child-bounties",
+ "pallet-collective",
+ "pallet-conviction-voting",
+ "pallet-democracy",
+ "pallet-election-provider-multi-phase",
+ "pallet-election-provider-support-benchmarking",
+ "pallet-elections-phragmen",
+ "pallet-fast-unstake",
+ "pallet-gilt",
+ "pallet-grandpa",
+ "pallet-identity",
+ "pallet-im-online",
+ "pallet-indices",
+ "pallet-membership",
+ "pallet-multisig",
+ "pallet-nomination-pools",
+ "pallet-nomination-pools-benchmarking",
+ "pallet-nomination-pools-runtime-api",
+ "pallet-offences",
+ "pallet-offences-benchmarking",
+ "pallet-preimage",
+ "pallet-proxy",
+ "pallet-ranked-collective",
+ "pallet-recovery",
+ "pallet-referenda",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-session-benchmarking",
+ "pallet-society",
+ "pallet-staking",
+ "pallet-staking-reward-fn",
+ "pallet-timestamp",
+ "pallet-tips",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
+ "pallet-utility",
+ "pallet-vesting",
+ "pallet-whitelist",
+ "pallet-xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-authority-discovery",
+ "sp-block-builder",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-mmr-primitives",
+ "sp-npos-elections",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
+ "static_assertions",
+ "substrate-wasm-builder",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-builder 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -3753,8 +3851,22 @@ version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "smallvec",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
+]
+
+[[package]]
+name = "kusama-runtime-constants"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "frame-support",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -4577,7 +4689,7 @@ source = "git+https://github.com/zeitgeistpm/external#fc957f4629c4a4ee650d912e5d
 dependencies = [
  "nimbus-primitives",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "session-keys-primitives",
  "sp-api",
  "sp-application-crypto",
@@ -4797,7 +4909,7 @@ dependencies = [
  "nimbus-primitives",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-client",
+ "polkadot-client 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-manual-seal",
@@ -5069,15 +5181,15 @@ dependencies = [
  "frame-support",
  "frame-system",
  "orml-traits",
- "pallet-xcm",
+ "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-builder",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -5147,7 +5259,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -5162,7 +5274,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-std",
- "xcm",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -5189,8 +5301,8 @@ dependencies = [
  "parity-scale-codec",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -5203,15 +5315,15 @@ dependencies = [
  "frame-system",
  "orml-traits",
  "orml-xcm-support",
- "pallet-xcm",
+ "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -6288,8 +6400,26 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "pallet-xcm"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -6305,8 +6435,25 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "pallet-xcm-benchmarks"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -6629,74 +6776,74 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "rand 0.8.5",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-network-protocol",
- "polkadot-node-subsystem",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "rand 0.8.5",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "derive_more",
  "fatality",
  "futures 0.3.25",
  "lru 0.8.1",
  "parity-scale-codec",
- "polkadot-erasure-coding",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "rand 0.8.5",
  "sp-core",
  "sp-keystore",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "fatality",
  "futures 0.3.25",
  "lru 0.8.1",
  "parity-scale-codec",
- "polkadot-erasure-coding",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "rand 0.8.5",
  "sc-network",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -6708,9 +6855,9 @@ dependencies = [
  "frame-benchmarking-cli",
  "futures 0.3.25",
  "log",
- "polkadot-client",
- "polkadot-node-core-pvf",
- "polkadot-node-metrics",
+ "polkadot-client 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-core-pvf 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-metrics 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "polkadot-performance-test",
  "polkadot-service",
  "sc-cli",
@@ -6737,11 +6884,51 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
- "polkadot-core-primitives",
- "polkadot-node-core-parachains-inherent",
- "polkadot-primitives",
- "polkadot-runtime",
- "polkadot-runtime-common",
+ "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-core-parachains-inherent 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-executor",
+ "sc-service",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-finality-grandpa",
+ "sp-inherents",
+ "sp-keyring",
+ "sp-mmr-primitives",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-storage",
+ "sp-timestamp",
+ "sp-transaction-pool",
+]
+
+[[package]]
+name = "polkadot-client"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "beefy-primitives",
+ "frame-benchmarking",
+ "frame-benchmarking-cli",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "polkadot-core-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-core-parachains-inherent 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-client-api",
  "sc-consensus",
  "sc-executor",
@@ -6768,23 +6955,23 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "always-assert",
  "bitvec",
  "fatality",
  "futures 0.3.25",
  "futures-timer",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-core",
  "sp-keystore",
  "sp-runtime",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -6801,9 +6988,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-core-primitives"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "derive_more",
  "fatality",
@@ -6812,17 +7012,17 @@ dependencies = [
  "indexmap",
  "lru 0.8.1",
  "parity-scale-codec",
- "polkadot-erasure-coding",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-network",
  "sp-application-crypto",
  "sp-keystore",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -6831,8 +7031,22 @@ version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
 dependencies = [
  "parity-scale-codec",
- "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "reed-solomon-novelpoly",
+ "sp-core",
+ "sp-trie",
+ "thiserror",
+]
+
+[[package]]
+name = "polkadot-erasure-coding"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "parity-scale-codec",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "reed-solomon-novelpoly",
  "sp-core",
  "sp-trie",
@@ -6842,27 +7056,27 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
  "futures-timer",
- "polkadot-node-network-protocol",
- "polkadot-node-subsystem",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sc-network",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -6871,40 +7085,40 @@ dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-network-protocol",
- "polkadot-node-subsystem",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-network",
  "sc-network-common",
  "sp-consensus",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
- "polkadot-erasure-coding",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-core",
  "sp-maybe-compressed-blob",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -6914,12 +7128,12 @@ dependencies = [
  "lru 0.8.1",
  "merlin",
  "parity-scale-codec",
- "polkadot-node-jaeger",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-keystore",
  "schnorrkel",
  "sp-application-crypto",
@@ -6927,130 +7141,130 @@ dependencies = [
  "sp-consensus-slots",
  "sp-runtime",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "bitvec",
  "futures 0.3.25",
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
- "polkadot-erasure-coding",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "bitvec",
  "fatality",
  "futures 0.3.25",
- "polkadot-erasure-coding",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
- "polkadot-statement-table",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-statement-table 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-keystore",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-subsystem",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-keystore",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "wasm-timer",
 ]
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
  "parity-scale-codec",
- "polkadot-node-core-pvf",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-node-core-pvf 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-maybe-compressed-blob",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-subsystem",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-client-api",
  "sc-consensus-babe",
  "sp-blockchain",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "fatality",
  "futures 0.3.25",
  "kvdb",
  "lru 0.8.1",
  "parity-scale-codec",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-keystore",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7061,31 +7275,48 @@ dependencies = [
  "async-trait",
  "futures 0.3.25",
  "futures-timer",
- "polkadot-node-subsystem",
- "polkadot-primitives",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sp-blockchain",
  "sp-inherents",
  "sp-runtime",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "polkadot-node-core-parachains-inherent"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "async-trait",
+ "futures 0.3.25",
+ "futures-timer",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "sp-blockchain",
+ "sp-inherents",
+ "sp-runtime",
+ "thiserror",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "bitvec",
  "fatality",
  "futures 0.3.25",
  "futures-timer",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "rand 0.8.5",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7101,9 +7332,9 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives",
- "polkadot-node-metrics",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-metrics 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "rand 0.8.5",
  "rayon",
  "sc-executor",
@@ -7117,39 +7348,71 @@ dependencies = [
  "sp-tracing",
  "sp-wasm-interface",
  "tempfile",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "polkadot-node-core-pvf"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "always-assert",
+ "assert_matches",
+ "async-process",
+ "async-std",
+ "futures 0.3.25",
+ "futures-timer",
+ "parity-scale-codec",
+ "pin-project",
+ "polkadot-core-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-metrics 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "rand 0.8.5",
+ "rayon",
+ "sc-executor",
+ "sc-executor-common",
+ "sc-executor-wasmtime",
+ "slotmap",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "sp-wasm-interface",
+ "tempfile",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-keystore",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
  "memory-lru",
  "parity-util-mem",
- "polkadot-node-subsystem",
- "polkadot-node-subsystem-types",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-consensus-babe",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7163,8 +7426,26 @@ dependencies = [
  "mick-jaeger",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "sc-network",
+ "sp-core",
+ "thiserror",
+]
+
+[[package]]
+name = "polkadot-node-jaeger"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "async-std",
+ "lazy_static",
+ "log",
+ "mick-jaeger",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-network",
  "sp-core",
  "thiserror",
@@ -7180,13 +7461,32 @@ dependencies = [
  "futures-timer",
  "log",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "prioritized-metered-channel",
  "sc-cli",
  "sc-service",
  "sc-tracing",
  "substrate-prometheus-endpoint",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "polkadot-node-metrics"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "bs58",
+ "futures 0.3.25",
+ "futures-timer",
+ "log",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "prioritized-metered-channel",
+ "sc-cli",
+ "sc-service",
+ "sc-tracing",
+ "substrate-prometheus-endpoint",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7200,16 +7500,39 @@ dependencies = [
  "futures 0.3.25",
  "hex",
  "parity-scale-codec",
- "polkadot-node-jaeger",
- "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
  "sc-network-common",
  "strum",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "polkadot-node-network-protocol"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "fatality",
+ "futures 0.3.25",
+ "hex",
+ "parity-scale-codec",
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "rand 0.8.5",
+ "sc-authority-discovery",
+ "sc-network",
+ "sc-network-common",
+ "strum",
+ "thiserror",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7220,8 +7543,30 @@ dependencies = [
  "bounded-vec",
  "futures 0.3.25",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "schnorrkel",
+ "serde",
+ "sp-application-crypto",
+ "sp-consensus-babe",
+ "sp-consensus-vrf",
+ "sp-core",
+ "sp-keystore",
+ "sp-maybe-compressed-blob",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
+name = "polkadot-node-primitives"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "bounded-vec",
+ "futures 0.3.25",
+ "parity-scale-codec",
+ "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "schnorrkel",
  "serde",
  "sp-application-crypto",
@@ -7239,9 +7584,19 @@ name = "polkadot-node-subsystem"
 version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
 dependencies = [
- "polkadot-node-jaeger",
- "polkadot-node-subsystem-types",
- "polkadot-overseer",
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "polkadot-node-subsystem"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7253,11 +7608,34 @@ dependencies = [
  "derive_more",
  "futures 0.3.25",
  "orchestra",
- "polkadot-node-jaeger",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-primitives",
- "polkadot-statement-table",
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-statement-table 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "sc-network",
+ "smallvec",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-consensus-babe",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
+name = "polkadot-node-subsystem-types"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "async-trait",
+ "derive_more",
+ "futures 0.3.25",
+ "orchestra",
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-statement-table 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-network",
  "smallvec",
  "sp-api",
@@ -7270,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7284,20 +7662,20 @@ dependencies = [
  "parity-util-mem",
  "parking_lot 0.11.2",
  "pin-project",
- "polkadot-node-jaeger",
- "polkadot-node-metrics",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
- "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-metrics 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "prioritized-metered-channel",
  "rand 0.8.5",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7312,15 +7690,38 @@ dependencies = [
  "orchestra",
  "parity-util-mem",
  "parking_lot 0.12.1",
- "polkadot-node-metrics",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem-types",
- "polkadot-primitives",
+ "polkadot-node-metrics 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sc-client-api",
  "sp-api",
  "sp-core",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "polkadot-overseer"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "async-trait",
+ "futures 0.3.25",
+ "futures-timer",
+ "lru 0.8.1",
+ "orchestra",
+ "parity-util-mem",
+ "parking_lot 0.12.1",
+ "polkadot-node-metrics 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "sc-client-api",
+ "sp-api",
+ "sp-core",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7332,7 +7733,24 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "parity-util-mem",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-parachain"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "derive_more",
+ "frame-support",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "polkadot-core-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "scale-info",
  "serde",
  "sp-core",
@@ -7346,11 +7764,11 @@ version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
 dependencies = [
  "env_logger 0.9.3",
- "kusama-runtime",
+ "kusama-runtime 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "log",
- "polkadot-erasure-coding",
- "polkadot-node-core-pvf",
- "polkadot-node-primitives",
+ "polkadot-erasure-coding 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-core-pvf 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "quote",
  "thiserror",
 ]
@@ -7365,8 +7783,38 @@ dependencies = [
  "hex-literal",
  "parity-scale-codec",
  "parity-util-mem",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-authority-discovery",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+ "sp-trie",
+ "sp-version",
+]
+
+[[package]]
+name = "polkadot-primitives"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "bitvec",
+ "frame-system",
+ "hex-literal",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "polkadot-core-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "scale-info",
  "serde",
  "sp-api",
@@ -7395,7 +7843,39 @@ dependencies = [
  "jsonrpsee",
  "pallet-mmr-rpc",
  "pallet-transaction-payment-rpc",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "sc-chain-spec",
+ "sc-client-api",
+ "sc-consensus-babe",
+ "sc-consensus-babe-rpc",
+ "sc-consensus-epochs",
+ "sc-finality-grandpa",
+ "sc-finality-grandpa-rpc",
+ "sc-rpc",
+ "sc-sync-state-rpc",
+ "sc-transaction-pool-api",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-keystore",
+ "sp-runtime",
+ "substrate-frame-rpc-system",
+ "substrate-state-trie-migration-rpc",
+]
+
+[[package]]
+name = "polkadot-rpc"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "beefy-gadget",
+ "beefy-gadget-rpc",
+ "jsonrpsee",
+ "pallet-mmr-rpc",
+ "pallet-transaction-payment-rpc",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
@@ -7472,12 +7952,12 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm",
+ "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-constants",
- "polkadot-runtime-parachains",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-constants 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -7501,9 +7981,98 @@ dependencies = [
  "sp-version",
  "static_assertions",
  "substrate-wasm-builder",
- "xcm",
- "xcm-builder",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "polkadot-runtime"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "beefy-primitives",
+ "bitvec",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "hex-literal",
+ "log",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-bags-list",
+ "pallet-balances",
+ "pallet-bounties",
+ "pallet-child-bounties",
+ "pallet-collective",
+ "pallet-democracy",
+ "pallet-election-provider-multi-phase",
+ "pallet-election-provider-support-benchmarking",
+ "pallet-elections-phragmen",
+ "pallet-fast-unstake",
+ "pallet-grandpa",
+ "pallet-identity",
+ "pallet-im-online",
+ "pallet-indices",
+ "pallet-membership",
+ "pallet-multisig",
+ "pallet-nomination-pools",
+ "pallet-nomination-pools-benchmarking",
+ "pallet-nomination-pools-runtime-api",
+ "pallet-offences",
+ "pallet-offences-benchmarking",
+ "pallet-preimage",
+ "pallet-proxy",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-session-benchmarking",
+ "pallet-staking",
+ "pallet-staking-reward-curve",
+ "pallet-timestamp",
+ "pallet-tips",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
+ "pallet-utility",
+ "pallet-vesting",
+ "pallet-xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-constants 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-block-builder",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-mmr-primitives",
+ "sp-npos-elections",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
+ "static_assertions",
+ "substrate-wasm-builder",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-builder 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7533,13 +8102,13 @@ dependencies = [
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-parachains",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "rustc-hex",
  "scale-info",
  "serde",
  "serde_derive",
- "slot-range-helper",
+ "slot-range-helper 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "sp-api",
  "sp-core",
  "sp-inherents",
@@ -7550,7 +8119,54 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "static_assertions",
- "xcm",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "polkadot-runtime-common"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "beefy-primitives",
+ "bitvec",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "libsecp256k1",
+ "log",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-bags-list",
+ "pallet-balances",
+ "pallet-beefy-mmr",
+ "pallet-election-provider-multi-phase",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-treasury",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "serde_derive",
+ "slot-range-helper 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "static_assertions",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7559,8 +8175,22 @@ version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "smallvec",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
+]
+
+[[package]]
+name = "polkadot-runtime-constants"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "frame-support",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -7574,7 +8204,19 @@ source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e
 dependencies = [
  "bs58",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "sp-std",
+ "sp-tracing",
+]
+
+[[package]]
+name = "polkadot-runtime-metrics"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "bs58",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-std",
  "sp-tracing",
 ]
@@ -7600,8 +8242,8 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-metrics",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-metrics 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rustc-hex",
@@ -7618,14 +8260,57 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "static_assertions",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "polkadot-runtime-parachains"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "bitflags",
+ "bitvec",
+ "derive_more",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-metrics 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "static_assertions",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "polkadot-service"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -7634,7 +8319,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.25",
  "hex-literal",
- "kusama-runtime",
+ "kusama-runtime 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "kvdb",
  "kvdb-rocksdb",
  "lru 0.8.1",
@@ -7647,7 +8332,7 @@ dependencies = [
  "polkadot-availability-bitfield-distribution",
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
- "polkadot-client",
+ "polkadot-client 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-collator-protocol",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
@@ -7661,24 +8346,24 @@ dependencies = [
  "polkadot-node-core-chain-api",
  "polkadot-node-core-chain-selection",
  "polkadot-node-core-dispute-coordinator",
- "polkadot-node-core-parachains-inherent",
+ "polkadot-node-core-parachains-inherent 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-core-provisioner",
  "polkadot-node-core-pvf-checker",
  "polkadot-node-core-runtime-api",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
- "polkadot-node-subsystem-types",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-overseer",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-rpc",
- "polkadot-runtime",
- "polkadot-runtime-constants",
- "polkadot-runtime-parachains",
+ "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-rpc 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-constants 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-statement-distribution",
- "rococo-runtime",
+ "rococo-runtime 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",
@@ -7722,29 +8407,29 @@ dependencies = [
  "sp-trie",
  "substrate-prometheus-endpoint",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "westend-runtime",
 ]
 
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
  "futures 0.3.25",
  "indexmap",
  "parity-scale-codec",
- "polkadot-node-network-protocol",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
+ "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-keystore",
  "sp-staking",
  "thiserror",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -7753,7 +8438,17 @@ version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
 dependencies = [
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "sp-core",
+]
+
+[[package]]
+name = "polkadot-statement-table"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "sp-core",
 ]
 
@@ -7785,12 +8480,12 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-vesting",
- "pallet-xcm",
+ "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -7813,9 +8508,9 @@ dependencies = [
  "sp-version",
  "substrate-wasm-builder",
  "test-runtime-constants",
- "xcm",
- "xcm-builder",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -7830,14 +8525,14 @@ dependencies = [
  "pallet-balances",
  "pallet-staking",
  "pallet-transaction-payment",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
- "polkadot-overseer",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-rpc",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-subsystem 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-rpc 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "polkadot-service",
  "polkadot-test-runtime",
  "rand 0.8.5",
@@ -7869,7 +8564,7 @@ dependencies = [
  "tempfile",
  "test-runtime-constants",
  "tokio",
- "tracing-gum",
+ "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -8514,14 +9209,14 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm",
- "pallet-xcm-benchmarks",
+ "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
- "rococo-runtime-constants",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "rococo-runtime-constants 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "scale-info",
  "serde",
  "serde_derive",
@@ -8543,9 +9238,93 @@ dependencies = [
  "sp-version",
  "static_assertions",
  "substrate-wasm-builder",
- "xcm",
- "xcm-builder",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "rococo-runtime"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "beefy-merkle-tree",
+ "beefy-primitives",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "hex-literal",
+ "log",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-beefy",
+ "pallet-beefy-mmr",
+ "pallet-bounties",
+ "pallet-child-bounties",
+ "pallet-collective",
+ "pallet-democracy",
+ "pallet-elections-phragmen",
+ "pallet-gilt",
+ "pallet-grandpa",
+ "pallet-identity",
+ "pallet-im-online",
+ "pallet-indices",
+ "pallet-membership",
+ "pallet-mmr",
+ "pallet-multisig",
+ "pallet-offences",
+ "pallet-preimage",
+ "pallet-proxy",
+ "pallet-recovery",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-society",
+ "pallet-staking",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "pallet-tips",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
+ "pallet-utility",
+ "pallet-vesting",
+ "pallet-xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "parity-scale-codec",
+ "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "rococo-runtime-constants 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "scale-info",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-block-builder",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-mmr-primitives",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
+ "static_assertions",
+ "substrate-wasm-builder",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-builder 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -8554,8 +9333,22 @@ version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "smallvec",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
+]
+
+[[package]]
+name = "rococo-runtime-constants"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "frame-support",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -10224,6 +11017,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "slot-range-helper"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "enumn",
+ "parity-scale-codec",
+ "paste",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "slotmap"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11420,8 +12225,8 @@ version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -11689,16 +12494,39 @@ name = "tracing-gum"
 version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
 dependencies = [
- "polkadot-node-jaeger",
- "polkadot-primitives",
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "tracing",
- "tracing-gum-proc-macro",
+ "tracing-gum-proc-macro 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "tracing-gum"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing",
+ "tracing-gum-proc-macro 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+dependencies = [
+ "expander 0.0.6",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-gum-proc-macro"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -12410,7 +13238,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -12462,13 +13290,13 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm",
- "pallet-xcm-benchmarks",
+ "pallet-xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -12492,19 +13320,19 @@ dependencies = [
  "sp-version",
  "substrate-wasm-builder",
  "westend-runtime-constants",
- "xcm",
- "xcm-builder",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-builder 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -12742,7 +13570,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "xcm-procedural",
+ "xcm-procedural 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "xcm"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "derivative",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "xcm-procedural 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -12755,14 +13597,34 @@ dependencies = [
  "log",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "scale-info",
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "xcm-builder"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
@@ -12781,14 +13643,14 @@ dependencies = [
  "parachain-info",
  "parity-scale-codec",
  "paste",
- "polkadot-primitives",
- "polkadot-runtime-parachains",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "quote",
  "sp-arithmetic",
  "sp-io",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -12806,13 +13668,42 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+]
+
+[[package]]
+name = "xcm-executor"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
 ]
 
 [[package]]
 name = "xcm-procedural"
 version = "0.9.32"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "xcm-procedural"
+version = "0.9.32"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -12867,8 +13758,8 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "polkadot-cli",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "polkadot-service",
  "polkadot-test-service",
  "sc-basic-authorship",
@@ -12993,13 +13884,13 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm",
+ "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "parachain-info",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-runtime",
- "polkadot-runtime-parachains",
+ "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "scale-info",
  "session-keys-primitives",
  "sp-api",
@@ -13018,10 +13909,10 @@ dependencies = [
  "substrate-fixed",
  "substrate-wasm-builder",
  "test-case",
- "xcm",
- "xcm-builder",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "xcm-emulator",
- "xcm-executor",
+ "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "zeitgeist-primitives",
  "zrml-authorized",
  "zrml-court",
@@ -13202,7 +14093,7 @@ dependencies = [
  "sp-runtime",
  "substrate-fixed",
  "test-case",
- "xcm",
+ "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
  "zeitgeist-primitives",
  "zrml-authorized",
  "zrml-court",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,13 +500,13 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "rococo-runtime 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
+ "rococo-runtime",
  "scale-info",
  "session-keys-primitives",
  "sp-api",
@@ -525,10 +525,10 @@ dependencies = [
  "substrate-fixed",
  "substrate-wasm-builder",
  "test-case",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-builder",
  "xcm-emulator",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor",
  "zeitgeist-primitives",
  "zrml-authorized",
  "zrml-court",
@@ -1462,10 +1462,10 @@ dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-overseer",
+ "polkadot-primitives",
  "sc-client-api",
  "sp-api",
  "sp-consensus",
@@ -1484,7 +1484,7 @@ dependencies = [
  "dyn-clone",
  "futures 0.3.25",
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
@@ -1528,9 +1528,9 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-primitives",
+ "polkadot-parachain",
+ "polkadot-primitives",
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
@@ -1550,10 +1550,10 @@ dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "parity-scale-codec",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-overseer",
+ "polkadot-primitives",
  "rand 0.8.5",
  "sc-client-api",
  "sc-consensus",
@@ -1575,7 +1575,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "parking_lot 0.12.1",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
  "sc-service",
@@ -1600,7 +1600,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
 ]
 
 [[package]]
@@ -1618,7 +1618,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain",
  "scale-info",
  "sp-core",
  "sp-externalities",
@@ -1655,7 +1655,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
 ]
 
 [[package]]
@@ -1673,8 +1673,8 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -1683,9 +1683,9 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.32#6abd385ce49f7feb882218646410feb063404b77"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
+ "polkadot-primitives",
  "sp-api",
  "sp-runtime",
  "sp-std",
@@ -1739,9 +1739,9 @@ dependencies = [
  "parity-scale-codec",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -1755,7 +1755,7 @@ dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "polkadot-cli",
- "polkadot-client 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-client",
  "polkadot-service",
  "sc-cli",
  "sc-client-api",
@@ -1779,7 +1779,7 @@ dependencies = [
  "futures 0.3.25",
  "jsonrpsee-core",
  "parity-scale-codec",
- "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-overseer",
  "polkadot-service",
  "sc-client-api",
  "sp-api",
@@ -1823,7 +1823,7 @@ source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.32#6abd
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives",
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
@@ -3652,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -3665,7 +3665,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex-literal",
- "kusama-runtime-constants 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "kusama-runtime-constants",
  "log",
  "pallet-authority-discovery",
  "pallet-authorship",
@@ -3712,12 +3712,12 @@ dependencies = [
  "pallet-utility",
  "pallet-vesting",
  "pallet-whitelist",
- "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "pallet-xcm",
+ "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -3742,121 +3742,9 @@ dependencies = [
  "sp-version",
  "static_assertions",
  "substrate-wasm-builder",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
-]
-
-[[package]]
-name = "kusama-runtime"
-version = "0.9.32"
-source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
-dependencies = [
- "beefy-primitives",
- "bitvec",
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
- "hex-literal",
- "kusama-runtime-constants 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "log",
- "pallet-authority-discovery",
- "pallet-authorship",
- "pallet-babe",
- "pallet-bags-list",
- "pallet-balances",
- "pallet-bounties",
- "pallet-child-bounties",
- "pallet-collective",
- "pallet-conviction-voting",
- "pallet-democracy",
- "pallet-election-provider-multi-phase",
- "pallet-election-provider-support-benchmarking",
- "pallet-elections-phragmen",
- "pallet-fast-unstake",
- "pallet-gilt",
- "pallet-grandpa",
- "pallet-identity",
- "pallet-im-online",
- "pallet-indices",
- "pallet-membership",
- "pallet-multisig",
- "pallet-nomination-pools",
- "pallet-nomination-pools-benchmarking",
- "pallet-nomination-pools-runtime-api",
- "pallet-offences",
- "pallet-offences-benchmarking",
- "pallet-preimage",
- "pallet-proxy",
- "pallet-ranked-collective",
- "pallet-recovery",
- "pallet-referenda",
- "pallet-scheduler",
- "pallet-session",
- "pallet-session-benchmarking",
- "pallet-society",
- "pallet-staking",
- "pallet-staking-reward-fn",
- "pallet-timestamp",
- "pallet-tips",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-treasury",
- "pallet-utility",
- "pallet-vesting",
- "pallet-whitelist",
- "pallet-xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "rustc-hex",
- "scale-info",
- "serde",
- "serde_derive",
- "smallvec",
- "sp-api",
- "sp-arithmetic",
- "sp-authority-discovery",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-mmr-primitives",
- "sp-npos-elections",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std",
- "sp-transaction-pool",
- "sp-version",
- "static_assertions",
- "substrate-wasm-builder",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-builder 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "kusama-runtime-constants"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "frame-support",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -3865,8 +3753,8 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "frame-support",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -4689,7 +4577,7 @@ source = "git+https://github.com/zeitgeistpm/external#fc957f4629c4a4ee650d912e5d
 dependencies = [
  "nimbus-primitives",
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives",
  "session-keys-primitives",
  "sp-api",
  "sp-application-crypto",
@@ -4909,7 +4797,7 @@ dependencies = [
  "nimbus-primitives",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-client 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-client",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-manual-seal",
@@ -5181,15 +5069,15 @@ dependencies = [
  "frame-support",
  "frame-system",
  "orml-traits",
- "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "pallet-xcm",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -5259,7 +5147,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
 ]
 
 [[package]]
@@ -5274,7 +5162,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
 ]
 
 [[package]]
@@ -5301,8 +5189,8 @@ dependencies = [
  "parity-scale-codec",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -5315,15 +5203,15 @@ dependencies = [
  "frame-system",
  "orml-traits",
  "orml-xcm-support",
- "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "pallet-xcm",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -6389,24 +6277,6 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime",
- "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
-]
-
-[[package]]
-name = "pallet-xcm"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "frame-support",
@@ -6418,25 +6288,8 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "pallet-xcm-benchmarks"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -6452,8 +6305,8 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -6779,13 +6632,13 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "rand 0.8.5",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -6794,12 +6647,12 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "rand 0.8.5",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -6812,17 +6665,17 @@ dependencies = [
  "futures 0.3.25",
  "lru 0.8.1",
  "parity-scale-codec",
- "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-erasure-coding",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "rand 0.8.5",
  "sp-core",
  "sp-keystore",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -6834,30 +6687,30 @@ dependencies = [
  "futures 0.3.25",
  "lru 0.8.1",
  "parity-scale-codec",
- "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-erasure-coding",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "rand 0.8.5",
  "sc-network",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-cli"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
  "futures 0.3.25",
  "log",
- "polkadot-client 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-core-pvf 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-metrics 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-client",
+ "polkadot-node-core-pvf",
+ "polkadot-node-metrics",
  "polkadot-performance-test",
  "polkadot-service",
  "sc-cli",
@@ -6875,46 +6728,6 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "beefy-primitives",
- "frame-benchmarking",
- "frame-benchmarking-cli",
- "frame-system",
- "frame-system-rpc-runtime-api",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-core-parachains-inherent 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "sc-client-api",
- "sc-consensus",
- "sc-executor",
- "sc-service",
- "sp-api",
- "sp-authority-discovery",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-babe",
- "sp-core",
- "sp-finality-grandpa",
- "sp-inherents",
- "sp-keyring",
- "sp-mmr-primitives",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-storage",
- "sp-timestamp",
- "sp-transaction-pool",
-]
-
-[[package]]
-name = "polkadot-client"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "beefy-primitives",
@@ -6924,11 +6737,11 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
- "polkadot-core-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-core-parachains-inherent 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-core-primitives",
+ "polkadot-node-core-parachains-inherent",
+ "polkadot-primitives",
+ "polkadot-runtime",
+ "polkadot-runtime-common",
  "sc-client-api",
  "sc-consensus",
  "sc-executor",
@@ -6962,29 +6775,16 @@ dependencies = [
  "fatality",
  "futures 0.3.25",
  "futures-timer",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sp-core",
  "sp-keystore",
  "sp-runtime",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-core-primitives"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "parity-scale-codec",
- "parity-util-mem",
- "scale-info",
- "sp-core",
- "sp-runtime",
- "sp-std",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7012,31 +6812,17 @@ dependencies = [
  "indexmap",
  "lru 0.8.1",
  "parity-scale-codec",
- "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-erasure-coding",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sc-network",
  "sp-application-crypto",
  "sp-keystore",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-erasure-coding"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "parity-scale-codec",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "reed-solomon-novelpoly",
- "sp-core",
- "sp-trie",
- "thiserror",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7045,8 +6831,8 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "parity-scale-codec",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives",
+ "polkadot-primitives",
  "reed-solomon-novelpoly",
  "sp-core",
  "sp-trie",
@@ -7060,17 +6846,17 @@ source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-
 dependencies = [
  "futures 0.3.25",
  "futures-timer",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sc-network",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7085,16 +6871,16 @@ dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-overseer",
+ "polkadot-primitives",
  "sc-network",
  "sc-network-common",
  "sp-consensus",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7104,15 +6890,15 @@ source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-
 dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
- "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-erasure-coding",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sp-core",
  "sp-maybe-compressed-blob",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7128,12 +6914,12 @@ dependencies = [
  "lru 0.8.1",
  "merlin",
  "parity-scale-codec",
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-jaeger",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-overseer",
+ "polkadot-primitives",
  "sc-keystore",
  "schnorrkel",
  "sp-application-crypto",
@@ -7141,7 +6927,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-runtime",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7154,14 +6940,14 @@ dependencies = [
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
- "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-erasure-coding",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-overseer",
+ "polkadot-primitives",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7172,15 +6958,15 @@ dependencies = [
  "bitvec",
  "fatality",
  "futures 0.3.25",
- "polkadot-erasure-coding 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-erasure-coding",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-statement-table 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
+ "polkadot-statement-table",
  "sp-keystore",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7189,12 +6975,12 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sp-keystore",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
  "wasm-timer",
 ]
 
@@ -7206,14 +6992,14 @@ dependencies = [
  "async-trait",
  "futures 0.3.25",
  "parity-scale-codec",
- "polkadot-node-core-pvf 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-core-pvf",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-parachain",
+ "polkadot-primitives",
  "sp-maybe-compressed-blob",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7222,13 +7008,13 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sc-client-api",
  "sc-consensus-babe",
  "sp-blockchain",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7240,12 +7026,12 @@ dependencies = [
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7258,30 +7044,13 @@ dependencies = [
  "kvdb",
  "lru 0.8.1",
  "parity-scale-codec",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sc-keystore",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-node-core-parachains-inherent"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "async-trait",
- "futures 0.3.25",
- "futures-timer",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "sp-blockchain",
- "sp-inherents",
- "sp-runtime",
- "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7292,13 +7061,13 @@ dependencies = [
  "async-trait",
  "futures 0.3.25",
  "futures-timer",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem",
+ "polkadot-primitives",
  "sp-blockchain",
  "sp-inherents",
  "sp-runtime",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7310,45 +7079,13 @@ dependencies = [
  "fatality",
  "futures 0.3.25",
  "futures-timer",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "rand 0.8.5",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-node-core-pvf"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "always-assert",
- "assert_matches",
- "async-process",
- "async-std",
- "futures 0.3.25",
- "futures-timer",
- "parity-scale-codec",
- "pin-project",
- "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-metrics 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "rand 0.8.5",
- "rayon",
- "sc-executor",
- "sc-executor-common",
- "sc-executor-wasmtime",
- "slotmap",
- "sp-core",
- "sp-externalities",
- "sp-io",
- "sp-maybe-compressed-blob",
- "sp-tracing",
- "sp-wasm-interface",
- "tempfile",
- "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7364,9 +7101,9 @@ dependencies = [
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-metrics 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-core-primitives",
+ "polkadot-node-metrics",
+ "polkadot-parachain",
  "rand 0.8.5",
  "rayon",
  "sc-executor",
@@ -7380,7 +7117,7 @@ dependencies = [
  "sp-tracing",
  "sp-wasm-interface",
  "tempfile",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7389,14 +7126,14 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "futures 0.3.25",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-overseer",
+ "polkadot-primitives",
  "sp-keystore",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7407,30 +7144,12 @@ dependencies = [
  "futures 0.3.25",
  "memory-lru",
  "parity-util-mem",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sp-consensus-babe",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-node-jaeger"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "async-std",
- "lazy_static",
- "log",
- "mick-jaeger",
- "parity-scale-codec",
- "parking_lot 0.12.1",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "sc-network",
- "sp-core",
- "thiserror",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7444,30 +7163,11 @@ dependencies = [
  "mick-jaeger",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-primitives",
+ "polkadot-primitives",
  "sc-network",
  "sp-core",
  "thiserror",
-]
-
-[[package]]
-name = "polkadot-node-metrics"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "bs58",
- "futures 0.3.25",
- "futures-timer",
- "log",
- "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "prioritized-metered-channel",
- "sc-cli",
- "sc-service",
- "sc-tracing",
- "substrate-prometheus-endpoint",
- "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -7480,36 +7180,13 @@ dependencies = [
  "futures-timer",
  "log",
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "prioritized-metered-channel",
  "sc-cli",
  "sc-service",
  "sc-tracing",
  "substrate-prometheus-endpoint",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-node-network-protocol"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "async-trait",
- "derive_more",
- "fatality",
- "futures 0.3.25",
- "hex",
- "parity-scale-codec",
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "rand 0.8.5",
- "sc-authority-discovery",
- "sc-network",
- "sc-network-common",
- "strum",
- "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7523,38 +7200,16 @@ dependencies = [
  "futures 0.3.25",
  "hex",
  "parity-scale-codec",
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-jaeger",
+ "polkadot-node-primitives",
+ "polkadot-primitives",
  "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
  "sc-network-common",
  "strum",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-node-primitives"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "bounded-vec",
- "futures 0.3.25",
- "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "schnorrkel",
- "serde",
- "sp-application-crypto",
- "sp-consensus-babe",
- "sp-consensus-vrf",
- "sp-core",
- "sp-keystore",
- "sp-maybe-compressed-blob",
- "thiserror",
- "zstd",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7565,8 +7220,8 @@ dependencies = [
  "bounded-vec",
  "futures 0.3.25",
  "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-parachain",
+ "polkadot-primitives",
  "schnorrkel",
  "serde",
  "sp-application-crypto",
@@ -7582,44 +7237,11 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
-]
-
-[[package]]
-name = "polkadot-node-subsystem"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-node-subsystem-types"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "async-trait",
- "derive_more",
- "futures 0.3.25",
- "orchestra",
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-statement-table 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "sc-network",
- "smallvec",
- "sp-api",
- "sp-authority-discovery",
- "sp-consensus-babe",
- "substrate-prometheus-endpoint",
- "thiserror",
+ "polkadot-node-jaeger",
+ "polkadot-node-subsystem-types",
+ "polkadot-overseer",
 ]
 
 [[package]]
@@ -7631,11 +7253,11 @@ dependencies = [
  "derive_more",
  "futures 0.3.25",
  "orchestra",
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-statement-table 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-jaeger",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-primitives",
+ "polkadot-statement-table",
  "sc-network",
  "smallvec",
  "sp-api",
@@ -7662,43 +7284,20 @@ dependencies = [
  "parity-util-mem",
  "parking_lot 0.11.2",
  "pin-project",
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-metrics 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-jaeger",
+ "polkadot-node-metrics",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-overseer",
+ "polkadot-primitives",
  "prioritized-metered-channel",
  "rand 0.8.5",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-overseer"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "async-trait",
- "futures 0.3.25",
- "futures-timer",
- "lru 0.8.1",
- "orchestra",
- "parity-util-mem",
- "parking_lot 0.12.1",
- "polkadot-node-metrics 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "sc-client-api",
- "sp-api",
- "sp-core",
- "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7713,32 +7312,15 @@ dependencies = [
  "orchestra",
  "parity-util-mem",
  "parking_lot 0.12.1",
- "polkadot-node-metrics 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-metrics",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem-types",
+ "polkadot-primitives",
  "sc-client-api",
  "sp-api",
  "sp-core",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-parachain"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "derive_more",
- "frame-support",
- "parity-scale-codec",
- "parity-util-mem",
- "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime",
- "sp-std",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -7750,7 +7332,7 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "parity-util-mem",
- "polkadot-core-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-core-primitives",
  "scale-info",
  "serde",
  "sp-core",
@@ -7761,14 +7343,14 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "env_logger 0.9.3",
- "kusama-runtime 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "kusama-runtime",
  "log",
- "polkadot-erasure-coding 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-core-pvf 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-erasure-coding",
+ "polkadot-node-core-pvf",
+ "polkadot-node-primitives",
  "quote",
  "thiserror",
 ]
@@ -7776,36 +7358,6 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "bitvec",
- "frame-system",
- "hex-literal",
- "parity-scale-codec",
- "parity-util-mem",
- "polkadot-core-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "scale-info",
- "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-authority-discovery",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-staking",
- "sp-std",
- "sp-trie",
- "sp-version",
-]
-
-[[package]]
-name = "polkadot-primitives"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "bitvec",
@@ -7813,8 +7365,8 @@ dependencies = [
  "hex-literal",
  "parity-scale-codec",
  "parity-util-mem",
- "polkadot-core-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
  "scale-info",
  "serde",
  "sp-api",
@@ -7836,38 +7388,6 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "beefy-gadget",
- "beefy-gadget-rpc",
- "jsonrpsee",
- "pallet-mmr-rpc",
- "pallet-transaction-payment-rpc",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "sc-chain-spec",
- "sc-client-api",
- "sc-consensus-babe",
- "sc-consensus-babe-rpc",
- "sc-consensus-epochs",
- "sc-finality-grandpa",
- "sc-finality-grandpa-rpc",
- "sc-rpc",
- "sc-sync-state-rpc",
- "sc-transaction-pool-api",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-babe",
- "sp-keystore",
- "sp-runtime",
- "substrate-frame-rpc-system",
- "substrate-state-trie-migration-rpc",
-]
-
-[[package]]
-name = "polkadot-rpc"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "beefy-gadget",
@@ -7875,7 +7395,7 @@ dependencies = [
  "jsonrpsee",
  "pallet-mmr-rpc",
  "pallet-transaction-payment-rpc",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
@@ -7895,95 +7415,6 @@ dependencies = [
  "sp-runtime",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
-]
-
-[[package]]
-name = "polkadot-runtime"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "beefy-primitives",
- "bitvec",
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "frame-try-runtime",
- "hex-literal",
- "log",
- "pallet-authority-discovery",
- "pallet-authorship",
- "pallet-babe",
- "pallet-bags-list",
- "pallet-balances",
- "pallet-bounties",
- "pallet-child-bounties",
- "pallet-collective",
- "pallet-democracy",
- "pallet-election-provider-multi-phase",
- "pallet-election-provider-support-benchmarking",
- "pallet-elections-phragmen",
- "pallet-fast-unstake",
- "pallet-grandpa",
- "pallet-identity",
- "pallet-im-online",
- "pallet-indices",
- "pallet-membership",
- "pallet-multisig",
- "pallet-nomination-pools",
- "pallet-nomination-pools-benchmarking",
- "pallet-nomination-pools-runtime-api",
- "pallet-offences",
- "pallet-offences-benchmarking",
- "pallet-preimage",
- "pallet-proxy",
- "pallet-scheduler",
- "pallet-session",
- "pallet-session-benchmarking",
- "pallet-staking",
- "pallet-staking-reward-curve",
- "pallet-timestamp",
- "pallet-tips",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-treasury",
- "pallet-utility",
- "pallet-vesting",
- "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-constants 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "rustc-hex",
- "scale-info",
- "serde",
- "serde_derive",
- "smallvec",
- "sp-api",
- "sp-authority-discovery",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-mmr-primitives",
- "sp-npos-elections",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std",
- "sp-transaction-pool",
- "sp-version",
- "static_assertions",
- "substrate-wasm-builder",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -8041,12 +7472,12 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "pallet-xcm",
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-constants 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-constants",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -8070,56 +7501,9 @@ dependencies = [
  "sp-version",
  "static_assertions",
  "substrate-wasm-builder",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-builder 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-runtime-common"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "beefy-primitives",
- "bitvec",
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "libsecp256k1",
- "log",
- "pallet-authorship",
- "pallet-babe",
- "pallet-bags-list",
- "pallet-balances",
- "pallet-beefy-mmr",
- "pallet-election-provider-multi-phase",
- "pallet-session",
- "pallet-staking",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-treasury",
- "pallet-vesting",
- "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "rustc-hex",
- "scale-info",
- "serde",
- "serde_derive",
- "slot-range-helper 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "sp-api",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-npos-elections",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std",
- "static_assertions",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -8149,13 +7533,13 @@ dependencies = [
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "scale-info",
  "serde",
  "serde_derive",
- "slot-range-helper 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "slot-range-helper",
  "sp-api",
  "sp-core",
  "sp-inherents",
@@ -8166,21 +7550,7 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "static_assertions",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-runtime-constants"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "frame-support",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
+ "xcm",
 ]
 
 [[package]]
@@ -8189,8 +7559,8 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "frame-support",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -8200,68 +7570,13 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "bs58",
- "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "sp-std",
- "sp-tracing",
-]
-
-[[package]]
-name = "polkadot-runtime-metrics"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "bs58",
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sp-std",
  "sp-tracing",
-]
-
-[[package]]
-name = "polkadot-runtime-parachains"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "bitflags",
- "bitvec",
- "derive_more",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-authority-discovery",
- "pallet-authorship",
- "pallet-babe",
- "pallet-balances",
- "pallet-session",
- "pallet-staking",
- "pallet-timestamp",
- "pallet-vesting",
- "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-metrics 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rustc-hex",
- "scale-info",
- "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std",
- "static_assertions",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
 ]
 
 [[package]]
@@ -8285,8 +7600,8 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-metrics 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
+ "polkadot-runtime-metrics",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rustc-hex",
@@ -8303,8 +7618,8 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "static_assertions",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -8319,7 +7634,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.25",
  "hex-literal",
- "kusama-runtime 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "kusama-runtime",
  "kvdb",
  "kvdb-rocksdb",
  "lru 0.8.1",
@@ -8332,7 +7647,7 @@ dependencies = [
  "polkadot-availability-bitfield-distribution",
  "polkadot-availability-distribution",
  "polkadot-availability-recovery",
- "polkadot-client 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-client",
  "polkadot-collator-protocol",
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
@@ -8346,24 +7661,24 @@ dependencies = [
  "polkadot-node-core-chain-api",
  "polkadot-node-core-chain-selection",
  "polkadot-node-core-dispute-coordinator",
- "polkadot-node-core-parachains-inherent 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-core-parachains-inherent",
  "polkadot-node-core-provisioner",
  "polkadot-node-core-pvf-checker",
  "polkadot-node-core-runtime-api",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem-types 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
- "polkadot-overseer 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-rpc 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-constants 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-overseer",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "polkadot-rpc",
+ "polkadot-runtime",
+ "polkadot-runtime-constants",
+ "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
- "rococo-runtime 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "rococo-runtime",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",
@@ -8407,7 +7722,7 @@ dependencies = [
  "sp-trie",
  "substrate-prometheus-endpoint",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "tracing-gum",
  "westend-runtime",
 ]
 
@@ -8421,25 +7736,15 @@ dependencies = [
  "futures 0.3.25",
  "indexmap",
  "parity-scale-codec",
- "polkadot-node-network-protocol 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-network-protocol",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sp-keystore",
  "sp-staking",
  "thiserror",
- "tracing-gum 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "polkadot-statement-table"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "sp-core",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -8448,14 +7753,14 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "parity-scale-codec",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
  "sp-core",
 ]
 
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -8480,12 +7785,12 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-vesting",
- "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "pallet-xcm",
  "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -8508,15 +7813,15 @@ dependencies = [
  "sp-version",
  "substrate-wasm-builder",
  "test-runtime-constants",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -8525,14 +7830,14 @@ dependencies = [
  "pallet-balances",
  "pallet-staking",
  "pallet-transaction-payment",
- "polkadot-node-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-node-subsystem 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-overseer 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-rpc 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-node-primitives",
+ "polkadot-node-subsystem",
+ "polkadot-overseer",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "polkadot-rpc",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "polkadot-service",
  "polkadot-test-runtime",
  "rand 0.8.5",
@@ -8564,7 +7869,7 @@ dependencies = [
  "tempfile",
  "test-runtime-constants",
  "tokio",
- "tracing-gum 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -9162,90 +8467,6 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "beefy-merkle-tree",
- "beefy-primitives",
- "frame-benchmarking",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "hex-literal",
- "log",
- "pallet-authority-discovery",
- "pallet-authorship",
- "pallet-babe",
- "pallet-balances",
- "pallet-beefy",
- "pallet-beefy-mmr",
- "pallet-bounties",
- "pallet-child-bounties",
- "pallet-collective",
- "pallet-democracy",
- "pallet-elections-phragmen",
- "pallet-gilt",
- "pallet-grandpa",
- "pallet-identity",
- "pallet-im-online",
- "pallet-indices",
- "pallet-membership",
- "pallet-mmr",
- "pallet-multisig",
- "pallet-offences",
- "pallet-preimage",
- "pallet-proxy",
- "pallet-recovery",
- "pallet-scheduler",
- "pallet-session",
- "pallet-society",
- "pallet-staking",
- "pallet-sudo",
- "pallet-timestamp",
- "pallet-tips",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-treasury",
- "pallet-utility",
- "pallet-vesting",
- "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "rococo-runtime-constants 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "scale-info",
- "serde",
- "serde_derive",
- "smallvec",
- "sp-api",
- "sp-authority-discovery",
- "sp-block-builder",
- "sp-consensus-babe",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-mmr-primitives",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std",
- "sp-transaction-pool",
- "sp-version",
- "static_assertions",
- "substrate-wasm-builder",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
-]
-
-[[package]]
-name = "rococo-runtime"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "beefy-merkle-tree",
@@ -9293,14 +8514,14 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "pallet-xcm",
+ "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "rococo-runtime-constants 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
+ "rococo-runtime-constants",
  "scale-info",
  "serde",
  "serde_derive",
@@ -9322,23 +8543,9 @@ dependencies = [
  "sp-version",
  "static_assertions",
  "substrate-wasm-builder",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-builder 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "rococo-runtime-constants"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "frame-support",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -9347,8 +8554,8 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "frame-support",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -11007,18 +10214,6 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "enumn",
- "parity-scale-codec",
- "paste",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "slot-range-helper"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "enumn",
@@ -12222,11 +11417,11 @@ dependencies = [
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
+source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "frame-support",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -12492,35 +11687,12 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "tracing",
- "tracing-gum-proc-macro 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
-]
-
-[[package]]
-name = "tracing-gum"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
- "polkadot-node-jaeger 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-node-jaeger",
+ "polkadot-primitives",
  "tracing",
- "tracing-gum-proc-macro 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "tracing-gum-proc-macro"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "expander 0.0.6",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "tracing-gum-proc-macro",
 ]
 
 [[package]]
@@ -13290,13 +12462,13 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "pallet-xcm-benchmarks 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "pallet-xcm",
+ "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -13320,9 +12492,9 @@ dependencies = [
  "sp-version",
  "substrate-wasm-builder",
  "westend-runtime-constants",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-builder 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -13331,8 +12503,8 @@ version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "frame-support",
- "polkadot-primitives 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "polkadot-runtime-common 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -13562,20 +12734,6 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "derivative",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "xcm-procedural 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
-]
-
-[[package]]
-name = "xcm"
-version = "0.9.32"
 source = "git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes#90e98fe87db4b62c7722e802549d2b3739b07017"
 dependencies = [
  "derivative",
@@ -13584,27 +12742,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "xcm-procedural 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "xcm-builder"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "pallet-transaction-payment",
- "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "scale-info",
- "sp-arithmetic",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-procedural",
 ]
 
 [[package]]
@@ -13617,14 +12755,14 @@ dependencies = [
  "log",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "polkadot-parachain",
  "scale-info",
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
- "xcm-executor 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -13643,32 +12781,14 @@ dependencies = [
  "parachain-info",
  "parity-scale-codec",
  "paste",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
  "quote",
  "sp-arithmetic",
  "sp-io",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
-]
-
-[[package]]
-name = "xcm-executor"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -13686,18 +12806,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm 0.9.32 (git+https://github.com/zeitgeistpm/polkadot.git?branch=v0.9.32-recent-bootnodes)",
-]
-
-[[package]]
-name = "xcm-procedural"
-version = "0.9.32"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.32#c71e872afed296d1825b15ea4b2a74750c1ba647"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn",
+ "xcm",
 ]
 
 [[package]]
@@ -13758,8 +12867,8 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "polkadot-cli",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain",
+ "polkadot-primitives",
  "polkadot-service",
  "polkadot-test-service",
  "sc-basic-authorship",
@@ -13884,13 +12993,13 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vesting",
- "pallet-xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",
- "polkadot-parachain 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-primitives 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "polkadot-runtime-parachains 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "polkadot-runtime",
+ "polkadot-runtime-parachains",
  "scale-info",
  "session-keys-primitives",
  "sp-api",
@@ -13909,10 +13018,10 @@ dependencies = [
  "substrate-fixed",
  "substrate-wasm-builder",
  "test-case",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
- "xcm-builder 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
+ "xcm-builder",
  "xcm-emulator",
- "xcm-executor 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm-executor",
  "zeitgeist-primitives",
  "zrml-authorized",
  "zrml-court",
@@ -14093,7 +13202,7 @@ dependencies = [
  "sp-runtime",
  "substrate-fixed",
  "test-case",
- "xcm 0.9.32 (git+https://github.com/paritytech/polkadot?branch=release-v0.9.32)",
+ "xcm",
  "zeitgeist-primitives",
  "zrml-authorized",
  "zrml-court",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,4 +114,20 @@ opt-level = 3
 panic = "unwind"
 
 [patch."https://github.com/paritytech/polkadot"]
+pallet-xcm = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-cli = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-client = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-core-primitives = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-node-primitives = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-node-subsystem = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-overseer = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-parachain = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-primitives = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-runtime = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-runtime-parachains = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
 polkadot-service = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+polkadot-test-service = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+rococo-runtime = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+xcm = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+xcm-builder = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }
+xcm-executor = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,3 +112,6 @@ lto = true
 opt-level = 3
 # Zeitgeist runtime requires unwinding.
 panic = "unwind"
+
+[patch."https://github.com/paritytech/polkadot"]
+polkadot-service = { git = "https://github.com/zeitgeistpm/polkadot.git", branch = "v0.9.32-recent-bootnodes" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -107,6 +107,7 @@ zeitgeist-primitives = { path = "../primitives" }
 zeitgeist-runtime = { path = "../runtime/zeitgeist", optional = true }
 zrml-liquidity-mining = { path = "../zrml/liquidity-mining" }
 zrml-swaps-rpc = { path = "../zrml/swaps/rpc" }
+
 [features]
 default = ["with-battery-station-runtime", "with-zeitgeist-runtime"]
 parachain = [


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
As Chris discovered, the Battery Station node does not connect to the Rococo relay chain. This is caused by the node using a Cumulus version which uses `polkadot-service` that contains deprecated bootnodes that are not active anymore.

This PR uses a patched `polkadot-service` crate that utilized the most recent Rococo bootnodes.

### What important points should reviewers know?
None.

### Is there something left for follow-up PRs?
- Next maintenance PRs have to check whether a patch is required again or not.

### What alternative implementations were considered?
None.

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->
- Patched crated: https://github.com/zeitgeistpm/polkadot/commit/90e98fe87db4b62c7722e802549d2b3739b07017
- Based on Parity PR: https://github.com/paritytech/polkadot/commit/b24be2796d253b32fe2948c3d092d6a3e5e8181d

### References
None.
