### PR TITLE
Set in-progress when need and rerun CI in merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,6 +35,7 @@ pull_request_rules:
             - s:in-progress
             - s:review-needed
   - name: Set in-progress label after changes are pushed
+    conditions:
     actions:
         label:
           add:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,6 @@ pull_request_rules:
       - check-success=Quick check benchmarks
       - check-success=Test standalone build
       - check-success=Test parachain build
-      - check-success=Fuzz
       - label=s:accepted
     actions:
       label:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -46,7 +46,7 @@ pull_request_rules:
             - s:on-hold
             - s:review-needed
             - s:revision-needed
-  - name: Trigger CI after Mergify merged the base branch
+  - name: Trigger CI after Mergify merged the base branch (fix merge queue)
     conditions:
       - commits[-1].author=mergify[bot]
       - label=s:in-progress

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,7 +35,7 @@ pull_request_rules:
             - s:in-progress
             - s:review-needed
   - name: Set in-progress label after changes are pushed
-    conditions:
+    conditions: []
     actions:
         label:
           add:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,7 +35,8 @@ pull_request_rules:
             - s:in-progress
             - s:review-needed
   - name: Set in-progress label after changes are pushed
-    conditions: []
+    conditions:
+      -  commits[-1].date_committer>=0 days 00:01 ago
     actions:
         label:
           add:
@@ -51,10 +52,11 @@ pull_request_rules:
     conditions:
       - commits[-1].author=mergify[bot]
       - label=s:in-progress
+      - queue-position=0
     actions:
         label:
           remove:
             - s:in-progress
           add:
             - s:accepted
-
+            

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,7 @@ pull_request_rules:
       - check-success=Quick check benchmarks
       - check-success=Test standalone build
       - check-success=Test parachain build
+      - check-success=Fuzz
       - label=s:accepted
     actions:
       label:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,8 +19,8 @@ pull_request_rules:
         remove:
           - s:in-progress
           - s:review-needed
-      merge:
-        method: squash
+      queue:
+        merge_method: squash
   - name: ask to resolve conflict
     conditions:
       - conflict
@@ -34,4 +34,26 @@ pull_request_rules:
             - s:accepted
             - s:in-progress
             - s:review-needed
+  - name: Set in-progress label after changes are pushed
+    actions:
+        label:
+          add:
+            - s:in-progress
+          remove:
+            - s:accepted
+            - s:available
+            - s:blocked
+            - s:on-hold
+            - s:review-needed
+            - s:revision-needed
+  - name: Trigger CI after Mergify merged the base branch
+    conditions:
+      - commits[-1].author=mergify[bot]
+      - label=s:in-progress
+    actions:
+        label:
+          remove:
+            - s:in-progress
+          add:
+            - s:accepted
 


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
- Whenever a commit is added, adds the label `s:in-progress` and removes all other labels
- Whenever a commit by Mergify is made and the label is `s:in-progress`, the label `s:in-progress` is removed and the label `s:accepted` is added. This is a workaround to trigger the CI when Mergify is in the process of merging a PR from the merge queue. Right now, Mergify merges the base branch into main for the current merge queue candidate and then the CI does not trigger.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->
closes #1128 

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References
- https://docs.mergify.com

