### PR TITLE
Add prediction market and swaps proxies

### DIFF
--- a/primitives/src/proxy_type.rs
+++ b/primitives/src/proxy_type.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Forecasting Technologies LTD.
+// Copyright 2023 Forecasting Technologies LTD.
 // Copyright 2021-2022 Zeitgeist PM LLC.
 //
 // This file is part of Zeitgeist.

--- a/primitives/src/proxy_type.rs
+++ b/primitives/src/proxy_type.rs
@@ -1,3 +1,4 @@
+// Copyright 2022-2023 Forecasting Technologies LTD.
 // Copyright 2021-2022 Zeitgeist PM LLC.
 //
 // This file is part of Zeitgeist.

--- a/primitives/src/proxy_type.rs
+++ b/primitives/src/proxy_type.rs
@@ -37,11 +37,13 @@ pub enum ProxyType {
     CancelProxy,
     Governance,
     Staking,
-    CreateMarket,
+    CreateEditMarket,
     ReportOutcome,
+    Dispute,
     ProvideLiquidity,
     BuySellCompleteSets,
     Trading,
+    HandleAssets,
 }
 
 impl Default for ProxyType {

--- a/primitives/src/proxy_type.rs
+++ b/primitives/src/proxy_type.rs
@@ -36,6 +36,11 @@ pub enum ProxyType {
     CancelProxy,
     Governance,
     Staking,
+    CreateMarket,
+    ReportOutcome,
+    ProvideLiquidity,
+    BuySellCompleteSets,
+    Trading,
 }
 
 impl Default for ProxyType {

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -805,6 +805,34 @@ macro_rules! impl_config_traits {
                     ProxyType::Staking => matches!(c, RuntimeCall::ParachainStaking(..)),
                     #[cfg(not(feature = "parachain"))]
                     ProxyType::Staking => false,
+                    ProxyType::CreateMarket =>
+                        matches!(c,
+                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::create_market {..}) |
+                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::create_cpmm_market_and_deploy_assets {..})
+                        ),
+                    ProxyType::ReportOutcome =>
+                        matches!(c,
+                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::report {..})
+                        ),
+                    ProxyType::ProvideLiquidity =>
+                        matches!(c,
+                            RuntimeCall::Swaps(zrml_swaps::Call::pool_join {..}) |
+                            RuntimeCall::Swaps(zrml_swaps::Call::pool_join_with_exact_asset_amount {..}) |
+                            RuntimeCall::Swaps(zrml_swaps::Call::pool_join_with_exact_pool_amount {..}) |
+                            RuntimeCall::Swaps(zrml_swaps::Call::pool_exit {..}) |
+                            RuntimeCall::Swaps(zrml_swaps::Call::pool_exit_with_exact_asset_amount {..}) |
+                            RuntimeCall::Swaps(zrml_swaps::Call::pool_exit_with_exact_pool_amount {..})
+                        ),
+                    ProxyType::BuySellCompleteSets =>
+                        matches!(c,
+                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::buy_complete_set {..}) |
+                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::sell_complete_set {..})
+                        ),
+                    ProxyType::Trading =>
+                        matches!(c,
+                            RuntimeCall::Swaps(zrml_swaps::Call::swap_exact_amount_in {..}) |
+                            RuntimeCall::Swaps(zrml_swaps::Call::swap_exact_amount_out {..})
+                        ),
                 }
             }
 

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -805,34 +805,64 @@ macro_rules! impl_config_traits {
                     ProxyType::Staking => matches!(c, RuntimeCall::ParachainStaking(..)),
                     #[cfg(not(feature = "parachain"))]
                     ProxyType::Staking => false,
-                    ProxyType::CreateMarket =>
-                        matches!(c,
-                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::create_market {..}) |
-                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::create_cpmm_market_and_deploy_assets {..})
-                        ),
-                    ProxyType::ReportOutcome =>
-                        matches!(c,
-                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::report {..})
-                        ),
-                    ProxyType::ProvideLiquidity =>
-                        matches!(c,
-                            RuntimeCall::Swaps(zrml_swaps::Call::pool_join {..}) |
-                            RuntimeCall::Swaps(zrml_swaps::Call::pool_join_with_exact_asset_amount {..}) |
-                            RuntimeCall::Swaps(zrml_swaps::Call::pool_join_with_exact_pool_amount {..}) |
-                            RuntimeCall::Swaps(zrml_swaps::Call::pool_exit {..}) |
-                            RuntimeCall::Swaps(zrml_swaps::Call::pool_exit_with_exact_asset_amount {..}) |
-                            RuntimeCall::Swaps(zrml_swaps::Call::pool_exit_with_exact_pool_amount {..})
-                        ),
-                    ProxyType::BuySellCompleteSets =>
-                        matches!(c,
-                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::buy_complete_set {..}) |
-                            RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::sell_complete_set {..})
-                        ),
-                    ProxyType::Trading =>
-                        matches!(c,
-                            RuntimeCall::Swaps(zrml_swaps::Call::swap_exact_amount_in {..}) |
-                            RuntimeCall::Swaps(zrml_swaps::Call::swap_exact_amount_out {..})
-                        ),
+                    ProxyType::CreateEditMarket => matches!(
+                        c,
+                        RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::create_market { .. })
+                            | RuntimeCall::PredictionMarkets(
+                                zrml_prediction_markets::Call::edit_market { .. }
+                            )
+                    ),
+                    ProxyType::ReportOutcome => matches!(
+                        c,
+                        RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::report { .. })
+                    ),
+                    ProxyType::Dispute => matches!(
+                        c,
+                        RuntimeCall::PredictionMarkets(zrml_prediction_markets::Call::dispute { .. })
+                    ),
+                    ProxyType::ProvideLiquidity => matches!(
+                        c,
+                        RuntimeCall::Swaps(zrml_swaps::Call::pool_join { .. })
+                            | RuntimeCall::Swaps(zrml_swaps::Call::pool_exit { .. })
+                            | RuntimeCall::PredictionMarkets(
+                                zrml_prediction_markets::Call::deploy_swap_pool_for_market { .. }
+                            )
+                            | RuntimeCall::PredictionMarkets(
+                                zrml_prediction_markets::Call::deploy_swap_pool_and_additional_liquidity { .. }
+                            )
+                    ),
+                    ProxyType::BuySellCompleteSets => matches!(
+                        c,
+                        RuntimeCall::PredictionMarkets(
+                            zrml_prediction_markets::Call::buy_complete_set { .. }
+                        ) | RuntimeCall::PredictionMarkets(
+                            zrml_prediction_markets::Call::sell_complete_set { .. }
+                        )
+                    ),
+                    ProxyType::Trading => matches!(
+                        c,
+                        RuntimeCall::Swaps(zrml_swaps::Call::swap_exact_amount_in { .. })
+                            | RuntimeCall::Swaps(zrml_swaps::Call::swap_exact_amount_out { .. })
+                    ),
+                    ProxyType::HandleAssets => matches!(
+                        c,
+                        RuntimeCall::Swaps(zrml_swaps::Call::pool_join { .. })
+                            | RuntimeCall::Swaps(zrml_swaps::Call::pool_exit { .. })
+                            | RuntimeCall::Swaps(zrml_swaps::Call::swap_exact_amount_in { .. })
+                            | RuntimeCall::Swaps(zrml_swaps::Call::swap_exact_amount_out { .. })
+                            | RuntimeCall::PredictionMarkets(
+                                zrml_prediction_markets::Call::buy_complete_set { .. }
+                            )
+                            | RuntimeCall::PredictionMarkets(
+                                zrml_prediction_markets::Call::sell_complete_set { .. }
+                            )
+                            | RuntimeCall::PredictionMarkets(
+                                zrml_prediction_markets::Call::deploy_swap_pool_for_market { .. }
+                            )
+                            | RuntimeCall::PredictionMarkets(
+                                zrml_prediction_markets::Call::deploy_swap_pool_and_additional_liquidity { .. }
+                            )
+                    ),
                 }
             }
 

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -827,9 +827,6 @@ macro_rules! impl_config_traits {
                             | RuntimeCall::PredictionMarkets(
                                 zrml_prediction_markets::Call::deploy_swap_pool_for_market { .. }
                             )
-                            | RuntimeCall::PredictionMarkets(
-                                zrml_prediction_markets::Call::deploy_swap_pool_and_additional_liquidity { .. }
-                            )
                     ),
                     ProxyType::BuySellCompleteSets => matches!(
                         c,


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Fixes https://github.com/zeitgeistpm/zeitgeist/issues/970

It allows to delegate a call on behalf of an account to another account.

It adds enum variants of the ProxyType in order to use them for different calls of zrml_prediction_markets or zrml_swaps.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

