### PR TITLE
Inflate defensively

### DIFF
--- a/primitives/src/constants/mock.rs
+++ b/primitives/src/constants/mock.rs
@@ -48,6 +48,7 @@ parameter_types! {
     pub const MaxDelegations: u32 = 5;
     pub const MaxSelectedDraws: u32 = 510;
     pub const MaxCourtParticipants: u32 = 1_000;
+    pub const MaxYearlyInflation: Perbill = Perbill::from_percent(10u32);
     pub const MinJurorStake: Balance = 50 * CENT;
     pub const InflationPeriod: BlockNumber = 20;
 }

--- a/runtime/battery-station/src/parameters.rs
+++ b/runtime/battery-station/src/parameters.rs
@@ -129,6 +129,8 @@ parameter_types! {
     pub const MaxSelectedDraws: u32 = 510;
     /// The maximum number of jurors / delegators that can be registered.
     pub const MaxCourtParticipants: u32 = 1_000;
+    /// The maximum yearly inflation for court incentivisation.
+    pub const MaxYearlyInflation: Perbill = Perbill::from_percent(10);
     /// The minimum stake a user needs to reserve to become a juror.
     pub const MinJurorStake: Balance = 500 * BASE;
     /// The interval for requesting multiple court votes at once.

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1077,6 +1077,7 @@ macro_rules! impl_config_traits {
             type MaxDelegations = MaxDelegations;
             type MaxSelectedDraws = MaxSelectedDraws;
             type MaxCourtParticipants = MaxCourtParticipants;
+            type MaxYearlyInflation = MaxYearlyInflation;
             type MinJurorStake = MinJurorStake;
             type MonetaryGovernanceOrigin = EnsureRoot<AccountId>;
             type Random = RandomnessCollectiveFlip;

--- a/runtime/zeitgeist/src/parameters.rs
+++ b/runtime/zeitgeist/src/parameters.rs
@@ -129,6 +129,8 @@ parameter_types! {
     pub const MaxSelectedDraws: u32 = 510;
     /// The maximum number of jurors / delegators that can be registered.
     pub const MaxCourtParticipants: u32 = 1_000;
+    /// The maximum yearly inflation for court incentivisation.
+    pub const MaxYearlyInflation: Perbill = Perbill::from_percent(10);
     /// The minimum stake a user needs to reserve to become a juror.
     pub const MinJurorStake: Balance = 500 * BASE;
     /// The interval for requesting multiple court votes at once.

--- a/zrml/court/src/mock.rs
+++ b/zrml/court/src/mock.rs
@@ -35,8 +35,8 @@ use zeitgeist_primitives::{
     constants::mock::{
         AggregationPeriod, AppealBond, AppealPeriod, BlockHashCount, BlocksPerYear, CourtPalletId,
         InflationPeriod, LockId, MaxAppeals, MaxApprovals, MaxCourtParticipants, MaxDelegations,
-        MaxReserves, MaxSelectedDraws, MinJurorStake, MinimumPeriod, PmPalletId, RequestInterval,
-        VotePeriod, BASE,
+        MaxReserves, MaxSelectedDraws, MaxYearlyInflation, MinJurorStake, MinimumPeriod,
+        PmPalletId, RequestInterval, VotePeriod, BASE,
     },
     traits::DisputeResolutionApi,
     types::{
@@ -152,6 +152,7 @@ impl crate::Config for Runtime {
     type MaxDelegations = MaxDelegations;
     type MaxSelectedDraws = MaxSelectedDraws;
     type MaxCourtParticipants = MaxCourtParticipants;
+    type MaxYearlyInflation = MaxYearlyInflation;
     type MinJurorStake = MinJurorStake;
     type MonetaryGovernanceOrigin = EnsureRoot<AccountIdTest>;
     type PalletId = CourtPalletId;

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -3117,7 +3117,7 @@ fn handle_inflation_works() {
 }
 
 #[test]
-fn handle_inflationis_noop_if_yearly_inflation_is_zero() {
+fn handle_inflation_is_noop_if_yearly_inflation_is_zero() {
     ExtBuilder::default().build().execute_with(|| {
         YearlyInflation::<Runtime>::kill();
 

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -3119,7 +3119,7 @@ fn handle_inflation_works() {
 #[test]
 fn handle_inflationis_noop_if_yearly_inflation_is_zero() {
     ExtBuilder::default().build().execute_with(|| {
-        <YearlyInflation<Runtime>>::kill();
+        YearlyInflation::<Runtime>::kill();
 
         let inflation_period = InflationPeriod::get();
         run_blocks(inflation_period);

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -3121,14 +3121,11 @@ fn handle_inflationis_noop_if_yearly_inflation_is_zero() {
     ExtBuilder::default().build().execute_with(|| {
         YearlyInflation::<Runtime>::kill();
 
-        let inflation_period = InflationPeriod::get();
-        run_blocks(inflation_period);
-        let now = <frame_system::Pallet<Runtime>>::block_number();
-
+        let inflation_period_block = InflationPeriod::get();
         // save current storage root
         let tmp = storage_root(StateVersion::V1);
         // handle_inflation is a noop for the storage
-        Court::handle_inflation(now);
+        Court::handle_inflation(inflation_period_block);
         assert_eq!(tmp, storage_root(StateVersion::V1));
     });
 }

--- a/zrml/court/src/tests.rs
+++ b/zrml/court/src/tests.rs
@@ -39,7 +39,7 @@ use pallet_balances::{BalanceLock, NegativeImbalance};
 use rand::seq::SliceRandom;
 use sp_runtime::{
     traits::{BlakeTwo256, Hash, Zero},
-    Perquintill,
+    Perbill, Perquintill,
 };
 use test_case::test_case;
 use zeitgeist_primitives::{
@@ -3056,6 +3056,8 @@ fn random_jurors_returns_a_subset_of_jurors() {
 #[test]
 fn handle_inflation_works() {
     ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(Court::set_inflation(RuntimeOrigin::root(), Perbill::from_percent(2u32)));
+
         let mut jurors = <CourtPool<Runtime>>::get();
         let mut free_balances_before = BTreeMap::new();
         let jurors_list = [1000, 10_000, 100_000, 1_000_000, 10_000_000];

--- a/zrml/neo-swaps/src/mock.rs
+++ b/zrml/neo-swaps/src/mock.rs
@@ -55,11 +55,11 @@ use zeitgeist_primitives::{
         MaxEditReasonLen, MaxGlobalDisputeVotes, MaxGracePeriod, MaxInRatio, MaxLocks,
         MaxMarketLifetime, MaxOracleDuration, MaxOutRatio, MaxOwners, MaxRejectReasonLen,
         MaxReserves, MaxSelectedDraws, MaxSubsidyPeriod, MaxSwapFee, MaxTotalWeight, MaxWeight,
-        MinAssets, MinCategories, MinDisputeDuration, MinJurorStake, MinOracleDuration,
-        MinOutcomeVoteAmount, MinSubsidy, MinSubsidyPeriod, MinWeight, MinimumPeriod,
-        NeoMaxSwapFee, NeoSwapsPalletId, OutcomeBond, OutcomeFactor, OutsiderBond, PmPalletId,
-        RemoveKeysLimit, RequestInterval, SimpleDisputesPalletId, SwapsPalletId, TreasuryPalletId,
-        VotePeriod, VotingOutcomeFee, BASE, CENT,
+        MaxYearlyInflation, MinAssets, MinCategories, MinDisputeDuration, MinJurorStake,
+        MinOracleDuration, MinOutcomeVoteAmount, MinSubsidy, MinSubsidyPeriod, MinWeight,
+        MinimumPeriod, NeoMaxSwapFee, NeoSwapsPalletId, OutcomeBond, OutcomeFactor, OutsiderBond,
+        PmPalletId, RemoveKeysLimit, RequestInterval, SimpleDisputesPalletId, SwapsPalletId,
+        TreasuryPalletId, VotePeriod, VotingOutcomeFee, BASE, CENT,
     },
     traits::{DeployPoolApi, DistributeFees},
     types::{
@@ -295,6 +295,7 @@ impl zrml_court::Config for Runtime {
     type MaxDelegations = MaxDelegations;
     type MaxSelectedDraws = MaxSelectedDraws;
     type MaxCourtParticipants = MaxCourtParticipants;
+    type MaxYearlyInflation = MaxYearlyInflation;
     type MinJurorStake = MinJurorStake;
     type MonetaryGovernanceOrigin = EnsureRoot<AccountIdTest>;
     type PalletId = CourtPalletId;

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -51,11 +51,11 @@ use zeitgeist_primitives::{
         MaxDisputes, MaxEditReasonLen, MaxGlobalDisputeVotes, MaxGracePeriod, MaxInRatio,
         MaxMarketLifetime, MaxOracleDuration, MaxOutRatio, MaxOwners, MaxRejectReasonLen,
         MaxReserves, MaxSelectedDraws, MaxSubsidyPeriod, MaxSwapFee, MaxTotalWeight, MaxWeight,
-        MinAssets, MinCategories, MinDisputeDuration, MinJurorStake, MinOracleDuration,
-        MinOutcomeVoteAmount, MinSubsidy, MinSubsidyPeriod, MinWeight, MinimumPeriod, OutcomeBond,
-        OutcomeFactor, OutsiderBond, PmPalletId, RemoveKeysLimit, RequestInterval,
-        SimpleDisputesPalletId, SwapsPalletId, TreasuryPalletId, VotePeriod, VotingOutcomeFee,
-        BASE, CENT, MILLISECS_PER_BLOCK,
+        MaxYearlyInflation, MinAssets, MinCategories, MinDisputeDuration, MinJurorStake,
+        MinOracleDuration, MinOutcomeVoteAmount, MinSubsidy, MinSubsidyPeriod, MinWeight,
+        MinimumPeriod, OutcomeBond, OutcomeFactor, OutsiderBond, PmPalletId, RemoveKeysLimit,
+        RequestInterval, SimpleDisputesPalletId, SwapsPalletId, TreasuryPalletId, VotePeriod,
+        VotingOutcomeFee, BASE, CENT, MILLISECS_PER_BLOCK,
     },
     traits::DeployPoolApi,
     types::{
@@ -343,6 +343,7 @@ impl zrml_court::Config for Runtime {
     type MaxDelegations = MaxDelegations;
     type MaxSelectedDraws = MaxSelectedDraws;
     type MaxCourtParticipants = MaxCourtParticipants;
+    type MaxYearlyInflation = MaxYearlyInflation;
     type MinJurorStake = MinJurorStake;
     type MonetaryGovernanceOrigin = EnsureRoot<AccountIdTest>;
     type PalletId = CourtPalletId;


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Firstly, it sets the initial inflation to zero. Secondly, it adds a defensive `MaxYearlyInflation` config parameter to protect us from the accident to fail and set the inflation to an unreasonable high amount.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

