### PR TITLE
Don't panic on spec_version mismatch during try-runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ check-dummy:
 		try-runtime \
 		--execution=Native \
 		--chain=${TRYRUNTIME_CHAIN} \
+		--no-spec-check-panic \
 		on-runtime-upgrade \
 		live \
 		--uri=${TRYRUNTIME_URL}


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
When a tag is pushed, a workflow is executed that runs `try-runtime` against the mainnet. When a tag is pushed, the `spec_version` usually is already incremented. `try-runtime` checks the condition that the spec version is equal on the remote and local runtime (that is used for testing). Consequently, this check will always fail. An example can be inspected at https://github.com/zeitgeistpm/zeitgeist/actions/runs/5359669650/jobs/9723563958?pr=1033:
> Thread 'main' panicked at 'spec version mismatch (local 46 != remote 45). This could cause some issues.'

This PR reduces the severity of this failing check from "error" to "warning".

### What important points should reviewers know?
/ 

### Is there something left for follow-up PRs?
/ 

### What alternative implementations were considered?
/ 

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->
- https://github.com/zeitgeistpm/zeitgeist/pull/1033

### References
/ 
