### PR TITLE
Adjust mergify status checks and label management

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,4 +27,11 @@ pull_request_rules:
     actions:
         comment:
           message: This pull request is now in conflicts. Could you fix it @{{author}}? 🙏
+        label:
+          add:
+            - s:revision-needed
+          remove:
+            - s:accepted
+            - s:in-progress
+            - s:review-needed
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,13 +1,18 @@
 pull_request_rules:
   - name: Auto merge
     conditions:
-      - base=main
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
-      - check-success=format
-      - check-success=tests
-      - check-success=fuzz
-      - check-success=benchmark
+      - check-success=Coverage / Coverage
+      - check-success=Rust / Format
+      - check-success=Rust / Copyright Notices
+      - check-success=Rust / Checks (clippy)
+      - check-success=Rust / Checks (parachain)
+      - check-success=Rust / Checks (standalone)
+      - check-success=Rust / Quick check benchmarks
+      - check-success=Rust / Test standalone build
+      - check-success=Rust / Test parachain build
+      - check-success=Rust / Fuzz
       - label=s:accepted
     actions:
       label:


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
- Completes the list of status checks required to pass before merging
- Fixes status check names required to pass before merging
- Removes the condition that merge checks are only executed when merging into `main`
- Mergify now removes invalid status labels when a conflict is detected and adds `s:revision-needed`

### What important points should reviewers know?

### Is there something left for follow-up PRs?
- Status labels and a non-conflict state machine should be always reflected in mergify
- Maybe the requirements for merging into branches should be update depending on the type of branch (i.e. main or release)

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References
- [Passing status checks not registered properly](https://github.com/zeitgeistpm/zeitgeist/runs/15037500885)
- [Propoer mergify status checks configuration](https://docs.mergify.com/conditions/#about-status-checks)
