### PR TITLE
Ensure MinBetSize after fee

### DIFF
--- a/zrml/parimutuel/src/benchmarking.rs
+++ b/zrml/parimutuel/src/benchmarking.rs
@@ -26,6 +26,7 @@ use frame_benchmarking::v2::*;
 use frame_support::traits::Get;
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
+use sp_runtime::{SaturatedConversion, Saturating};
 use zeitgeist_primitives::types::{Asset, MarketStatus, MarketType, OutcomeReport};
 use zrml_market_commons::MarketCommonsPalletApi;
 
@@ -60,7 +61,7 @@ mod benchmarks {
 
         let market_id = setup_market::<T>(MarketType::Categorical(64u16));
 
-        let amount = T::MinBetSize::get();
+        let amount = T::MinBetSize::get().saturating_mul(10u128.saturated_into::<BalanceOf<T>>());
         let asset = Asset::ParimutuelShare(market_id, 0u16);
 
         let market = T::MarketCommons::market(&market_id).unwrap();
@@ -77,12 +78,14 @@ mod benchmarks {
 
         let winner = whitelisted_caller();
         let winner_asset = Asset::ParimutuelShare(market_id, 0u16);
-        let winner_amount = T::MinBetSize::get() + T::MinBetSize::get();
+        let winner_amount =
+            T::MinBetSize::get().saturating_mul(20u128.saturated_into::<BalanceOf<T>>());
         buy_asset::<T>(market_id, winner_asset, &winner, winner_amount);
 
         let loser = whitelisted_caller();
         let loser_asset = Asset::ParimutuelShare(market_id, 1u16);
-        let loser_amount = T::MinBetSize::get();
+        let loser_amount =
+            T::MinBetSize::get().saturating_mul(10u128.saturated_into::<BalanceOf<T>>());
         buy_asset::<T>(market_id, loser_asset, &loser, loser_amount);
 
         T::MarketCommons::mutate_market(&market_id, |market| {
@@ -103,13 +106,15 @@ mod benchmarks {
         let loser_0 = whitelisted_caller();
         let loser_0_index = 0u16;
         let loser_0_asset = Asset::ParimutuelShare(market_id, loser_0_index);
-        let loser_0_amount = T::MinBetSize::get() + T::MinBetSize::get();
+        let loser_0_amount =
+            T::MinBetSize::get().saturating_mul(20u128.saturated_into::<BalanceOf<T>>());
         buy_asset::<T>(market_id, loser_0_asset, &loser_0, loser_0_amount);
 
         let loser_1 = whitelisted_caller();
         let loser_1_index = 1u16;
         let loser_1_asset = Asset::ParimutuelShare(market_id, loser_1_index);
-        let loser_1_amount = T::MinBetSize::get();
+        let loser_1_amount =
+            T::MinBetSize::get().saturating_mul(10u128.saturated_into::<BalanceOf<T>>());
         buy_asset::<T>(market_id, loser_1_asset, &loser_1, loser_1_amount);
 
         T::MarketCommons::mutate_market(&market_id, |market| {

--- a/zrml/parimutuel/src/tests/buy.rs
+++ b/zrml/parimutuel/src/tests/buy.rs
@@ -200,7 +200,7 @@ fn buy_fails_if_below_minimum_bet_size() {
         let amount = <Runtime as Config>::MinBetSize::get() - 1;
         assert_noop!(
             Parimutuel::buy(RuntimeOrigin::signed(ALICE), asset, amount),
-            Error::<Runtime>::AmountTooSmall
+            Error::<Runtime>::AmountBelowMinimumBetSize
         );
     });
 }

--- a/zrml/parimutuel/src/tests/buy.rs
+++ b/zrml/parimutuel/src/tests/buy.rs
@@ -34,11 +34,11 @@ fn buy_emits_event() {
         Markets::<Runtime>::insert(market_id, market);
 
         let asset = Asset::ParimutuelShare(market_id, 0u16);
-        let amount = <Runtime as Config>::MinBetSize::get();
+        let amount = 10 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), asset, amount));
 
-        let amount_minus_fees = 9900000000;
-        let fees = 100000000;
+        let amount_minus_fees = 99000000000;
+        let fees = 1000000000;
         assert_eq!(amount, amount_minus_fees + fees);
 
         System::assert_last_event(
@@ -63,11 +63,11 @@ fn buy_balances_change_correctly() {
             AssetManager::free_balance(base_asset, &Parimutuel::pot_account(market_id));
 
         let asset = Asset::ParimutuelShare(market_id, 0u16);
-        let amount = <Runtime as Config>::MinBetSize::get();
+        let amount = 10 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), asset, amount));
 
-        let amount_minus_fees = 9900000000;
-        let fees = 100000000;
+        let amount_minus_fees = 99000000000;
+        let fees = 1000000000;
         assert_eq!(amount, amount_minus_fees + fees);
 
         assert_eq!(AssetManager::free_balance(base_asset, &ALICE), free_alice_before - amount);

--- a/zrml/parimutuel/src/tests/claim.rs
+++ b/zrml/parimutuel/src/tests/claim.rs
@@ -35,12 +35,11 @@ fn claim_rewards_emits_event() {
         Markets::<Runtime>::insert(market_id, market);
 
         let winner_asset = Asset::ParimutuelShare(market_id, 0u16);
-        let winner_amount =
-            <Runtime as Config>::MinBetSize::get() + <Runtime as Config>::MinBetSize::get();
+        let winner_amount = 20 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), winner_asset, winner_amount));
 
         let loser_asset = Asset::ParimutuelShare(market_id, 1u16);
-        let loser_amount = <Runtime as Config>::MinBetSize::get();
+        let loser_amount = 10 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(BOB), loser_asset, loser_amount));
 
         let mut market = Markets::<Runtime>::get(market_id).unwrap();
@@ -50,8 +49,8 @@ fn claim_rewards_emits_event() {
 
         assert_ok!(Parimutuel::claim_rewards(RuntimeOrigin::signed(ALICE), market_id));
 
-        let withdrawn_asset_balance = 19800000000;
-        let actual_payoff = 29700000000;
+        let withdrawn_asset_balance = 198000000000;
+        let actual_payoff = 297000000000;
 
         System::assert_last_event(
             Event::RewardsClaimed {
@@ -75,17 +74,14 @@ fn claim_rewards_categorical_changes_balances_correctly() {
         Markets::<Runtime>::insert(market_id, market);
 
         let winner_asset = Asset::ParimutuelShare(market_id, 0u16);
-        let winner_amount_0 =
-            <Runtime as Config>::MinBetSize::get() + <Runtime as Config>::MinBetSize::get();
+        let winner_amount_0 = 20 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), winner_asset, winner_amount_0));
 
-        let winner_amount_1 = <Runtime as Config>::MinBetSize::get()
-            + <Runtime as Config>::MinBetSize::get()
-            + <Runtime as Config>::MinBetSize::get();
+        let winner_amount_1 = 30 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(CHARLIE), winner_asset, winner_amount_1));
 
         let loser_asset = Asset::ParimutuelShare(market_id, 1u16);
-        let loser_amount = <Runtime as Config>::MinBetSize::get();
+        let loser_amount = 10 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(BOB), loser_asset, loser_amount));
 
         let mut market = Markets::<Runtime>::get(market_id).unwrap();
@@ -93,17 +89,17 @@ fn claim_rewards_categorical_changes_balances_correctly() {
         market.resolved_outcome = Some(OutcomeReport::Categorical(0u16));
         Markets::<Runtime>::insert(market_id, market.clone());
 
-        let actual_payoff = 59400000000;
+        let actual_payoff = 594000000000;
         let winner_amount = winner_amount_0 + winner_amount_1;
         let total_pot_amount = loser_amount + winner_amount;
         let total_fees = Percent::from_percent(1) * total_pot_amount;
         assert_eq!(actual_payoff, total_pot_amount - total_fees);
 
-        // 2/5 from 59400000000 = 23760000000
-        let actual_payoff_alice = 23760000000;
+        // 2/5 from 594000000000 = 237600000000
+        let actual_payoff_alice = 237600000000;
         assert_eq!(Percent::from_percent(40) * actual_payoff, actual_payoff_alice);
-        // 3/5 from 59400000000 = 35640000000
-        let actual_payoff_charlie = 35640000000;
+        // 3/5 from 594000000000 = 356400000000
+        let actual_payoff_charlie = 356400000000;
         assert_eq!(Percent::from_percent(60) * actual_payoff, actual_payoff_charlie);
         assert_eq!(actual_payoff_alice + actual_payoff_charlie, actual_payoff);
 
@@ -255,12 +251,11 @@ fn claim_rewards_categorical_fails_if_no_winner() {
         Markets::<Runtime>::insert(market_id, market);
 
         let winner_asset = Asset::ParimutuelShare(market_id, 0u16);
-        let winner_amount =
-            <Runtime as Config>::MinBetSize::get() + <Runtime as Config>::MinBetSize::get();
+        let winner_amount = 20 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), winner_asset, winner_amount));
 
         let loser_asset = Asset::ParimutuelShare(market_id, 1u16);
-        let loser_amount = <Runtime as Config>::MinBetSize::get();
+        let loser_amount = 10 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(BOB), loser_asset, loser_amount));
 
         let mut market = Markets::<Runtime>::get(market_id).unwrap();
@@ -286,12 +281,11 @@ fn claim_rewards_categorical_fails_if_no_winning_shares() {
         Markets::<Runtime>::insert(market_id, market);
 
         let winner_asset = Asset::ParimutuelShare(market_id, 0u16);
-        let winner_amount =
-            <Runtime as Config>::MinBetSize::get() + <Runtime as Config>::MinBetSize::get();
+        let winner_amount = 20 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), winner_asset, winner_amount));
 
         let loser_asset = Asset::ParimutuelShare(market_id, 1u16);
-        let loser_amount = <Runtime as Config>::MinBetSize::get();
+        let loser_amount = 10 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(BOB), loser_asset, loser_amount));
 
         let mut market = Markets::<Runtime>::get(market_id).unwrap();
@@ -317,12 +311,11 @@ fn claim_refunds_works() {
         Markets::<Runtime>::insert(market_id, market);
 
         let alice_asset = Asset::ParimutuelShare(market_id, 0u16);
-        let alice_amount =
-            <Runtime as Config>::MinBetSize::get() + <Runtime as Config>::MinBetSize::get();
+        let alice_amount = 20 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), alice_asset, alice_amount));
 
         let bob_asset = Asset::ParimutuelShare(market_id, 1u16);
-        let bob_amount = <Runtime as Config>::MinBetSize::get();
+        let bob_amount = 10 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(BOB), bob_asset, bob_amount));
 
         let mut market = Markets::<Runtime>::get(market_id).unwrap();

--- a/zrml/parimutuel/src/tests/refund.rs
+++ b/zrml/parimutuel/src/tests/refund.rs
@@ -137,7 +137,7 @@ fn refund_fails_if_refund_not_allowed() {
         Markets::<Runtime>::insert(market_id, market);
 
         let asset = Asset::ParimutuelShare(market_id, 0u16);
-        let amount = <Runtime as Config>::MinBetSize::get();
+        let amount = 10 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), asset, amount));
 
         let mut market = Markets::<Runtime>::get(market_id).unwrap();
@@ -163,7 +163,7 @@ fn refund_fails_if_refundable_balance_is_zero() {
         Markets::<Runtime>::insert(market_id, market);
 
         let asset = Asset::ParimutuelShare(market_id, 0u16);
-        let amount = <Runtime as Config>::MinBetSize::get();
+        let amount = 2 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), asset, amount));
 
         let mut market = Markets::<Runtime>::get(market_id).unwrap();
@@ -192,7 +192,7 @@ fn refund_emits_event() {
         Markets::<Runtime>::insert(market_id, market);
 
         let asset = Asset::ParimutuelShare(market_id, 0u16);
-        let amount = <Runtime as Config>::MinBetSize::get();
+        let amount = 10 * <Runtime as Config>::MinBetSize::get();
         assert_ok!(Parimutuel::buy(RuntimeOrigin::signed(ALICE), asset, amount));
 
         let mut market = Markets::<Runtime>::get(market_id).unwrap();


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Ensure the amount minus fees is above the MinBetSize for parimutuels.

Adds `require_transactional`, because this PR breaks the rule `verify first, write last`.

An error because of the existential deposit should not happen as long as the `MinBetSize` minus the market creator fees is above the existential deposits.

### What important points should reviewers know?

Malte noticed that amount_minus_fees should be checked for MinBetSize. The concern was that `amount_minus_fees` could drop below the existential deposit, if `MinBetSize` was not high enough after the deduction of external fees. The implementation of `transfer` and `deposit` itself would throw an internal error, if the situation ever occurs, that this case happens. But in order for us to clarify the error message if it happens, we now throw our own error message to clarify the mitigation actions for the front end and polkadot js users.

### Is there something left for follow-up PRs?

After https://github.com/zeitgeistpm/zeitgeist/pull/1183 is merged, we should use consistent `verify first, write last` and mitigate the TODO in this PR.

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

