### PR TITLE
Add env_logger and add force-debug feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,7 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
+ "sp-debug-derive",
  "sp-finality-grandpa",
  "sp-inherents",
  "sp-io",
@@ -2550,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -2728,7 +2729,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84f2e425d9790201ba4af4630191feac6dcc98765b118d4d18e91d23c2353866"
 dependencies = [
- "env_logger 0.10.0",
+ "env_logger 0.10.1",
  "log",
 ]
 
@@ -14460,6 +14461,7 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
+ "sp-debug-derive",
  "sp-finality-grandpa",
  "sp-inherents",
  "sp-io",
@@ -14517,6 +14519,7 @@ dependencies = [
 name = "zrml-authorized"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14535,6 +14538,7 @@ name = "zrml-court"
 version = "0.4.2"
 dependencies = [
  "arrayvec 0.7.4",
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14558,6 +14562,7 @@ dependencies = [
 name = "zrml-global-disputes"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14578,6 +14583,7 @@ dependencies = [
 name = "zrml-liquidity-mining"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14596,6 +14602,7 @@ dependencies = [
 name = "zrml-market-commons"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-support",
  "frame-system",
  "pallet-balances",
@@ -14612,6 +14619,7 @@ dependencies = [
 name = "zrml-neo-swaps"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "fixed",
  "frame-benchmarking",
  "frame-support",
@@ -14656,6 +14664,7 @@ dependencies = [
 name = "zrml-orderbook"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14689,6 +14698,7 @@ dependencies = [
 name = "zrml-parimutuel"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14710,6 +14720,7 @@ dependencies = [
 name = "zrml-prediction-markets"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14773,6 +14784,7 @@ version = "0.4.2"
 dependencies = [
  "arbitrary",
  "cfg-if",
+ "env_logger 0.10.1",
  "frame-support",
  "frame-system",
  "hashbrown 0.12.3",
@@ -14804,6 +14816,7 @@ dependencies = [
 name = "zrml-simple-disputes"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14824,6 +14837,7 @@ dependencies = [
 name = "zrml-styx"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14840,6 +14854,7 @@ dependencies = [
 name = "zrml-swaps"
 version = "0.4.2"
 dependencies = [
+ "env_logger 0.10.1",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,7 @@ sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "pol
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
+sp-debug-derive = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.38", default-features = false }
@@ -251,6 +252,7 @@ libfuzzer-sys = "0.4.7"
 more-asserts = "0.3.1"
 test-case = "3.1.0"
 url = "2.2.2"
+env_logger = "0.10.1"
 
 # Other (wasm)
 arbitrary = { version = "1.3.0", default-features = false }

--- a/runtime/battery-station/Cargo.toml
+++ b/runtime/battery-station/Cargo.toml
@@ -37,6 +37,7 @@ scale-info = { workspace = true, features = ["derive"] }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-core = { workspace = true }
+sp-debug-derive = { workspace = true }
 sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
@@ -412,6 +413,8 @@ try-runtime = [
     "cumulus-pallet-xcmp-queue?/try-runtime",
     "parachain-info?/try-runtime",
 ]
+# Allow to print logs details (no wasm:stripped)
+force-debug = [ "sp-debug-derive/force-debug" ]
 
 [package]
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]

--- a/runtime/zeitgeist/Cargo.toml
+++ b/runtime/zeitgeist/Cargo.toml
@@ -36,6 +36,7 @@ scale-info = { workspace = true, features = ["derive"] }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-core = { workspace = true }
+sp-debug-derive = { workspace = true }
 sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
@@ -401,6 +402,8 @@ try-runtime = [
     "cumulus-pallet-xcmp-queue?/try-runtime",
     "parachain-info?/try-runtime",
 ]
+# Allow to print logs details (no wasm:stripped)
+force-debug = [ "sp-debug-derive/force-debug" ]
 
 [package]
 authors = ["Zeitgeist PM <contact@zeitgeist.pm>"]

--- a/scripts/benchmarks/quick_check.sh
+++ b/scripts/benchmarks/quick_check.sh
@@ -25,6 +25,7 @@ export PROFILE=release
 export PROFILE_DIR=release
 export ADDITIONAL_PARAMS=--detailed-log-output
 export EXECUTION=native
-export ADDITIONAL_FEATURES=""
+# force-debug for no <wasm::stripped> output
+export ADDITIONAL_FEATURES="force-debug"
 
 source ./scripts/benchmarks/run_benchmarks.sh

--- a/zrml/authorized/Cargo.toml
+++ b/zrml/authorized/Cargo.toml
@@ -13,6 +13,7 @@ pallet-balances = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 zeitgeist-primitives = { workspace = true, features = ["mock", "default"] }
+env_logger = { workspace = true }
 
 [features]
 default = ["std"]

--- a/zrml/authorized/src/mock.rs
+++ b/zrml/authorized/src/mock.rs
@@ -201,6 +201,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/court/Cargo.toml
+++ b/zrml/court/Cargo.toml
@@ -19,6 +19,7 @@ pallet-timestamp = { workspace = true, features = ["default"] }
 pallet-treasury = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 zeitgeist-primitives = { workspace = true, features = ["mock", "default"] }
+env_logger = { workspace = true }
 
 test-case = { workspace = true }
 

--- a/zrml/court/src/mock.rs
+++ b/zrml/court/src/mock.rs
@@ -257,6 +257,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/global-disputes/Cargo.toml
+++ b/zrml/global-disputes/Cargo.toml
@@ -18,6 +18,7 @@ pallet-balances = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 zeitgeist-primitives = { workspace = true, features = ["mock", "default"] }
+env_logger = { workspace = true }
 
 test-case = { workspace = true }
 

--- a/zrml/global-disputes/src/mock.rs
+++ b/zrml/global-disputes/src/mock.rs
@@ -199,6 +199,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/liquidity-mining/Cargo.toml
+++ b/zrml/liquidity-mining/Cargo.toml
@@ -14,6 +14,7 @@ pallet-balances = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 zeitgeist-primitives = { workspace = true, features = ["mock", "default"] }
+env_logger = { workspace = true }
 
 [features]
 default = ["std"]

--- a/zrml/liquidity-mining/src/mock.rs
+++ b/zrml/liquidity-mining/src/mock.rs
@@ -138,6 +138,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         crate::GenesisConfig::<Runtime> {
             initial_balance: self.initial_balance,
             per_block_distribution: self.per_block_incentives,

--- a/zrml/market-commons/Cargo.toml
+++ b/zrml/market-commons/Cargo.toml
@@ -12,6 +12,7 @@ pallet-balances = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 zeitgeist-primitives = { workspace = true, features = ["mock", "default"] }
+env_logger = { workspace = true }
 
 [features]
 default = ["std"]

--- a/zrml/market-commons/src/mock.rs
+++ b/zrml/market-commons/src/mock.rs
@@ -106,6 +106,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: vec![] }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/neo-swaps/Cargo.toml
+++ b/zrml/neo-swaps/Cargo.toml
@@ -37,7 +37,7 @@ zrml-prediction-markets-runtime-api = { workspace = true, optional = true }
 zrml-rikiddo = { workspace = true, optional = true }
 zrml-simple-disputes = { workspace = true, optional = true }
 zrml-swaps = { workspace = true, optional = true }
-
+env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 more-asserts = { workspace = true }
@@ -77,6 +77,7 @@ mock = [
     "zrml-prediction-markets/mock",
     "zrml-prediction-markets/default",
     "serde/default",
+    "env_logger/default",
 ]
 parachain = ["zrml-prediction-markets/parachain"]
 runtime-benchmarks = [

--- a/zrml/neo-swaps/src/mock.rs
+++ b/zrml/neo-swaps/src/mock.rs
@@ -484,6 +484,8 @@ impl Default for ExtBuilder {
 impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/orderbook/Cargo.toml
+++ b/zrml/orderbook/Cargo.toml
@@ -16,6 +16,7 @@ pallet-balances = { workspace = true, optional = true }
 pallet-timestamp = { workspace = true, optional = true }
 sp-io = { workspace = true, optional = true }
 zrml-market-commons = { workspace = true, optional = true }
+env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
@@ -31,6 +32,7 @@ mock = [
     "orml-currencies/default",
     "sp-io/default",
     "zeitgeist-primitives/mock",
+    "env_logger/default",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",

--- a/zrml/orderbook/src/mock.rs
+++ b/zrml/orderbook/src/mock.rs
@@ -150,6 +150,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/parimutuel/Cargo.toml
+++ b/zrml/parimutuel/Cargo.toml
@@ -16,6 +16,7 @@ pallet-balances = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 zeitgeist-primitives = { workspace = true, features = ["mock", "default"] }
+env_logger = { workspace = true }
 
 test-case = { workspace = true }
 

--- a/zrml/parimutuel/src/mock.rs
+++ b/zrml/parimutuel/src/mock.rs
@@ -199,6 +199,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/prediction-markets/Cargo.toml
+++ b/zrml/prediction-markets/Cargo.toml
@@ -32,6 +32,7 @@ xcm = { workspace = true, optional = true }
 zrml-prediction-markets-runtime-api = { workspace = true, optional = true }
 zrml-rikiddo = { workspace = true, optional = true }
 zrml-swaps = { workspace = true, optional = true }
+env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 more-asserts = { workspace = true }
@@ -57,6 +58,7 @@ mock = [
     "zrml-swaps/default",
     "xcm/default",
     "orml-asset-registry/default",
+    "env_logger/default",
 ]
 parachain = []
 runtime-benchmarks = [

--- a/zrml/prediction-markets/src/mock.rs
+++ b/zrml/prediction-markets/src/mock.rs
@@ -480,6 +480,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/rikiddo/Cargo.toml
+++ b/zrml/rikiddo/Cargo.toml
@@ -13,6 +13,7 @@ sp-io = { workspace = true, optional = true }
 sp-runtime = { workspace = true }
 substrate-fixed = { workspace = true, features = ["serde"] }
 zeitgeist-primitives = { workspace = true }
+env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 zrml-rikiddo = { workspace = true, features = ["mock", "default"] }
@@ -24,6 +25,7 @@ mock = [
     "pallet-timestamp/default",
     "sp-io/default",
     "zeitgeist-primitives/mock",
+    "env_logger/default",
 ]
 std = [
     "frame-support/std",

--- a/zrml/rikiddo/src/mock.rs
+++ b/zrml/rikiddo/src/mock.rs
@@ -148,6 +148,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/simple-disputes/Cargo.toml
+++ b/zrml/simple-disputes/Cargo.toml
@@ -16,6 +16,7 @@ pallet-balances = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 zeitgeist-primitives = { workspace = true, features = ["mock", "default"] }
+env_logger = { workspace = true }
 
 [features]
 default = ["std"]

--- a/zrml/simple-disputes/src/mock.rs
+++ b/zrml/simple-disputes/src/mock.rs
@@ -220,6 +220,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/styx/Cargo.toml
+++ b/zrml/styx/Cargo.toml
@@ -12,6 +12,7 @@ pallet-balances = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 zeitgeist-primitives = { workspace = true, features = ["mock", "default"] }
+env_logger = { workspace = true }
 
 [features]
 default = ["std"]

--- a/zrml/styx/src/mock.rs
+++ b/zrml/styx/src/mock.rs
@@ -111,6 +111,9 @@ impl ExtBuilder {
     pub fn build(self) -> sp_io::TestExternalities {
         let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut t)
             .unwrap();

--- a/zrml/swaps/Cargo.toml
+++ b/zrml/swaps/Cargo.toml
@@ -22,6 +22,7 @@ sp-api = { workspace = true, optional = true }
 sp-io = { workspace = true, optional = true }
 zrml-market-commons = { workspace = true, optional = true }
 zrml-swaps-runtime-api = { workspace = true, optional = true }
+env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 more-asserts = { workspace = true }
@@ -40,6 +41,7 @@ mock = [
     "zeitgeist-primitives/mock",
     "zrml-market-commons/default",
     "zrml-swaps-runtime-api/default",
+    "env_logger/default",
 ]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",

--- a/zrml/swaps/src/mock.rs
+++ b/zrml/swaps/src/mock.rs
@@ -283,6 +283,9 @@ impl ExtBuilder {
         let mut storage =
             frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
+        // see the logs in tests when using `cargo test -- --nocapture`
+        let _ = env_logger::builder().is_test(true).try_init();
+
         pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
             .assimilate_storage(&mut storage)
             .unwrap();


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Adds the env_logger to the mocks so that logs like `log::info`, `log::error`, `log::warn` can be seen in tests. 

It also adds the `force-debug` feature to easily identify the causes of problems in benchmarks or in release builds, because all logs are expanded and not `wasm::stripped` in this case.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

