### PR TITLE
Implement `force_pool_exit` and disable other zrml-swaps functions

### DIFF
--- a/runtime/battery-station/src/lib.rs
+++ b/runtime/battery-station/src/lib.rs
@@ -58,9 +58,9 @@ use zrml_prediction_markets::Call::{
 };
 use zrml_rikiddo::types::{EmaMarketVolume, FeeSigmoid, RikiddoSigmoidMV};
 use zrml_swaps::Call::{
-    pool_exit, pool_exit_with_exact_asset_amount, pool_exit_with_exact_pool_amount, pool_join,
-    pool_join_with_exact_asset_amount, pool_join_with_exact_pool_amount, swap_exact_amount_in,
-    swap_exact_amount_out,
+    force_pool_exit, pool_exit, pool_exit_with_exact_asset_amount,
+    pool_exit_with_exact_pool_amount, pool_join, pool_join_with_exact_asset_amount,
+    pool_join_with_exact_pool_amount, swap_exact_amount_in, swap_exact_amount_out,
 };
 #[cfg(feature = "parachain")]
 use {
@@ -164,7 +164,6 @@ impl Contains<RuntimeCall> for ContractsCallfilter {
 #[derive(scale_info::TypeInfo)]
 pub struct IsCallable;
 
-// Currently disables Rikiddo.
 impl Contains<RuntimeCall> for IsCallable {
     fn contains(call: &RuntimeCall) -> bool {
         #[allow(clippy::match_like_matches_macro)]
@@ -181,6 +180,10 @@ impl Contains<RuntimeCall> for IsCallable {
                     ..
                 } => false,
                 _ => true,
+            },
+            RuntimeCall::Swaps(inner_call) => match inner_call {
+                force_pool_exit { .. } => true,
+                _ => false,
             },
             _ => true,
         }

--- a/runtime/zeitgeist/src/lib.rs
+++ b/runtime/zeitgeist/src/lib.rs
@@ -123,6 +123,7 @@ impl Contains<RuntimeCall> for IsCallable {
         use zrml_prediction_markets::Call::{
             admin_move_market_to_closed, admin_move_market_to_resolved, create_market, edit_market,
         };
+        use zrml_swaps::Call::force_pool_exit;
 
         #[allow(clippy::match_like_matches_macro)]
         match runtime_call {
@@ -170,6 +171,10 @@ impl Contains<RuntimeCall> for IsCallable {
                 }
             }
             RuntimeCall::SimpleDisputes(_) => false,
+            RuntimeCall::Swaps(inner_call) => match inner_call {
+                force_pool_exit { .. } => true,
+                _ => false,
+            },
             RuntimeCall::System(inner_call) => {
                 match inner_call {
                     // Some "waste" storage will never impact proper operation.

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -129,36 +129,7 @@ mod pallet {
             min_assets_out: Vec<BalanceOf<T>>,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
-            ensure!(pool_amount != Zero::zero(), Error::<T>::ZeroAmount);
-            let who_clone = who.clone();
-            let pool = Self::pool_by_id(pool_id)?;
-            // If the pool is still in use, prevent a pool drain.
-            Self::ensure_minimum_liquidity_shares(pool_id, &pool, pool_amount)?;
-            let pool_account_id = Pallet::<T>::pool_account_id(&pool_id);
-            let params = PoolParams {
-                asset_bounds: min_assets_out,
-                event: |evt| Self::deposit_event(Event::PoolExit(evt)),
-                pool_account_id: &pool_account_id,
-                pool_amount,
-                pool_id,
-                pool: &pool,
-                transfer_asset: |amount, amount_bound, asset| {
-                    Self::ensure_minimum_balance(pool_id, &pool, asset, amount)?;
-                    ensure!(amount >= amount_bound, Error::<T>::LimitOut);
-                    T::AssetManager::transfer(asset, &pool_account_id, &who, amount)?;
-                    Ok(())
-                },
-                transfer_pool: || {
-                    Self::burn_pool_shares(pool_id, &who, pool_amount)?;
-                    Ok(())
-                },
-                fee: |amount: BalanceOf<T>| {
-                    let exit_fee_amount = amount.bmul(Self::calc_exit_fee(&pool))?;
-                    Ok(exit_fee_amount)
-                },
-                who: who_clone,
-            };
-            crate::utils::pool::<_, _, _, _, T>(params)
+            Self::do_pool_exit(who, pool_id, pool_amount, min_assets_out)
         }
 
         /// Pool - Exit with exact pool amount
@@ -747,6 +718,44 @@ mod pallet {
     pub(crate) type NextPoolId<T> = StorageValue<_, PoolId, ValueQuery>;
 
     impl<T: Config> Pallet<T> {
+        fn do_pool_exit(
+            who: T::AccountId,
+            pool_id: PoolId,
+            pool_amount: BalanceOf<T>,
+            min_assets_out: Vec<BalanceOf<T>>,
+        ) -> DispatchResult {
+            ensure!(pool_amount != Zero::zero(), Error::<T>::ZeroAmount);
+            let who_clone = who.clone();
+            let pool = Self::pool_by_id(pool_id)?;
+            // If the pool is still in use, prevent a pool drain.
+            Self::ensure_minimum_liquidity_shares(pool_id, &pool, pool_amount)?;
+            let pool_account_id = Pallet::<T>::pool_account_id(&pool_id);
+            let params = PoolParams {
+                asset_bounds: min_assets_out,
+                event: |evt| Self::deposit_event(Event::PoolExit(evt)),
+                pool_account_id: &pool_account_id,
+                pool_amount,
+                pool_id,
+                pool: &pool,
+                transfer_asset: |amount, amount_bound, asset| {
+                    Self::ensure_minimum_balance(pool_id, &pool, asset, amount)?;
+                    ensure!(amount >= amount_bound, Error::<T>::LimitOut);
+                    T::AssetManager::transfer(asset, &pool_account_id, &who, amount)?;
+                    Ok(())
+                },
+                transfer_pool: || {
+                    Self::burn_pool_shares(pool_id, &who, pool_amount)?;
+                    Ok(())
+                },
+                fee: |amount: BalanceOf<T>| {
+                    let exit_fee_amount = amount.bmul(Self::calc_exit_fee(&pool))?;
+                    Ok(exit_fee_amount)
+                },
+                who: who_clone,
+            };
+            crate::utils::pool::<_, _, _, _, T>(params)
+        }
+
         pub fn get_spot_price(
             pool_id: &PoolId,
             asset_in: &AssetOf<T>,

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -483,6 +483,22 @@ mod pallet {
             )?;
             Ok(Some(weight).into())
         }
+
+        #[pallet::call_index(11)]
+        #[pallet::weight(T::WeightInfo::pool_exit(
+            min_assets_out.len().min(T::MaxAssets::get().into()) as u32
+        ))]
+        #[transactional]
+        pub fn force_pool_exit(
+            origin: OriginFor<T>,
+            who: T::AccountId,
+            #[pallet::compact] pool_id: PoolId,
+            #[pallet::compact] pool_amount: BalanceOf<T>,
+            min_assets_out: Vec<BalanceOf<T>>,
+        ) -> DispatchResult {
+            let _ = ensure_signed(origin)?;
+            Self::do_pool_exit(who, pool_id, pool_amount, min_assets_out)
+        }
     }
 
     #[pallet::config]


### PR DESCRIPTION
### What does it do?

Implements `force_pool_exit`, which allows any user to forcibly withdraw another user's funds held in a Balancer-style pool. This will be used to defund all Balancer-style pools after the migration to LMSR that will be executed in 0.5.0.

### What important points should reviewers know?

- I've installled call filters for all functions of zrml-swaps except `force_pool_exit`. Seemed appropriate. It's not strictly necessary because all pools will be closed and no pool can be created, but it just seemed reasonable to me.
- I've not benchmarked `force_pool_exit` because it's virtually equivalent to `pool_exit` in terms of computation and just used the `pool_exit` benchmark instead.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

