### PR TITLE
Fix neo-swaps doc strings

### DIFF
--- a/zrml/neo-swaps/src/lib.rs
+++ b/zrml/neo-swaps/src/lib.rs
@@ -164,7 +164,8 @@ mod pallet {
             external_fee_amount: BalanceOf<T>,
         },
         /// Informant sold a position. `amount_out` is the amount of collateral received by `who`,
-        /// including swap and external fees.
+        /// with swap and external fees not yet deducted. The actual amount received is
+        /// `amount_out - swap_fee_amount - external_fee_amount`.
         SellExecuted {
             who: T::AccountId,
             market_id: MarketIdOf<T>,

--- a/zrml/neo-swaps/src/lib.rs
+++ b/zrml/neo-swaps/src/lib.rs
@@ -126,8 +126,8 @@ mod pallet {
 
         type WeightInfo: WeightInfoZeitgeist;
 
-        /// The maximum allowed liquidity tree depth per pool. Each pool can support `2^(depth + 1)
-        /// - 1` liquidity providers. **Must** be less than 16.
+        /// The maximum allowed liquidity tree depth per pool. Each pool can support 
+        /// `2^(depth + 1) - 1` liquidity providers. **Must** be less than 16.
         #[pallet::constant]
         type MaxLiquidityTreeDepth: Get<u32>;
 

--- a/zrml/neo-swaps/src/lib.rs
+++ b/zrml/neo-swaps/src/lib.rs
@@ -126,7 +126,7 @@ mod pallet {
 
         type WeightInfo: WeightInfoZeitgeist;
 
-        /// The maximum allowed liquidity tree depth per pool. Each pool can support 
+        /// The maximum allowed liquidity tree depth per pool. Each pool can support
         /// `2^(depth + 1) - 1` liquidity providers. **Must** be less than 16.
         #[pallet::constant]
         type MaxLiquidityTreeDepth: Get<u32>;


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Clarifies the meaning of the fields in `SellExecuted` and fixes a line break in another doc string to make it look better in the documentation.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

