### PR TITLE
Fix parachain-staking benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5033,7 +5033,7 @@ dependencies = [
 [[package]]
 name = "moonbeam-vrf"
 version = "0.1.0"
-source = "git+https://github.com/zeitgeistpm/moonbeam?branch=polkadot-v0.9.37-use-paritytech-dependencies#f869fd30031eb55f4a89ac261b36f639bd20473b"
+source = "git+https://github.com/zeitgeistpm/moonbeam?branch=polkadot-v0.9.37-use-paritytech-dependencies-bench-fix#4bfc6efcf614266927e92c1b64b0ef8a322426c6"
 dependencies = [
  "nimbus-primitives",
  "parity-scale-codec",
@@ -5774,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/zeitgeistpm/moonbeam?branch=polkadot-v0.9.37-use-paritytech-dependencies#f869fd30031eb55f4a89ac261b36f639bd20473b"
+source = "git+https://github.com/zeitgeistpm/moonbeam?branch=polkadot-v0.9.37-use-paritytech-dependencies-bench-fix#4bfc6efcf614266927e92c1b64b0ef8a322426c6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6380,7 +6380,7 @@ dependencies = [
 [[package]]
 name = "pallet-parachain-staking"
 version = "3.0.0"
-source = "git+https://github.com/zeitgeistpm/moonbeam?branch=polkadot-v0.9.37-use-paritytech-dependencies#f869fd30031eb55f4a89ac261b36f639bd20473b"
+source = "git+https://github.com/zeitgeistpm/moonbeam?branch=polkadot-v0.9.37-use-paritytech-dependencies-bench-fix#4bfc6efcf614266927e92c1b64b0ef8a322426c6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10712,7 +10712,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/zeitgeistpm/moonbeam?branch=polkadot-v0.9.37-use-paritytech-dependencies#f869fd30031eb55f4a89ac261b36f639bd20473b"
+source = "git+https://github.com/zeitgeistpm/moonbeam?branch=polkadot-v0.9.37-use-paritytech-dependencies-bench-fix#4bfc6efcf614266927e92c1b64b0ef8a322426c6"
 dependencies = [
  "async-trait",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,12 +92,12 @@ pallet-author-slot-filter = { git = "https://github.com/zeitgeistpm/nimbus", bra
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.37", default-features = false }
 
 # Moonbeam (client)
-moonbeam-vrf = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "polkadot-v0.9.37-use-paritytech-dependencies" }
+moonbeam-vrf = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "polkadot-v0.9.37-use-paritytech-dependencies-bench-fix" }
 
 # Moonbeam (wasm)
-pallet-author-mapping = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "polkadot-v0.9.37-use-paritytech-dependencies", default-features = false }
-pallet-parachain-staking = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "polkadot-v0.9.37-use-paritytech-dependencies", default-features = false }
-session-keys-primitives = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "polkadot-v0.9.37-use-paritytech-dependencies", default-features = false }
+pallet-author-mapping = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "polkadot-v0.9.37-use-paritytech-dependencies-bench-fix", default-features = false }
+pallet-parachain-staking = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "polkadot-v0.9.37-use-paritytech-dependencies-bench-fix", default-features = false }
+session-keys-primitives = { git = "https://github.com/zeitgeistpm/moonbeam", branch = "polkadot-v0.9.37-use-paritytech-dependencies-bench-fix", default-features = false }
 
 # ORML (wasm)
 orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.37", default-features = false }

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -93,7 +93,7 @@ pub fn dev_config() -> Result<BatteryStationChainSpec, String> {
                     nominations: vec![],
                     parachain_bond_reserve_percent: DefaultParachainBondReservePercent::get(),
                     parachain_id: crate::BATTERY_STATION_PARACHAIN_ID.into(),
-                    num_selected_candidates: 1,
+                    num_selected_candidates: 8,
                 },
                 #[cfg(not(feature = "parachain"))]
                 AdditionalChainSpec {


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
Two errors hindered the successful execution of the benchmarks within `pallet-parachain-staking`.
1. `MinSelectedCandiates = 8` for battery station runtime, which is used in `dev` parachain, is less than `num_selected_candidates` in `dev` parachain's `GenesisConfig`. However, the condition `num_selected_candidates >= MinSelectedCandidates` must be met.
2. https://github.com/moonbeam-foundation/moonbeam/pull/2227

This PR fixes 1. and updated dependencies from the Moonbeam branch that incorporates 2.
### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

