### PR TITLE
Use u32 asset id for foreign tx fee payment

### DIFF
--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -83,6 +83,12 @@ pub type BasicCurrencyAdapter<R, B> = orml_currencies::BasicCurrencyAdapter<R, B
 
 pub type CurrencyId = Asset<MarketId>;
 
+/// The asset id specifically used for pallet_assets_tx_payment for
+/// paying transaction fees in different assets.
+/// Since the polkadot extension and wallets can't handle custom asset ids other than just u32,
+/// we are using a u32 as on the asset-hubs here.
+pub type TxPaymentAssetId = u32;
+
 /// Index of a transaction in the chain.
 pub type Index = u64;
 

--- a/runtime/common/src/fees.rs
+++ b/runtime/common/src/fees.rs
@@ -67,7 +67,7 @@ macro_rules! impl_foreign_fees {
         use frame_support::{
             pallet_prelude::InvalidTransaction,
             traits::{
-                fungibles::CreditOf,
+                fungibles::{CreditOf, Inspect},
                 tokens::{
                     fungibles::Balanced, BalanceConversion, WithdrawConsequence, WithdrawReasons,
                 },
@@ -77,7 +77,7 @@ macro_rules! impl_foreign_fees {
         };
         use orml_traits::{
             arithmetic::{One, Zero},
-            asset_registry::Inspect,
+            asset_registry::Inspect as AssetRegistryInspect,
         };
         use pallet_asset_tx_payment::HandleCredit;
         use sp_runtime::traits::{Convert, DispatchInfoOf, PostDispatchInfoOf};
@@ -121,7 +121,7 @@ macro_rules! impl_foreign_fees {
         pub(crate) fn get_fee_factor(
             currency_id: CurrencyId,
         ) -> Result<Balance, TransactionValidityError> {
-            let metadata = <AssetRegistry as Inspect>::metadata(&asset_id).ok_or(
+            let metadata = <AssetRegistry as AssetRegistryInspect>::metadata(&currency_id).ok_or(
                 TransactionValidityError::Invalid(InvalidTransaction::Custom(
                     CustomTxError::NoAssetMetadata as u8,
                 )),

--- a/runtime/common/src/fees.rs
+++ b/runtime/common/src/fees.rs
@@ -79,17 +79,16 @@ macro_rules! impl_foreign_fees {
         use orml_traits::arithmetic::{One, Zero};
         use pallet_asset_tx_payment::HandleCredit;
         use sp_runtime::traits::{Convert, DispatchInfoOf, PostDispatchInfoOf};
+        use zeitgeist_primitives::types::TxPaymentAssetId;
         use zrml_swaps::check_arithm_rslt::CheckArithmRslt;
 
         #[repr(u8)]
         pub enum CustomTxError {
             FeeConversionArith = 0,
-            NoForeignAsset = 1,
+            NoForeignAssetsOnStandaloneChain = 1,
             NoAssetMetadata = 2,
             NoFeeFactor = 3,
-            InvalidAssetId = 4,
-            // Used Some(AssetId::Ztg) instead of None for real ZTG token of pallet_balances
-            TokensZtgUsedInsteadOfPalletBalances = 5,
+            NonForeignAssetPaid = 4,
         }
 
         // It does calculate foreign fees by extending transactions to include an optional
@@ -118,9 +117,9 @@ macro_rules! impl_foreign_fees {
 
         #[cfg(feature = "parachain")]
         pub(crate) fn get_fee_factor(
-            asset_id: CurrencyId,
+            currency_id: CurrencyId,
         ) -> Result<Balance, TransactionValidityError> {
-            let location = AssetConvert::convert(asset_id);
+            let location = AssetConvert::convert(currency_id);
             let metadata = location
                 .and_then(|loc| {
                     <AssetRegistry as orml_traits::asset_registry::Inspect>::metadata_by_location(
@@ -138,40 +137,22 @@ macro_rules! impl_foreign_fees {
         }
 
         pub struct TTCBalanceToAssetBalance;
-        impl BalanceConversion<Balance, CurrencyId, Balance> for TTCBalanceToAssetBalance {
+        impl BalanceConversion<Balance, TxPaymentAssetId, Balance> for TTCBalanceToAssetBalance {
             type Error = TransactionValidityError;
 
             fn to_asset_balance(
                 native_fee: Balance,
-                asset_id: CurrencyId,
+                asset_id: TxPaymentAssetId,
             ) -> Result<Balance, Self::Error> {
-                match asset_id {
-                    Asset::Ztg => {
-                        return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(
-                            CustomTxError::TokensZtgUsedInsteadOfPalletBalances as u8,
-                        )));
-                    }
-                    #[cfg(not(feature = "parachain"))]
-                    Asset::ForeignAsset(_) => {
-                        return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(
-                            CustomTxError::NoForeignAsset as u8,
-                        )));
-                    }
-                    #[cfg(feature = "parachain")]
-                    Asset::ForeignAsset(_) => {
-                        let fee_factor = get_fee_factor(asset_id)?;
-                        let converted_fee = calculate_fee(native_fee, fee_factor)?;
-                        Ok(converted_fee)
-                    }
-                    Asset::CategoricalOutcome(_, _)
-                    | Asset::ScalarOutcome(_, _)
-                    | Asset::CombinatorialOutcome
-                    | Asset::PoolShare(_) => {
-                        return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(
-                            CustomTxError::InvalidAssetId as u8,
-                        )));
-                    }
+                if !cfg!(feature = "parachain") {
+                    return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(
+                        CustomTxError::NoForeignAssetsOnStandaloneChain as u8,
+                    )));
                 }
+                let currency_id = Asset::ForeignAsset(asset_id);
+                let fee_factor = get_fee_factor(currency_id)?;
+                let converted_fee = calculate_fee(native_fee, fee_factor)?;
+                Ok(converted_fee)
             }
         }
 
@@ -180,6 +161,76 @@ macro_rules! impl_foreign_fees {
             fn handle_credit(final_fee: CreditOf<AccountId, Tokens>) {
                 // Handle the final fee and tip, e.g. by transferring to the treasury.
                 DealWithForeignFees::on_unbalanced(final_fee);
+            }
+        }
+
+        pub struct TokensTxCharger;
+        impl pallet_asset_tx_payment::OnChargeAssetTransaction<Runtime> for TokensTxCharger {
+            type AssetId = TxPaymentAssetId;
+            type Balance = Balance;
+            type LiquidityInfo = CreditOf<AccountId, Tokens>;
+
+            fn withdraw_fee(
+                who: &AccountId,
+                call: &RuntimeCall,
+                _dispatch_info: &DispatchInfoOf<RuntimeCall>,
+                asset_id: Self::AssetId,
+                native_fee: Self::Balance,
+                _tip: Self::Balance,
+            ) -> Result<Self::LiquidityInfo, TransactionValidityError> {
+                // We don't know the precision of the underlying asset. Because the converted fee could be
+                // less than one (e.g. 0.5) but gets rounded down by integer division we introduce a minimum
+                // fee.
+                let min_converted_fee =
+                    if native_fee.is_zero() { Zero::zero() } else { One::one() };
+                let converted_fee =
+                    TTCBalanceToAssetBalance::to_asset_balance(native_fee, asset_id)?
+                        .max(min_converted_fee);
+                let currency_id = Asset::ForeignAsset(asset_id);
+                let can_withdraw =
+                    <Tokens as Inspect<AccountId>>::can_withdraw(currency_id, who, converted_fee);
+                if can_withdraw != WithdrawConsequence::Success {
+                    return Err(InvalidTransaction::Payment.into());
+                }
+                <Tokens as Balanced<AccountId>>::withdraw(currency_id, who, converted_fee)
+                    .map_err(|_| TransactionValidityError::from(InvalidTransaction::Payment))
+            }
+
+            fn correct_and_deposit_fee(
+                who: &AccountId,
+                _dispatch_info: &DispatchInfoOf<RuntimeCall>,
+                _post_info: &PostDispatchInfoOf<RuntimeCall>,
+                corrected_native_fee: Self::Balance,
+                tip: Self::Balance,
+                paid: Self::LiquidityInfo,
+            ) -> Result<(), TransactionValidityError> {
+                let min_converted_fee =
+                    if corrected_native_fee.is_zero() { Zero::zero() } else { One::one() };
+                let asset_id = match paid.asset() {
+                    Asset::ForeignAsset(asset_id) => asset_id,
+                    _ => {
+                        return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(
+                            CustomTxError::NonForeignAssetPaid as u8,
+                        )));
+                    }
+                };
+                // Convert the corrected fee and tip into the asset used for payment.
+                let converted_fee =
+                    TTCBalanceToAssetBalance::to_asset_balance(corrected_native_fee, asset_id)?
+                        .max(min_converted_fee);
+                let converted_tip = TTCBalanceToAssetBalance::to_asset_balance(tip, asset_id)?;
+
+                // Calculate how much refund we should return.
+                let (final_fee, refund) = paid.split(converted_fee);
+                // Refund to the account that paid the fees. If this fails, the account might have dropped
+                // below the existential balance. In that case we don't refund anything.
+                let _ = <Tokens as Balanced<AccountId>>::resolve(who, refund);
+
+                // Handle the final fee and tip, e.g. by transferring to the treasury.
+                // Note: The `corrected_native_fee` already includes the `tip`.
+                TTCHandleCredit::handle_credit(final_fee);
+
+                Ok(())
             }
         }
     };
@@ -264,7 +315,8 @@ macro_rules! fee_tests {
                     location: Some(xcm::VersionedMultiLocation::V1(xcm::latest::MultiLocation::parent())),
                     additional: custom_metadata,
                 };
-                let dot = Asset::ForeignAsset(0);
+                let dot_asset_id = 0u32;
+                let dot = Asset::ForeignAsset(dot_asset_id);
 
                 assert_ok!(AssetRegistry::register_asset(RuntimeOrigin::root(), meta, Some(dot)));
 
@@ -281,7 +333,7 @@ macro_rules! fee_tests {
                     &Treasury::account_id(),
                     &mock_call,
                     &mock_dispatch_info,
-                    dot,
+                    dot_asset_id,
                     BASE / 2,
                     0,
                 ).unwrap().peek(), 71_560_260);
@@ -309,7 +361,8 @@ macro_rules! fee_tests {
                         location: Some(xcm::VersionedMultiLocation::V1(xcm::latest::MultiLocation::parent())),
                         additional: custom_metadata,
                     };
-                    let dot = Asset::ForeignAsset(0);
+                    let dot_asset_id = 0u32;
+                    let dot = Asset::ForeignAsset(dot_asset_id);
 
                     assert_ok!(AssetRegistry::register_asset(RuntimeOrigin::root(), meta.clone(), Some(dot)));
 
@@ -375,7 +428,8 @@ macro_rules! fee_tests {
                         location: Some(xcm::VersionedMultiLocation::V1(xcm::latest::MultiLocation::parent())),
                         additional: custom_metadata,
                     };
-                    let dot = Asset::ForeignAsset(0);
+                    let dot_asset_id = 0u32;
+                    let dot = Asset::ForeignAsset(dot_asset_id);
 
                     assert_ok!(AssetRegistry::register_asset(RuntimeOrigin::root(), meta, Some(dot)));
 

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -923,11 +923,6 @@ macro_rules! impl_config_traits {
             type WeightInfo = weights::pallet_timestamp::WeightInfo<Runtime>;
         }
 
-        pub type TokensTxCharger = pallet_asset_tx_payment::FungiblesAdapter<
-            TTCBalanceToAssetBalance,
-            TTCHandleCredit,
-        >;
-
         common_runtime::impl_foreign_fees!();
 
         impl pallet_asset_tx_payment::Config for Runtime {


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

This allows to integrate the front end extension and wallet properly. We use the advantage that the Polkadot asset hub relies on `u32` asset ids and we can therefore take this data structure too.

### What important points should reviewers know?

I couldn't just use the simple [FungiblesAdapter](https://github.com/paritytech/substrate/blob/eb80c4e3b81db9c0a2312dadcc20e007f9aa9c00/frame/transaction-payment/asset-tx-payment/src/payment.rs#L94-L174) anymore, because the asset id needed to be converted to `Asset::ForeignAsset(u32)` just before the `withdraw` call. Otherwise the `Tokens` wouldn't have known how to handle an asset id with just the `u32` type. 

Before that we used the custom Asset (CurrencyId), but since this does not properly integrate with the extension and wallet, we fall back on a mapping from `u32` to `Asset::ForeignAsset(u32)` internally. This also removes the requirement to define custom `signedExtensions` on the front end side, since we can use the `assetId` which is already in place for the wallets and Polkadot browser extension. 

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

Rewriting front end side code. We didn't really want to fork our own extensions and wallets..

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

