### PR TITLE
Add bad block of the proof size fiasko to Battery Station chain spec

### DIFF
--- a/node/res/bs_parachain.json
+++ b/node/res/bs_parachain.json
@@ -25,6 +25,9 @@
   "parachain_id": 2101,
   "relay_chain": "rococo",
   "consensusEngine": null,
+  "bad_blocks": [
+    "0x74d8c181547c1607ed28120f94cbe527cb3828772b3e794aabb45dc6a16e482d"
+  ],
   "codeSubstitutes": {},
   "genesis": {
     "raw": {


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Adds the block on which sudo authorized the upgrade of the first iteration of v0.4.0 on Battery Station, which contained benchmarks which grossly overestimated the required proof size, effectively bricking the chain.

### What important points should reviewers know?

Here's a link to the block on which the upgrade was authorized: https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fbsr.zeitgeist.pm#/explorer/query/4278377; the upgrade was executed 50 blocks later.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

