### PR TITLE
Add Substrate style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ mark the PR with the following labels according to
 
 ## Style Guide
 
-- Refer to the [style guide]
+- Refer to the [style guide].
 
 [rules]: #Rules
 [docs/changelog_for_devs.md]: docs/changelog_for_devs.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,22 +52,9 @@ mark the PR with the following labels according to
 
 ## Style Guide
 
-- Use `rustfmt` to format your contributions.
-- Avoid panickers like `unwrap()` even if there's proof that they are
-  infallible.
-- Dispatches that don't use `#[transactional]` macro **must** contain a comment
-  including `MARK(non-transactional): ...` followed by a short explanation why
-  the dispatch doesn't require `#[transactional]`.
-- Functions are written in snake case, i.e. `my_function`, anything else is
-  declared in CamelCase (starting with a capital first letter).
-- Indentations consist of spaces, unless the language used requires tabs.
-- Anything that is publicly visible must be documented. This encompasses but is
-  not limited to whole crates (top level documentation), public types and
-  functions, dispatachble functions (functions that can be called by
-  transactions), the `Error` and `Event` enum as well as the `Config` trait.
-- Any newly added or modified functionality must be subject to at least one test
-  case. A full code coverage is the targeted goal.
+- Refer to the [style guide]
 
 [rules]: #Rules
 [docs/changelog_for_devs.md]: docs/changelog_for_devs.md
+[style guide]: docs/STYLE_GUIDE.md
 [zeitgeistpm]: https://github.com/zeitgeistpm

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,5 +1,7 @@
 # Style guide
 
+As a basis, the [Substrate Style Guide](https://docs.substrate.io/build/troubleshoot-your-code/) should be taken into account. In addition to that, the following sections further elaborate the style guide used in this repository.
+
 ## Comments
 
 - Comments **must** be wrapped at 100 chars per line.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,6 +1,9 @@
 # Style guide
 
-As a basis, the [Substrate Style Guide](https://docs.substrate.io/build/troubleshoot-your-code/) should be taken into account. In addition to that, the following sections further elaborate the style guide used in this repository.
+As a basis, the
+[Substrate Style Guide](https://docs.substrate.io/build/troubleshoot-your-code/)
+should be taken into account. In addition to that, the following sections
+further elaborate the style guide used in this repository.
 
 ## Comments
 


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
Adds a reference to the Substrate style guide into the Zeitgeist style guide.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->
closes #1023

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

