### PR TITLE
Set inflation to more than zero for a full benchmark of handle_inflation

### DIFF
--- a/zrml/court/src/benchmarks.rs
+++ b/zrml/court/src/benchmarks.rs
@@ -27,7 +27,7 @@ use crate::{
     types::{CourtParticipantInfo, CourtPoolItem, CourtStatus, Draw, Vote},
     AppealInfo, BalanceOf, Call, Config, CourtId, CourtPool, Courts, DelegatedStakesOf,
     MarketIdToCourtId, MarketOf, Pallet as Court, Pallet, Participants, RequestBlock,
-    SelectedDraws, VoteItem,
+    SelectedDraws, VoteItem, YearlyInflation,
 };
 use alloc::{vec, vec::Vec};
 use frame_benchmarking::{account, benchmarks, whitelisted_caller};
@@ -672,6 +672,7 @@ benchmarks! {
 
         <frame_system::Pallet<T>>::set_block_number(T::InflationPeriod::get());
         let now = <frame_system::Pallet<T>>::block_number();
+        YearlyInflation::<T>::put(Perbill::from_percent(2));
     }: {
         Court::<T>::handle_inflation(now);
     }


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

It sets the inflation to a value more than zero in order to let the benchmark reach the full scope of this `handle_inflation` function.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

