### PR TITLE
Reduce benchmark runs of Zeitgeist pallets

### DIFF
--- a/scripts/benchmarks/configuration.sh
+++ b/scripts/benchmarks/configuration.sh
@@ -30,8 +30,8 @@ export ZEITGEIST_PALLETS=(
     zrml_authorized zrml_court zrml_global_disputes zrml_liquidity_mining zrml_neo_swaps \
     zrml_orderbook zrml_parimutuel zrml_prediction_markets zrml_swaps zrml_styx \
 )
-export ZEITGEIST_PALLETS_RUNS="${ZEITGEIST_PALLETS_RUNS:-1000}"
-export ZEITGEIST_PALLETS_STEPS="${ZEITGEIST_PALLETS_STEPS:-10}"
+export ZEITGEIST_PALLETS_RUNS="${ZEITGEIST_PALLETS_RUNS:-20}"
+export ZEITGEIST_PALLETS_STEPS="${ZEITGEIST_PALLETS_STEPS:-50}"
 export ZEITGEIST_WEIGHT_TEMPLATE="./misc/weight_template.hbs"
 
 export PROFILE="${PROFILE:-production}"


### PR DESCRIPTION
Running benchmarks of Zeitgeist pallets on the Zeitgeist reference machine currently takes four days.

<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
- Reduces the benchmark iterations for Zeitgeist pallets (currently benchmarking those pallets takes 4 days on the reference machine)

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

