### PR TITLE
Only run copyright CI when merging into `main`

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,0 +1,34 @@
+name: Copyright
+
+on:
+  pull_request:
+    types: [ labeled ]
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  copyright:
+    name: Copyright Notices
+    if: |
+      github.event_name == 'pull_request' && 
+        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
+        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
+      github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+      - name: Install check-license and dependencies
+        run: |
+          pip install scripts/check-license
+          pip install -r scripts/check-license/requirements.txt
+      - name: Query files changed
+        id: files_changed
+        uses: Ana06/get-changed-files@v1.2
+        with:
+          filter: '*.rs$'
+      - name: Check copyright notices
+        run: check-license ${{ steps.files_changed.outputs.added_modified }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,31 +36,6 @@ jobs:
       - name: Format
         run: ./scripts/tests/format.sh --check
 
-  copyright:
-    name: Copyright Notices
-    if: |
-      github.event_name == 'pull_request' && 
-        (contains(github.event.pull_request.labels.*.name, 's:review-needed') ||
-        contains(github.event.pull_request.labels.*.name, 's:accepted')) ||
-      github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-      - name: Install check-license and dependencies
-        run: |
-          pip install scripts/check-license
-          pip install -r scripts/check-license/requirements.txt
-      - name: Query files changed
-        id: files_changed
-        uses: Ana06/get-changed-files@v1.2
-        with:
-          filter: '*.rs$'
-      - name: Check copyright notices
-        run: check-license ${{ steps.files_changed.outputs.added_modified }}
-
   checks:
     name: Checks
     if: |


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Only runs copyright CI when merging into `main`. We're making the assumption that all changes that are part of a PR actually "happened" in this PR. But in case of merges of `main` into feature branches, that is not the case.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

