### PR TITLE
Integrate zombienet configuration to start parachain node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+/tmp

--- a/integration-tests/zombienet.toml
+++ b/integration-tests/zombienet.toml
@@ -1,0 +1,23 @@
+[settings]
+timeout = 1000
+provider = "native"
+
+[relaychain]
+chain = "rococo-dev"
+default_command = "./tmp/polkadot"
+default_args = [ "--no-hardware-benchmarks", "-lparachain=debug", "--database=paritydb" ]
+
+  [[relaychain.nodes]]
+  name = "charlie"
+
+  [[relaychain.nodes]]
+  name = "bob"
+
+[[parachains]]
+id = 2101
+
+  [parachains.collator]
+  name = "alice"
+  command = "./target/debug/zeitgeist"
+  args = ["-lparachain=debug"]
+  ws_port = 9944

--- a/scripts/tests/spawn_network.sh
+++ b/scripts/tests/spawn_network.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+if [ ! -d "./scripts/tests" ]; then
+    echo "Please execute this script from the root of the Zeitgeist project folder"
+    exit 1
+fi;
+
+cargo build --features parachain
+
+# Define destination path
+DEST_PATH="./tmp/zombienet"
+
+# Check if the file already exists
+if [[ -f "${DEST_PATH}" ]]; then
+    echo "zombienet already exists in /tmp. Executing it."
+    ./tmp/zombienet spawn --provider native ./integration-tests/zombienet.toml
+    exit 0
+fi
+
+# Get the appropriate download link based on the OS
+case "$(uname -s)" in
+    Linux)
+        ARCHITECTURE="$(uname -m)"
+        if [[ "${ARCHITECTURE}" == "x86_64" ]]; then
+            FILE_NAME="zombienet-linux-x64"
+        elif [[ "${ARCHITECTURE}" == "aarch64" ]]; then
+            FILE_NAME="zombienet-linux-arm64"
+        else
+            echo "Unsupported architecture."
+            exit 1
+        fi
+        ;;
+    Darwin)
+        FILE_NAME="zombienet-macos"
+        ;;
+    *)
+        echo "Unsupported operating system."
+        exit 1
+        ;;
+esac
+
+# Fetch the latest release download URL from GitHub
+DOWNLOAD_URL=$(curl -s https://api.github.com/repos/paritytech/zombienet/releases/latest | \
+               jq -r ".assets[] | select(.name == \"${FILE_NAME}\") | .browser_download_url")
+
+if [[ -z "${DOWNLOAD_URL}" ]]; then
+    echo "Failed to retrieve download URL."
+    exit 1
+fi
+
+mkdir -p ./tmp/
+
+# Download the file
+echo "Downloading ${FILE_NAME} from ${DOWNLOAD_URL}"
+curl -L "${DOWNLOAD_URL}" -o "${DEST_PATH}"
+
+# Provide feedback on the download status
+if [[ $? -eq 0 ]]; then
+    echo "Download successful!"
+else
+    echo "Download failed!"
+    exit 1
+fi
+
+# Make the file executable
+chmod +x "${DEST_PATH}"
+
+./tmp/zombienet spawn --provider native ./integration-tests/zombienet.toml


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

This adds a script to spawn two validators on a local rococo relaychain network. Furthermore it spawns a zeitgeist parachain node to allow us to test parachain functionality.

### What important points should reviewers know?

This is the missing piece we all needed to ensure our parachain functionality runs as expected.

### Is there something left for follow-up PRs?

Integrate zndsl scripts to test against the parachain. https://github.com/paritytech/zombienet/blob/main/examples/

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

