### PR TITLE
Update weight templates to reflect weights-v2

### DIFF
--- a/misc/frame_weight_template.hbs
+++ b/misc/frame_weight_template.hbs
@@ -25,6 +25,9 @@ impl<T: frame_system::Config> {{pallet}}::weights::WeightInfo for WeightInfo<T> 
     {{#each benchmark.comments as |comment|}}
     /// {{comment}}
     {{/each}}
+    {{#each benchmark.component_ranges as |range|}}
+	/// The range of component `{{range.name}}` is `[{{range.min}}, {{range.max}}]`.
+	{{/each}}
     fn {{benchmark.name~}}
     (
         {{~#each benchmark.components as |c| ~}}
@@ -34,26 +37,25 @@ impl<T: frame_system::Config> {{pallet}}::weights::WeightInfo for WeightInfo<T> 
         //  Measured:  `{{benchmark.base_recorded_proof_size}}{{#each benchmark.component_recorded_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
         //  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
         // Minimum execution time: {{underscore benchmark.min_execution_time}} nanoseconds.
-        {{#if (ne benchmark.base_calculated_proof_size "0")}}
         Weight::from_parts({{underscore benchmark.base_weight}}, {{benchmark.base_calculated_proof_size}})
-        {{else}}
-        Weight::from_ref_time({{underscore benchmark.base_weight}})
-        {{/if}}
             {{#each benchmark.component_weight as |cw|}}
             // Standard Error: {{underscore cw.error}}
-            .saturating_add(Weight::from_ref_time({{underscore cw.slope}}).saturating_mul({{cw.name}}.into()))
+            .saturating_add(Weight::from_parts({{underscore cw.slope}}, 0).saturating_mul({{cw.name}}.into()))
             {{/each}}
             {{#if (ne benchmark.base_reads "0")}}
-            .saturating_add(T::DbWeight::get().reads({{benchmark.base_reads}}_u64))
+            .saturating_add(T::DbWeight::get().reads({{benchmark.base_reads}}))
             {{/if}}
             {{#each benchmark.component_reads as |cr|}}
             .saturating_add(T::DbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
             {{/each}}
             {{#if (ne benchmark.base_writes "0")}}
-            .saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}_u64))
+            .saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}))
             {{/if}}
+            {{#each benchmark.component_writes as |cw|}}
+			.saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+			{{/each}}
             {{#each benchmark.component_calculated_proof_size as |cp|}}
-			.saturating_add(Weight::from_proof_size({{cp.slope}}).saturating_mul({{cp.name}}.into()))
+			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
 			{{/each}}
     }
     {{/each}}

--- a/misc/frame_weight_template.hbs
+++ b/misc/frame_weight_template.hbs
@@ -26,8 +26,8 @@ impl<T: frame_system::Config> {{pallet}}::weights::WeightInfo for WeightInfo<T> 
     /// {{comment}}
     {{/each}}
     {{#each benchmark.component_ranges as |range|}}
-	/// The range of component `{{range.name}}` is `[{{range.min}}, {{range.max}}]`.
-	{{/each}}
+    /// The range of component `{{range.name}}` is `[{{range.min}}, {{range.max}}]`.
+    {{/each}}
     fn {{benchmark.name~}}
     (
         {{~#each benchmark.components as |c| ~}}
@@ -52,11 +52,11 @@ impl<T: frame_system::Config> {{pallet}}::weights::WeightInfo for WeightInfo<T> 
             .saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}))
             {{/if}}
             {{#each benchmark.component_writes as |cw|}}
-			.saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
-			{{/each}}
+            .saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+            {{/each}}
             {{#each benchmark.component_calculated_proof_size as |cp|}}
-			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
-			{{/each}}
+           .saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
+           {{/each}}
     }
     {{/each}}
 }

--- a/misc/orml_weight_template.hbs
+++ b/misc/orml_weight_template.hbs
@@ -34,26 +34,25 @@ impl<T: frame_system::Config> {{pallet}}::WeightInfo for WeightInfo<T> {
         //  Measured:  `{{benchmark.base_recorded_proof_size}}{{#each benchmark.component_recorded_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
         //  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
         // Minimum execution time: {{underscore benchmark.min_execution_time}} nanoseconds.
-        {{#if (ne benchmark.base_calculated_proof_size "0")}}
         Weight::from_parts({{underscore benchmark.base_weight}}, {{benchmark.base_calculated_proof_size}})
-        {{else}}
-        Weight::from_ref_time({{underscore benchmark.base_weight}})
-        {{/if}}
             {{#each benchmark.component_weight as |cw|}}
             // Standard Error: {{underscore cw.error}}
-            .saturating_add(Weight::from_ref_time({{underscore cw.slope}}).saturating_mul({{cw.name}}.into()))
+            .saturating_add(Weight::from_parts({{underscore cw.slope}}, 0).saturating_mul({{cw.name}}.into()))
             {{/each}}
             {{#if (ne benchmark.base_reads "0")}}
-            .saturating_add(T::DbWeight::get().reads({{benchmark.base_reads}}_u64))
+            .saturating_add(T::DbWeight::get().reads({{benchmark.base_reads}}))
             {{/if}}
             {{#each benchmark.component_reads as |cr|}}
             .saturating_add(T::DbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
             {{/each}}
             {{#if (ne benchmark.base_writes "0")}}
-            .saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}_u64))
+            .saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}))
             {{/if}}
+            {{#each benchmark.component_writes as |cw|}}
+			.saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+			{{/each}}
             {{#each benchmark.component_calculated_proof_size as |cp|}}
-			.saturating_add(Weight::from_proof_size({{cp.slope}}).saturating_mul({{cp.name}}.into()))
+			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
 			{{/each}}
     }
     {{/each}}

--- a/misc/orml_weight_template.hbs
+++ b/misc/orml_weight_template.hbs
@@ -25,6 +25,9 @@ impl<T: frame_system::Config> {{pallet}}::WeightInfo for WeightInfo<T> {
     {{#each benchmark.comments as |comment|}}
     /// {{comment}}
     {{/each}}
+    {{#each benchmark.component_ranges as |range|}}
+    /// The range of component `{{range.name}}` is `[{{range.min}}, {{range.max}}]`.
+    {{/each}}
     fn {{benchmark.name~}}
     (
         {{~#each benchmark.components as |c| ~}}

--- a/misc/orml_weight_template.hbs
+++ b/misc/orml_weight_template.hbs
@@ -49,11 +49,11 @@ impl<T: frame_system::Config> {{pallet}}::WeightInfo for WeightInfo<T> {
             .saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}))
             {{/if}}
             {{#each benchmark.component_writes as |cw|}}
-			.saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
-			{{/each}}
+            .saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+            {{/each}}
             {{#each benchmark.component_calculated_proof_size as |cp|}}
-			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
-			{{/each}}
+           .saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
+           {{/each}}
     }
     {{/each}}
 }

--- a/misc/weight_template.hbs
+++ b/misc/weight_template.hbs
@@ -37,6 +37,9 @@ impl<T: frame_system::Config> WeightInfoZeitgeist for WeightInfo<T> {
     {{#each benchmark.comments as |comment|}}
     /// {{comment}}
     {{/each}}
+    {{#each benchmark.component_ranges as |range|}}
+    /// The range of component `{{range.name}}` is `[{{range.min}}, {{range.max}}]`.
+    {{/each}}
     fn {{benchmark.name~}}
     (
         {{~#each benchmark.components as |c| ~}}

--- a/misc/weight_template.hbs
+++ b/misc/weight_template.hbs
@@ -46,26 +46,25 @@ impl<T: frame_system::Config> WeightInfoZeitgeist for WeightInfo<T> {
         //  Measured:  `{{benchmark.base_recorded_proof_size}}{{#each benchmark.component_recorded_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
         //  Estimated: `{{benchmark.base_calculated_proof_size}}{{#each benchmark.component_calculated_proof_size as |cp|}} + {{cp.name}} * ({{cp.slope}} ±{{underscore cp.error}}){{/each}}`
         // Minimum execution time: {{underscore benchmark.min_execution_time}} nanoseconds.
-        {{#if (ne benchmark.base_calculated_proof_size "0")}}
         Weight::from_parts({{underscore benchmark.base_weight}}, {{benchmark.base_calculated_proof_size}})
-        {{else}}
-        Weight::from_ref_time({{underscore benchmark.base_weight}})
-        {{/if}}
             {{#each benchmark.component_weight as |cw|}}
             // Standard Error: {{underscore cw.error}}
-            .saturating_add(Weight::from_ref_time({{underscore cw.slope}}).saturating_mul({{cw.name}}.into()))
+            .saturating_add(Weight::from_parts({{underscore cw.slope}}, 0).saturating_mul({{cw.name}}.into()))
             {{/each}}
             {{#if (ne benchmark.base_reads "0")}}
-            .saturating_add(T::DbWeight::get().reads({{benchmark.base_reads}}_u64))
+            .saturating_add(T::DbWeight::get().reads({{benchmark.base_reads}}))
             {{/if}}
             {{#each benchmark.component_reads as |cr|}}
             .saturating_add(T::DbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
             {{/each}}
             {{#if (ne benchmark.base_writes "0")}}
-            .saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}_u64))
+            .saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}))
             {{/if}}
+			{{#each benchmark.component_writes as |cw|}}
+			.saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+			{{/each}}
             {{#each benchmark.component_calculated_proof_size as |cp|}}
-			.saturating_add(Weight::from_proof_size({{cp.slope}}).saturating_mul({{cp.name}}.into()))
+			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
 			{{/each}}
     }
     {{/each}}

--- a/misc/weight_template.hbs
+++ b/misc/weight_template.hbs
@@ -60,12 +60,12 @@ impl<T: frame_system::Config> WeightInfoZeitgeist for WeightInfo<T> {
             {{#if (ne benchmark.base_writes "0")}}
             .saturating_add(T::DbWeight::get().writes({{benchmark.base_writes}}))
             {{/if}}
-			{{#each benchmark.component_writes as |cw|}}
-			.saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
-			{{/each}}
+            {{#each benchmark.component_writes as |cw|}}
+            .saturating_add(T::DbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+            {{/each}}
             {{#each benchmark.component_calculated_proof_size as |cp|}}
-			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
-			{{/each}}
+           .saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))
+           {{/each}}
     }
     {{/each}}
 }


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Fixes the templates to reflect the newest weight-v2. The information was taken from Acala [here](https://github.com/AcalaNetwork/Acala/tree/fe67fd1fcb8e666d769d55fec09bf171750ac4a1/templates).

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

https://github.com/zeitgeistpm/zeitgeist/pull/1101

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

