### PR TITLE
Allow selling complete sets regardless of market status

### DIFF
--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -2305,7 +2305,6 @@ mod pallet {
                 ),
                 Error::<T>::InvalidScoringRule
             );
-            Self::ensure_market_is_active(&market)?;
 
             let market_account = <zrml_market_commons::Pallet<T>>::market_account(market_id);
             ensure!(

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -141,13 +141,14 @@ fn simple_create_scalar_market(
     ));
 }
 
+#[test_case(MarketStatus::Proposed)]
+#[test_case(MarketStatus::Suspended)]
 #[test_case(MarketStatus::Closed)]
+#[test_case(MarketStatus::CollectingSubsidy)]
+#[test_case(MarketStatus::InsufficientSubsidy)]
 #[test_case(MarketStatus::Reported)]
 #[test_case(MarketStatus::Disputed)]
 #[test_case(MarketStatus::Resolved)]
-#[test_case(MarketStatus::Proposed)]
-#[test_case(MarketStatus::CollectingSubsidy)]
-#[test_case(MarketStatus::InsufficientSubsidy)]
 fn buy_complete_set_fails_if_market_is_not_active(status: MarketStatus) {
     ExtBuilder::default().build().execute_with(|| {
         simple_create_categorical_market(

--- a/zrml/prediction-markets/src/tests.rs
+++ b/zrml/prediction-markets/src/tests.rs
@@ -141,6 +141,33 @@ fn simple_create_scalar_market(
     ));
 }
 
+#[test_case(MarketStatus::Closed)]
+#[test_case(MarketStatus::Reported)]
+#[test_case(MarketStatus::Disputed)]
+#[test_case(MarketStatus::Resolved)]
+#[test_case(MarketStatus::Proposed)]
+#[test_case(MarketStatus::CollectingSubsidy)]
+#[test_case(MarketStatus::InsufficientSubsidy)]
+fn buy_complete_set_fails_if_market_is_not_active(status: MarketStatus) {
+    ExtBuilder::default().build().execute_with(|| {
+        simple_create_categorical_market(
+            Asset::Ztg,
+            MarketCreation::Permissionless,
+            0..2,
+            ScoringRule::CPMM,
+        );
+        let market_id = 0;
+        assert_ok!(MarketCommons::mutate_market(&market_id, |market| {
+            market.status = status;
+            Ok(())
+        }));
+        assert_noop!(
+            PredictionMarkets::buy_complete_set(RuntimeOrigin::signed(FRED), market_id, 1),
+            Error::<Runtime>::MarketIsNotActive,
+        );
+    });
+}
+
 #[test]
 fn admin_move_market_to_closed_successfully_closes_market_and_sets_end_blocknumber() {
     ExtBuilder::default().build().execute_with(|| {


### PR DESCRIPTION
### What does it do?

Allows selling complete sets regardless of market status. This is fine because even if the market is resolved, selling full sets can't be used to "arbitrage" redeeming. Also adds a test which ensures that `buy_complete_set` does observe the market state.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?

Fixes https://github.com/zeitgeistpm/zeitgeist/issues/1093.

### References

