### PR TITLE
Adapt arbitrage weight calculations to proof sizes

### DIFF
--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -116,7 +116,7 @@ mod pallet {
     pub(crate) const ARBITRAGE_MAX_ITERATIONS: usize = 30;
     const ARBITRAGE_THRESHOLD: u128 = CENT;
     const MIN_BALANCE: u128 = CENT;
-    const ON_IDLE_MIN_WEIGHT: Weight = Weight::from_ref_time(1_000_000);
+    const ON_IDLE_MIN_WEIGHT: Weight = Weight::from_parts(1_000_000, 100_000);
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
@@ -1271,19 +1271,33 @@ mod pallet {
             // The division can fail if the benchmark of `apply_to_cached_pools` is not linear in
             // the number of pools. This shouldn't ever happen, but if it does, we ensure that
             // `pool_count` is zero (this isn't really a runtime error).
-            let pool_count = weight
+            let weight_minus_overhead = weight.saturating_sub(overhead);
+            let max_pool_count_by_ref_time = weight_minus_overhead
                 .ref_time()
-                .saturating_sub(overhead.ref_time())
                 .checked_div(extra_weight_per_pool.ref_time())
                 .unwrap_or_else(|| {
-                    log::warn!("Unexpected zero division when calculating arbitrage weight");
+                    debug_assert!(
+                        false,
+                        "Unexpected zero division when calculating arbitrage ref time"
+                    );
                     0_u64
                 });
-            if pool_count == 0_u64 {
+            let max_pool_count_by_proof_size = weight_minus_overhead
+                .proof_size()
+                .checked_div(extra_weight_per_pool.proof_size())
+                .unwrap_or_else(|| {
+                    debug_assert!(
+                        false,
+                        "Unexpected zero division when calculating arbitrage proof size"
+                    );
+                    0_u64
+                });
+            let max_pool_count = max_pool_count_by_ref_time.min(max_pool_count_by_proof_size);
+            if max_pool_count == 0_u64 {
                 return weight;
             }
             Self::apply_to_cached_pools(
-                pool_count.saturated_into(),
+                max_pool_count.saturated_into(),
                 |pool_id| Self::execute_arbitrage(pool_id, ARBITRAGE_MAX_ITERATIONS),
                 extra_weight_per_pool,
             )


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->

### What does it do?

Previously, `execute_arbitrage_all` did the following calculation to estimate how many pools can be arbitrages. Let $w(a)$ be the weight required for arbitraging $a$ pools. We assume that $w$ is a linear function, $w(a) = ma + b$. We therefore have $w(1) - w(0) = m + b - b = m$. Suppose that $W$ is the available weight. Then the maximum number of pools we can arbitrage in the time available is $\frac{W - b}{m}$ (just solve $W = w(a)$ for $a$), ignoring the fact that we need to round down to make $a$ an integer.

But weights now have two components, ref time and proof size. The changes in this PR are the following:

- Introduce a minimum available proof size of 100 KB for `on_idle` to even do the calculation described above. This is definitely an overestimation, but we should be on the safe side.
- Perform the calculation described above both for the ref time and the proof size. This gives us a maximum amount of pools that can be arbitraged using the available ref time and a maximum amount of pools that can be arbitraged using the available proof size. Taking the minimum of both gives us the maximum number of pools we can arbitrage with the available resources.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

