### PR TITLE
Use self-hosted runner for docker parachain build

### DIFF
--- a/.github/workflows/docker-hub-parachain.yml
+++ b/.github/workflows/docker-hub-parachain.yml
@@ -19,7 +19,7 @@ jobs:
   publish:
     needs: hadolint
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, runtime-benchmark]
     steps:
       - uses: actions/checkout@v3
       - name: Checkout repository


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
See title

### What important points should reviewers know?
- Run fails due to insufficient disk space https://github.com/zeitgeistpm/zeitgeist/actions/runs/6169452668
- In the near future, other self-hosted runners will be available

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

