### PR TITLE
Run checks when the "s:accepted" label is set

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,8 +14,8 @@ jobs:
     name: Coverage
     if: |
       github.event_name == 'pull_request' && 
-        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
-        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,11 @@ env:
 jobs:
   coverage:
     name: Coverage
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed') || github.event_name == 'push')
+    if: |
+      github.event_name == 'pull_request' && 
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,7 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
         contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -41,6 +42,7 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
         contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -65,6 +67,7 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
         contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         scripts: [
@@ -92,6 +95,7 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
         contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -108,6 +112,7 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
         contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -142,6 +147,7 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
         contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -176,6 +182,7 @@ jobs:
         (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
         contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,8 +14,8 @@ jobs:
     name: Format
     if: |
       github.event_name == 'pull_request' && 
-        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
-        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
     steps:
       - name: Checkout repository
@@ -38,8 +38,8 @@ jobs:
     name: Copyright Notices
     if: |
       github.event_name == 'pull_request' && 
-        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
-        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
     steps:
       - name: Checkout repository
@@ -62,8 +62,8 @@ jobs:
     name: Checks
     if: |
       github.event_name == 'pull_request' && 
-        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
-        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
     strategy:
       matrix:
@@ -89,8 +89,8 @@ jobs:
     name: Quick check benchmarks
     if: |
       github.event_name == 'pull_request' && 
-        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
-        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
     steps:
       - name: Checkout repository
@@ -105,8 +105,8 @@ jobs:
     name: Test standalone build
     if: |
       github.event_name == 'pull_request' && 
-        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
-        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
     steps:
       - name: Checkout repository
@@ -139,8 +139,8 @@ jobs:
     name: Test parachain build
     if: |
       github.event_name == 'pull_request' && 
-        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
-        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
     steps:
       - name: Checkout repository
@@ -173,8 +173,8 @@ jobs:
     name: Fuzz
     if: |
       github.event_name == 'pull_request' && 
-        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
-        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
       github.event_name == 'push'
     steps:
       - name: Checkout repository

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,8 +12,11 @@ env:
 jobs:
   format:
     name: Format
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed') || github.event_name == 'push')
-    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && 
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+      github.event_name == 'push'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -33,8 +36,11 @@ jobs:
 
   copyright:
     name: Copyright Notices
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed') || github.event_name == 'push')
-    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && 
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+      github.event_name == 'push'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -54,8 +60,11 @@ jobs:
 
   checks:
     name: Checks
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed') || github.event_name == 'push')
-    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && 
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+      github.event_name == 'push'
     strategy:
       matrix:
         scripts: [
@@ -78,8 +87,11 @@ jobs:
 
   benchmark:
     name: Quick check benchmarks
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed') || github.event_name == 'push')
-    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && 
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+      github.event_name == 'push'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -91,8 +103,11 @@ jobs:
 
   test_standalone:
     name: Test standalone build
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed') || github.event_name == 'push')
-    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && 
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+      github.event_name == 'push'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -122,8 +137,11 @@ jobs:
 
   test_parachain:
     name: Test parachain build
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed') || github.event_name == 'push')
-    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && 
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+      github.event_name == 'push'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -153,8 +171,11 @@ jobs:
 
   fuzz:
     name: Fuzz
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 's:review-needed') || github.event_name == 'push')
-    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && 
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed' ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted') ||
+      github.event_name == 'push'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
It ensures that workflows are run when the "s:accepted" label is set. This is required for Mergify to automatically merge PRs using the merge queue. Without the changes in this commit, when the label "s:accepted" is set, the checks are skipped and Mergify's merge conditions are not satisfied.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

