### PR TITLE
Fix fee tests

### DIFF
--- a/runtime/battery-station/src/integration_tests/xcm/tests/transfers.rs
+++ b/runtime/battery-station/src/integration_tests/xcm/tests/transfers.rs
@@ -35,7 +35,7 @@ use orml_traits::MultiCurrency;
 use xcm::latest::{Junction, Junction::*, Junctions::*, MultiLocation, NetworkId};
 use xcm_emulator::{Limited, TestExt};
 use zeitgeist_primitives::{
-    constants::BalanceFractionalDecimals,
+    constants::{BalanceFractionalDecimals, BASE},
     types::{CustomMetadata, XcmMetadata},
 };
 
@@ -86,9 +86,6 @@ fn transfer_ztg_to_sibling() {
 
         // Verify that BOB now has (amount transferred - fee)
         assert_eq!(current_balance, transfer_amount - ztg_fee());
-
-        // Sanity check for the actual amount BOB ends up with
-        assert_eq!(current_balance, 49_907_304_000);
 
         // Verify that fees (of foreign currency) have been put into treasury
         assert_eq!(
@@ -352,7 +349,7 @@ fn transfer_roc_to_relay_chain() {
     });
 
     RococoNet::execute_with(|| {
-        assert_eq!(rococo_runtime::Balances::free_balance(&BOB), 999_988_806_429);
+        assert_eq!(rococo_runtime::Balances::free_balance(&BOB), 999_988_690_728);
     });
 }
 
@@ -419,10 +416,7 @@ fn transfer_ztg_to_sibling_with_custom_fee() {
         let custom_fee = calc_fee(default_per_second(10) * 10);
 
         // Verify that BOB now has (amount transferred - fee)
-        assert_eq!(current_balance, transfer_amount - custom_fee);
-
-        // Sanity check for the actual amount BOB ends up with
-        assert_eq!(current_balance, 49_073_040_000);
+        assert_eq!(current_balance, transfer_amount - ztg_fee() * fee_factor / BASE);
 
         // Verify that fees (of foreign currency) have been put into treasury
         assert_eq!(
@@ -434,8 +428,8 @@ fn transfer_ztg_to_sibling_with_custom_fee() {
 
 #[test]
 fn test_total_fee() {
-    assert_eq!(ztg_fee(), 92_696_000);
-    assert_eq!(roc_fee(), 9_269_600_000);
+    assert_eq!(ztg_fee(), 80_824_000);
+    assert_eq!(roc_fee(), 8_082_400_000);
 }
 
 #[inline]

--- a/runtime/zeitgeist/src/integration_tests/xcm/tests/transfers.rs
+++ b/runtime/zeitgeist/src/integration_tests/xcm/tests/transfers.rs
@@ -35,7 +35,7 @@ use orml_traits::MultiCurrency;
 use xcm::latest::{Junction, Junction::*, Junctions::*, MultiLocation, NetworkId};
 use xcm_emulator::{Limited, TestExt};
 use zeitgeist_primitives::{
-    constants::BalanceFractionalDecimals,
+    constants::{bASE, BalanceFractionalDecimals},
     types::{CustomMetadata, XcmMetadata},
 };
 
@@ -86,9 +86,6 @@ fn transfer_ztg_to_sibling() {
 
         // Verify that BOB now has (amount transferred - fee)
         assert_eq!(current_balance, transfer_amount - ztg_fee());
-
-        // Sanity check for the actual amount BOB ends up with
-        assert_eq!(current_balance, 49_907_304_000);
 
         // Verify that fees (of foreign currency) have been put into treasury
         assert_eq!(
@@ -470,7 +467,7 @@ fn transfer_dot_to_relay_chain() {
     });
 
     PolkadotNet::execute_with(|| {
-        assert_eq!(polkadot_runtime::Balances::free_balance(&BOB), 19_573_469_824);
+        assert_eq!(polkadot_runtime::Balances::free_balance(&BOB), 19_578_565_860);
     });
 }
 
@@ -540,7 +537,7 @@ fn transfer_ztg_to_sibling_with_custom_fee() {
         assert_eq!(current_balance, transfer_amount - custom_fee);
 
         // Sanity check for the actual amount BOB ends up with
-        assert_eq!(current_balance, 49_073_040_000);
+        assert_eq!(current_balance, transfer_amount - ztg_fee() * fee_factor / BASE);
 
         // Verify that fees (of foreign currency) have been put into treasury
         assert_eq!(
@@ -552,8 +549,8 @@ fn transfer_ztg_to_sibling_with_custom_fee() {
 
 #[test]
 fn test_total_fee() {
-    assert_eq!(ztg_fee(), 92_696_000);
-    assert_eq!(dot_fee(), 92_696_000);
+    assert_eq!(ztg_fee(), 80_824_000);
+    assert_eq!(dot_fee(), 80_824_000);
 }
 
 #[inline]

--- a/runtime/zeitgeist/src/integration_tests/xcm/tests/transfers.rs
+++ b/runtime/zeitgeist/src/integration_tests/xcm/tests/transfers.rs
@@ -35,7 +35,7 @@ use orml_traits::MultiCurrency;
 use xcm::latest::{Junction, Junction::*, Junctions::*, MultiLocation, NetworkId};
 use xcm_emulator::{Limited, TestExt};
 use zeitgeist_primitives::{
-    constants::{BASE, BalanceFractionalDecimals},
+    constants::{BalanceFractionalDecimals, BASE},
     types::{CustomMetadata, XcmMetadata},
 };
 

--- a/runtime/zeitgeist/src/integration_tests/xcm/tests/transfers.rs
+++ b/runtime/zeitgeist/src/integration_tests/xcm/tests/transfers.rs
@@ -35,7 +35,7 @@ use orml_traits::MultiCurrency;
 use xcm::latest::{Junction, Junction::*, Junctions::*, MultiLocation, NetworkId};
 use xcm_emulator::{Limited, TestExt};
 use zeitgeist_primitives::{
-    constants::{bASE, BalanceFractionalDecimals},
+    constants::{BASE, BalanceFractionalDecimals},
     types::{CustomMetadata, XcmMetadata},
 };
 


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
- Adjusts the default fee per second in the xcm `transfers` tests, as those changed due to an updated `default_fee_per_second` (inherited from updated [`ExtrinsicBaseWeight`](https://github.com/paritytech/substrate/blob/5ea6d95309aaccfa399c5f72e5a14a4b7c6c4ca1/frame/support/src/weights/extrinsic_weights.rs#L54).
- Removes unnecessary checks.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

