### PR TITLE
Support all fractional places

### DIFF
--- a/runtime/battery-station/src/xcm_config/config.rs
+++ b/runtime/battery-station/src/xcm_config/config.rs
@@ -24,7 +24,7 @@ use crate::{
 
 use frame_support::{parameter_types, traits::Everything, WeakBoundedVec};
 use orml_asset_registry::{AssetRegistryTrader, FixedRateAssetRegistryTrader};
-use orml_traits::{location::AbsoluteReserveProvider, MultiCurrency};
+use orml_traits::{asset_registry::Inspect, location::AbsoluteReserveProvider, MultiCurrency};
 use orml_xcm_support::{
     DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset,
 };
@@ -156,6 +156,44 @@ parameter_types! {
         ).into(),
         native_per_second(),
     );
+}
+
+/// A generic warpper around implementations of the (xcm-executor) `TransactAsset` trait.
+///
+/// Aligns the fractional decimal places of every incoming token.
+/// Reconstructs the original number of fractional decimal places of every outgoing token.
+#[allow(clippy::type_complexity)]
+pub struct<AssetRegistry, TransactAssetDelegate> AlignedFractionalTransactAsset {
+    /// Number of fractional decimal places
+    frac_dec_places: u128,
+}
+
+impl<AssetRegistry: Inspect, TransactAssetDelegate: TransactAsset> TransactAsset for AlignedFractionalTransactAsset
+{
+	fn deposit_asset(asset: &MultiAsset, location: &MultiLocation, _context: &XcmContext) -> Result {
+        let decimals = AssetRegistry::metadata_by_location(location)
+            .ok_or_else(|| XcmError::FailedToTransactAsset(e.into()))?
+            .decimals
+
+        // TODO adjust places
+	}
+
+	fn withdraw_asset(
+		asset: &MultiAsset,
+		location: &MultiLocation,
+		_maybe_context: Option<&XcmContext>,
+	) -> result::Result<Assets, XcmError> {
+        // TODO adjust places
+	}
+
+	fn transfer_asset(
+		asset: &MultiAsset,
+		from: &MultiLocation,
+		to: &MultiLocation,
+		_context: &XcmContext,
+	) -> result::Result<Assets, XcmError> {
+        // TODO ???
+	}
 }
 
 /// Means for transacting assets on this chain.


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
It adjusts all foreign token representations to the base `BASE`, currently `10^10`. More description TBD once ready for review.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References
- [Proposal: Support for tokens with arbitrary fractional decimal places](https://hackmd.io/@lZVVinJVS6WI4IpRgmbsLA/Hyz0dJXFn)
