### PR TITLE
Include system remarks to help testing process

### DIFF
--- a/runtime/battery-station/src/lib.rs
+++ b/runtime/battery-station/src/lib.rs
@@ -119,12 +119,10 @@ impl Contains<RuntimeCall> for ContractsCallfilter {
     fn contains(runtime_call: &RuntimeCall) -> bool {
         #[allow(clippy::match_like_matches_macro)]
         match runtime_call {
-            RuntimeCall::System(inner_call) => {
-                match inner_call {
-                    SystemCall::remark { .. } => true,
-                    SystemCall::remark_with_event { .. } => true,
-                    _ => false
-                }
+            RuntimeCall::System(inner_call) => match inner_call {
+                SystemCall::remark { .. } => true,
+                SystemCall::remark_with_event { .. } => true,
+                _ => false,
             },
             RuntimeCall::AssetManager(transfer { .. }) => true,
             RuntimeCall::PredictionMarkets(inner_call) => {

--- a/runtime/battery-station/src/lib.rs
+++ b/runtime/battery-station/src/lib.rs
@@ -119,6 +119,13 @@ impl Contains<RuntimeCall> for ContractsCallfilter {
     fn contains(runtime_call: &RuntimeCall) -> bool {
         #[allow(clippy::match_like_matches_macro)]
         match runtime_call {
+            RuntimeCall::System(inner_call) => {
+                match inner_call {
+                    SystemCall::remark { .. } => true,
+                    SystemCall::remark_with_event { .. } => true,
+                    _ => false
+                }
+            },
             RuntimeCall::AssetManager(transfer { .. }) => true,
             RuntimeCall::PredictionMarkets(inner_call) => {
                 match inner_call {


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
Adds `remark` and `remark_with_event` to the available pallet calls in battery station. This would be helpful for developers who want to test their smart contract setup with Zeitgeist Battery Station, but don't want to immediately implement any of the more complex extrinsics that are currently available (to ensure that their setup works, all other things being equal).

*I am one such developer*

