### PR TITLE
Reduce length of `MarketsCollectingSubsidy`

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -2075,7 +2075,7 @@ mod pallet {
     #[pallet::storage]
     pub type MarketsCollectingSubsidy<T: Config> = StorageValue<
         _,
-        BoundedVec<SubsidyUntil<T::BlockNumber, MomentOf<T>, MarketIdOf<T>>, ConstU32<1_048_576>>,
+        BoundedVec<SubsidyUntil<T::BlockNumber, MomentOf<T>, MarketIdOf<T>>, ConstU32<16>>,
         ValueQuery,
     >;
 


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Shortens the length of `MarketsCollectingSubsidy` to ensure that benchmarks don't overestimate the required proof size of `on_initialize`, which has led to local nodes and Battery Station becoming unresponsive.

### What important points should reviewers know?

Reviewers should diligently check that all benchmark results except for `pallet_parachain_staking::delegate_with_auto_compound` are not sufficiently small and that the local node accepts transactions.

### Is there something left for follow-up PRs?

Figure out why the benchmark of `delegate_with_auto_compound` is broken.

### What alternative implementations were considered?

### Are there relevant PRs or issues?

- https://github.com/paritytech/polkadot-sdk/issues/1589
- https://github.com/paritytech/polkadot-sdk/pull/1493

### References

