### PR TITLE
 Fix try-runtime makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,18 +22,26 @@ check-dummy:
 		--bin=zeitgeist \
 		--features=parachain,try-runtime \
 		try-runtime \
-		--execution=Native \
 		--chain=${TRYRUNTIME_CHAIN} \
-		--no-spec-check-panic \
+		--runtime=${RUNTIME_PATH} \
 		on-runtime-upgrade \
+		--checks=all \
 		live \
 		--uri=${TRYRUNTIME_URL}
 
 try-runtime-upgrade-battery-station:
-	@$(MAKE) TRYRUNTIME_CHAIN="battery_station_staging" TRYRUNTIME_URL="wss://bsr.zeitgeist.pm:443" -- --try-runtime
+	@$(MAKE) TRYRUNTIME_CHAIN="battery_station_staging" \
+		TRYRUNTIME_URL="wss://bsr.zeitgeist.pm:443" \
+		RUNTIME_PATH="./target/debug/wbuild/battery-station-runtime/battery_station_runtime.compact.compressed.wasm" \
+		-- \
+		--try-runtime
 
 try-runtime-upgrade-zeitgeist:
-	@$(MAKE) TRYRUNTIME_CHAIN="zeitgeist_staging" TRYRUNTIME_URL="wss://zeitgeist-rpc.dwellir.com:443" -- --try-runtime
+	@$(MAKE) TRYRUNTIME_CHAIN="zeitgeist_staging" \
+		TRYRUNTIME_URL="wss://zeitgeist-rpc.dwellir.com:443" \
+		RUNTIME_PATH="./target/debug/wbuild/zeitgeist-runtime/zeitgeist_runtime.compact.compressed.wasm" \
+		-- \
+		--try-runtime
 
 build:
 	SKIP_WASM_BUILD= cargo build


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
Adjust the try-runtime targets in the Makefile to properly invoke try-runtime.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

