### PR TITLE
Update versions to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "battery-station-runtime"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "cfg-if",
  "common-runtime",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "cfg-if",
  "cumulus-pallet-xcmp-queue",
@@ -14229,7 +14229,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-node"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "battery-station-runtime",
  "cfg-if",
@@ -14321,7 +14321,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-primitives"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "frame-support",
@@ -14340,7 +14340,7 @@ dependencies = [
 
 [[package]]
 name = "zeitgeist-runtime"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "cfg-if",
  "common-runtime",
@@ -14460,7 +14460,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-authorized"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14477,7 +14477,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-court"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "arrayvec 0.7.4",
  "frame-benchmarking",
@@ -14501,7 +14501,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-global-disputes"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14521,7 +14521,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-liquidity-mining"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14539,7 +14539,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-market-commons"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14555,7 +14555,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-orderbook-v1"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14584,7 +14584,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14636,7 +14636,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-prediction-markets-runtime-api"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -14645,7 +14645,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-rikiddo"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "cfg-if",
@@ -14678,7 +14678,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-simple-disputes"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14698,7 +14698,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-styx"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14714,7 +14714,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14757,7 +14757,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-rpc"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -14770,7 +14770,7 @@ dependencies = [
 
 [[package]]
 name = "zrml-swaps-runtime-api"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -187,7 +187,7 @@ description = "An evolving blockchain for prediction markets and futarchy."
 edition = "2021"
 homepage = "https://zeitgeist.pm"
 name = "zeitgeist-node"
-version = "0.3.11"
+version = "0.4.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -34,4 +34,4 @@ std = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zeitgeist-primitives"
-version = "0.3.11"
+version = "0.4.0"

--- a/runtime/battery-station/Cargo.toml
+++ b/runtime/battery-station/Cargo.toml
@@ -406,7 +406,7 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "battery-station-runtime"
-version = "0.3.11"
+version = "0.4.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/battery-station/src/lib.rs
+++ b/runtime/battery-station/src/lib.rs
@@ -105,10 +105,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("zeitgeist"),
     impl_name: create_runtime_str!("zeitgeist"),
     authoring_version: 1,
-    spec_version: 48,
+    spec_version: 49,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 23,
+    transaction_version: 24,
     state_version: 1,
 };
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -78,7 +78,7 @@ std = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "common-runtime"
-version = "0.3.11"
+version = "0.4.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/zeitgeist/Cargo.toml
+++ b/runtime/zeitgeist/Cargo.toml
@@ -394,7 +394,7 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zeitgeist-runtime"
-version = "0.3.11"
+version = "0.4.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -93,10 +93,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("zeitgeist"),
     impl_name: create_runtime_str!("zeitgeist"),
     authoring_version: 1,
-    spec_version: 48,
+    spec_version: 49,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 23,
+    transaction_version: 24,
     state_version: 1,
 };
 

--- a/zrml/authorized/Cargo.toml
+++ b/zrml/authorized/Cargo.toml
@@ -38,4 +38,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-authorized"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/court/Cargo.toml
+++ b/zrml/court/Cargo.toml
@@ -46,4 +46,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-court"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/global-disputes/Cargo.toml
+++ b/zrml/global-disputes/Cargo.toml
@@ -45,4 +45,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-global-disputes"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/liquidity-mining/Cargo.toml
+++ b/zrml/liquidity-mining/Cargo.toml
@@ -40,4 +40,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-liquidity-mining"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/market-commons/Cargo.toml
+++ b/zrml/market-commons/Cargo.toml
@@ -31,4 +31,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-market-commons"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/orderbook-v1/Cargo.toml
+++ b/zrml/orderbook-v1/Cargo.toml
@@ -47,4 +47,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-orderbook-v1"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/prediction-markets/Cargo.toml
+++ b/zrml/prediction-markets/Cargo.toml
@@ -95,4 +95,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-prediction-markets"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/prediction-markets/runtime-api/Cargo.toml
+++ b/zrml/prediction-markets/runtime-api/Cargo.toml
@@ -15,4 +15,4 @@ std = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-prediction-markets-runtime-api"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/rikiddo/Cargo.toml
+++ b/zrml/rikiddo/Cargo.toml
@@ -42,4 +42,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-rikiddo"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/simple-disputes/Cargo.toml
+++ b/zrml/simple-disputes/Cargo.toml
@@ -41,4 +41,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-simple-disputes"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/styx/Cargo.toml
+++ b/zrml/styx/Cargo.toml
@@ -36,4 +36,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-styx"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/swaps/Cargo.toml
+++ b/zrml/swaps/Cargo.toml
@@ -66,4 +66,4 @@ try-runtime = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-swaps"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/swaps/rpc/Cargo.toml
+++ b/zrml/swaps/rpc/Cargo.toml
@@ -11,4 +11,4 @@ zrml-swaps-runtime-api = { workspace = true, features = ["default"] }
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-swaps-rpc"
-version = "0.3.11"
+version = "0.4.0"

--- a/zrml/swaps/runtime-api/Cargo.toml
+++ b/zrml/swaps/runtime-api/Cargo.toml
@@ -18,4 +18,4 @@ std = [
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]
 edition = "2021"
 name = "zrml-swaps-runtime-api"
-version = "0.3.11"
+version = "0.4.0"


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
- Updates all Zeitgeist crate versions to v0.4.0
- Updates `RuntimeVersion` all runtimes:
 - `spec_version` = `48` -> `49`
 - `transaction_version` = `23` -> `24`

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References
