### PR TITLE
Run workflows required for merges when label s:review-needed is set

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,9 @@
 name: Coverage
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
+    types: [ labeled ]
+  push:
     branches: [ main ]
 
 env:
@@ -12,6 +12,7 @@ env:
 jobs:
   coverage:
     name: Coverage
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,9 +1,9 @@
 name: Rust
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
+    types: [ labeled ]
+  push:
     branches: [ main ]
 
 env:
@@ -12,6 +12,7 @@ env:
 jobs:
   format:
     name: Format
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -32,6 +33,7 @@ jobs:
 
   copyright:
     name: Copyright Notices
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -52,6 +54,7 @@ jobs:
 
   checks:
     name: Checks
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed'))
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -75,6 +78,7 @@ jobs:
 
   benchmark:
     name: Quick check benchmarks
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -87,6 +91,7 @@ jobs:
 
   test_standalone:
     name: Test standalone build
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -117,6 +122,7 @@ jobs:
 
   test_parachain:
     name: Test parachain build
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -147,6 +153,7 @@ jobs:
 
   fuzz:
     name: Fuzz
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
It only executed the `Rust` and `Coverage` workflows when the label `s:review-needed` is set. This will save huge amounts of workflow execution time and cost.
This will require proper state label handling. Should a PR review demand changes, the state should be set to `s:revision-needed`. Before the changes are implemented, the state should be transitioned to `s:in-progress`. Only after the PR is ready for review again, the state `s:review-needed` should be set. This effectively executes the `Rust` and `Coverage` workflows again.

### What important points should reviewers know?
https://github.com/zeitgeistpm/zeitgeist/pull/1042 will change the mergify config in a way that also ensures that `s:revision-needed` is automatically set should the `Rust` or `Coverage` workflow not succeed.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

