### PR TITLE
Avoid mergify dequeue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,7 +36,8 @@ pull_request_rules:
             - s:review-needed
   - name: Set in-progress label after changes are pushed
     conditions:
-      -  commits[-1].date_committer>=0 days 00:01 ago
+      - commits[-1].date_committer>=0 days 00:01 ago
+      - commits[-1].author!=mergify[bot]
     actions:
         label:
           add:
@@ -51,12 +52,18 @@ pull_request_rules:
   - name: Trigger CI after Mergify merged the base branch (fix merge queue)
     conditions:
       - commits[-1].author=mergify[bot]
-      - label=s:in-progress
+      - queue-position=0
+    actions:
+        label:
+          add:
+            - s:review-needed
+  - name: Remove CI trigger label
+    conditions:
+      - commits[-1].author=mergify[bot]
+      - label=s:review-needed
       - queue-position=0
     actions:
         label:
           remove:
-            - s:in-progress
-          add:
-            - s:accepted
-            
+            - s:review-needed
+

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,8 +36,8 @@ pull_request_rules:
             - s:review-needed
   - name: Set in-progress label after changes are pushed
     conditions:
-      - commits[-1].date_committer>=0 days 00:01 ago
       - commits[-1].author!=mergify[bot]
+      - commits[-1].date_committer>=0 days 00:01 ago
     actions:
         label:
           add:
@@ -52,6 +52,7 @@ pull_request_rules:
   - name: Trigger CI after Mergify merged the base branch (fix merge queue)
     conditions:
       - commits[-1].author=mergify[bot]
+      - commits[-1].date_committer>=0 days 00:01 ago
       - queue-position=0
     actions:
         label:


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?
https://github.com/zeitgeistpm/zeitgeist/pull/1244 leads to the situation that PRs are dequeued, because setting the `s:in-progress` label leads to skipping all relevant workflows. Although shortly after setting the `s:in-progress` label the `s:accepted` label is set again, the PR is still dequeued as the first instance where the workflows are reevaluated counts. This PR fixes this issue by avoiding setting the `s:in-progress` label when mergify does the commit and by setting the `s:review-needed` label instead when a PR is in queue position 0 and mergify does a commit, effectively triggering the CI but leaving the `s:accepted` label untouched. The `s:review-needed` label is removed by Mergify shortly after setting it.
### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References
- https://github.com/zeitgeistpm/zeitgeist/pull/1244
