### PR TITLE
Update toolchain to fix codecov errors

### DIFF
--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Forecasting Technologies LTD.
+// Copyright 2023-2024 Forecasting Technologies LTD.
 // Copyright 2021-2022 Zeitgeist PM LLC.
 //
 // This file is part of Zeitgeist.

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -283,7 +283,7 @@ pub fn inherent_benchmark_data() -> Result<InherentData> {
     let timestamp = sp_timestamp::InherentDataProvider::new(d.into());
 
     futures::executor::block_on(timestamp.provide_inherent_data(&mut inherent_data))
-        .map_err(|e| format!("creating inherent data: {:?}", e))?;
+        .map_err(|e| format!("creating inherent data: {e:?}"))?;
 
     Ok(inherent_data)
 }

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Forecasting Technologies LTD.
+// Copyright 2022-2024 Forecasting Technologies LTD.
 // Copyright 2021-2022 Zeitgeist PM LLC.
 //
 // This file is part of Zeitgeist.

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -207,7 +207,7 @@ where
 
 #[cfg(feature = "with-battery-station-runtime")]
 fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
+    TPublic::Pair::from_string(&format!("//{seed}"), None)
         .expect("static values are valid; qed")
         .public()
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -299,7 +299,7 @@ pub fn run() -> sc_cli::Result<()> {
                     BlockId::Number(number) => match client.block_hash(number) {
                         Ok(Some(hash)) => hash,
                         Ok(None) => return Err("Unknown block".into()),
-                        Err(e) => return Err(format!("Error reading block: {:?}", e).into()),
+                        Err(e) => return Err(format!("Error reading block: {e:?}").into()),
                     },
                 };
 
@@ -309,7 +309,7 @@ pub fn run() -> sc_cli::Result<()> {
                         Ok(())
                     }
                     Ok(None) => Err("Unknown block".into()),
-                    Err(e) => Err(format!("Error reading block: {:?}", e).into()),
+                    Err(e) => Err(format!("Error reading block: {e:?}").into()),
                 }
             })
         }
@@ -414,7 +414,7 @@ pub fn run() -> sc_cli::Result<()> {
                     &polkadot_cli,
                     config.tokio_handle.clone(),
                 )
-                .map_err(|err| format!("Relay chain argument error: {}", err))?;
+                .map_err(|err| format!("Relay chain argument error: {err}"))?;
 
                 cmd.run(config, polkadot_config)
             })
@@ -521,13 +521,13 @@ fn none_command(cli: Cli) -> sc_cli::Result<()> {
         let state_version = Cli::native_runtime_version(chain_spec).state_version();
         let block: zeitgeist_runtime::Block =
             cumulus_client_cli::generate_genesis_block(&**chain_spec, state_version)
-                .map_err(|e| format!("{:?}", e))?;
+                .map_err(|e| format!("{e:?}"))?;
         let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
 
         let tokio_handle = parachain_config.tokio_handle.clone();
         let polkadot_config =
             SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
-                .map_err(|err| format!("Relay chain argument error: {}", err))?;
+                .map_err(|err| format!("Relay chain argument error: {err}"))?;
 
         log::info!("Parachain id: {:?}", parachain_id);
         log::info!("Parachain Account: {}", parachain_account);

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Forecasting Technologies LTD.
+// Copyright 2022-2024 Forecasting Technologies LTD.
 // Copyright 2021-2022 Zeitgeist PM LLC.
 // Copyright 2019-2022 PureStake Inc.
 //

--- a/primitives/src/math/fixed.rs
+++ b/primitives/src/math/fixed.rs
@@ -303,7 +303,7 @@ impl<F: Fixed + ToString, N: TryFrom<u128>> FromFixedToDecimal<F> for N {
             Ordering::Equal => frac_part.to_string(),
         };
 
-        let mut fixed_decimal: u128 = format!("{}{}", int_part, new_frac_part)
+        let mut fixed_decimal: u128 = format!("{int_part}{new_frac_part}")
             .parse::<u128>()
             .map_err(|_| "Failed to parse the fixed decimal representation into u128")?;
         if increment_int_part {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-08-23"
+channel = "nightly-2023-02-01"
 components = ["clippy", "rustfmt", "llvm-tools-preview"]
 profile = "minimal"
 targets = ["wasm32-unknown-unknown"]

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -1068,8 +1068,7 @@ mod pallet {
                 let (imbalance, missing) = T::Currency::slash(ai, slashable);
                 debug_assert!(
                     missing.is_zero(),
-                    "Could not slash all of the amount for juror {:?}.",
-                    ai
+                    "Could not slash all of the amount for juror {ai:?}.",
                 );
                 T::Currency::resolve_creating(&reward_pot, imbalance);
             };
@@ -2018,8 +2017,7 @@ mod pallet {
                         total_imb.subsume(imb);
                         debug_assert!(
                             missing.is_zero(),
-                            "Could not slash all of the amount for delegator {:?}.",
-                            delegator
+                            "Could not slash all of the amount for delegator {delegator:?}.",
                         );
                     }
                     total_imb
@@ -2047,8 +2045,7 @@ mod pallet {
                             total_incentives.subsume(imb);
                             debug_assert!(
                                 missing.is_zero(),
-                                "Could not slash all of the amount for juror {:?}.",
-                                juror
+                                "Could not slash all of the amount for juror {juror:?}.",
                             );
 
                             let imb = slash_all_delegators(delegations.as_slice());

--- a/zrml/global-disputes/src/lib.rs
+++ b/zrml/global-disputes/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Forecasting Technologies LTD.
+// Copyright 2022-2024 Forecasting Technologies LTD.
 //
 // This file is part of Zeitgeist.
 //

--- a/zrml/global-disputes/src/lib.rs
+++ b/zrml/global-disputes/src/lib.rs
@@ -733,8 +733,8 @@ mod pallet {
             } else {
                 log::error!(
                     target: LOG_TARGET,
-                    "There should be always at least one owner for a voting \
-                     outcome. This can also happen if reward is smaller than owners_len."
+                    "There should be always at least one owner for a voting outcome. This can \
+                     also happen if reward is smaller than owners_len."
                 );
                 debug_assert!(false);
             }

--- a/zrml/neo-swaps/src/benchmarking.rs
+++ b/zrml/neo-swaps/src/benchmarking.rs
@@ -268,7 +268,7 @@ where
         complete_set_amount,
     ));
     assert_ok!(NeoSwaps::<T>::join(
-        RawOrigin::Signed(caller.clone()).into(),
+        RawOrigin::Signed(caller).into(),
         market_id,
         pool_shares_amount,
         vec![u128::MAX.saturated_into(); pool.assets().len()]
@@ -334,7 +334,7 @@ mod benchmarks {
         let base_asset = Asset::Ztg;
         let asset_count = n.try_into().unwrap();
         let market_id = create_market_and_deploy_pool::<T>(
-            alice.clone(),
+            alice,
             base_asset,
             asset_count,
             _10.saturated_into(),
@@ -366,7 +366,7 @@ mod benchmarks {
         let base_asset = Asset::Ztg;
         let asset_count = n.try_into().unwrap();
         let market_id = create_market_and_deploy_pool::<T>(
-            alice.clone(),
+            alice,
             base_asset,
             asset_count,
             _10.saturated_into(),
@@ -398,7 +398,7 @@ mod benchmarks {
         let base_asset = Asset::Ztg;
         let asset_count = n.try_into().unwrap();
         let market_id = create_market_and_deploy_pool::<T>(
-            alice.clone(),
+            alice,
             base_asset,
             asset_count,
             _10.saturated_into(),
@@ -436,7 +436,7 @@ mod benchmarks {
         let base_asset = Asset::Ztg;
         let asset_count = n.try_into().unwrap();
         let market_id = create_market_and_deploy_pool::<T>(
-            alice.clone(),
+            alice,
             base_asset,
             asset_count,
             _10.saturated_into(),
@@ -460,12 +460,8 @@ mod benchmarks {
     #[benchmark]
     fn withdraw_fees() {
         let alice: T::AccountId = whitelisted_caller();
-        let market_id = create_market_and_deploy_pool::<T>(
-            alice.clone(),
-            Asset::Ztg,
-            2u16,
-            _10.saturated_into(),
-        );
+        let market_id =
+            create_market_and_deploy_pool::<T>(alice, Asset::Ztg, 2u16, _10.saturated_into());
         let helper = BenchmarkHelper::<T>::new();
         let bob = helper.accounts().next().unwrap();
         helper.populate_liquidity_tree_until_full(market_id, bob.clone());

--- a/zrml/neo-swaps/src/mock.rs
+++ b/zrml/neo-swaps/src/mock.rs
@@ -24,7 +24,7 @@
 )]
 
 use crate as zrml_neo_swaps;
-use crate::{consts::*, AssetOf, MarketIdOf};
+use crate::{consts::*, AssetOf, BalanceOf, MarketIdOf};
 use core::marker::PhantomData;
 use frame_support::{
     construct_runtime, ord_parameter_types, parameter_types,
@@ -65,7 +65,6 @@ use zeitgeist_primitives::{
         Hash, Index, MarketId, Moment, UncheckedExtrinsicTest,
     },
 };
-use zrml_neo_swaps::BalanceOf;
 
 pub const ALICE: AccountIdTest = 0;
 #[allow(unused)]

--- a/zrml/neo-swaps/src/tests/buy.rs
+++ b/zrml/neo-swaps/src/tests/buy.rs
@@ -31,7 +31,7 @@ fn buy_works() {
             BASE_ASSET,
             MarketType::Categorical(2),
             liquidity,
-            spot_prices.clone(),
+            spot_prices,
             swap_fee,
         );
         let pool = Pools::<Runtime>::get(market_id).unwrap();

--- a/zrml/neo-swaps/src/tests/liquidity_tree_interactions.rs
+++ b/zrml/neo-swaps/src/tests/liquidity_tree_interactions.rs
@@ -27,7 +27,7 @@ fn withdraw_fees_interacts_correctly_with_join() {
             BASE_ASSET,
             MarketType::Categorical(category_count),
             _10,
-            spot_prices.clone(),
+            spot_prices,
             CENT,
         );
 

--- a/zrml/neo-swaps/src/tests/liquidity_tree_interactions.rs
+++ b/zrml/neo-swaps/src/tests/liquidity_tree_interactions.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Forecasting Technologies LTD.
+// Copyright 2023-2024 Forecasting Technologies LTD.
 //
 // This file is part of Zeitgeist.
 //

--- a/zrml/neo-swaps/src/tests/mod.rs
+++ b/zrml/neo-swaps/src/tests/mod.rs
@@ -92,7 +92,7 @@ fn create_market_and_deploy_pool(
         RuntimeOrigin::signed(ALICE),
         market_id,
         amount,
-        spot_prices.clone(),
+        spot_prices,
         swap_fee,
     ));
     market_id

--- a/zrml/neo-swaps/src/tests/mod.rs
+++ b/zrml/neo-swaps/src/tests/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Forecasting Technologies LTD.
+// Copyright 2023-2024 Forecasting Technologies LTD.
 //
 // This file is part of Zeitgeist.
 //

--- a/zrml/neo-swaps/src/tests/sell.rs
+++ b/zrml/neo-swaps/src/tests/sell.rs
@@ -29,7 +29,7 @@ fn sell_works() {
             BASE_ASSET,
             MarketType::Scalar(0..=1),
             liquidity,
-            spot_prices.clone(),
+            spot_prices,
             swap_fee,
         );
         let pool = Pools::<Runtime>::get(market_id).unwrap();

--- a/zrml/orderbook/src/benchmarks.rs
+++ b/zrml/orderbook/src/benchmarks.rs
@@ -52,7 +52,7 @@ fn order_common_parameters<T: Config>(
     let acc = generate_funded_account::<T>(seed, maker_asset)?;
     let maker_amount: BalanceOf<T> = BASE.saturating_mul(1_000).saturated_into();
     let taker_amount: BalanceOf<T> = BASE.saturating_mul(1_000).saturated_into();
-    T::MarketCommons::push_market(market.clone()).unwrap();
+    T::MarketCommons::push_market(market).unwrap();
     let market_id: MarketIdOf<T> = 0u32.into();
     Ok((market_id, acc, maker_asset, maker_amount, taker_amount))
 }

--- a/zrml/orderbook/src/benchmarks.rs
+++ b/zrml/orderbook/src/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Forecasting Technologies LTD.
+// Copyright 2023-2024 Forecasting Technologies LTD.
 // Copyright 2021-2022 Zeitgeist PM LLC.
 //
 // This file is part of Zeitgeist.

--- a/zrml/orderbook/src/lib.rs
+++ b/zrml/orderbook/src/lib.rs
@@ -443,7 +443,7 @@ mod pallet {
             Self::deposit_event(Event::OrderFilled {
                 order_id,
                 maker,
-                taker: taker.clone(),
+                taker,
                 filled_maker_amount: taker_fill,
                 filled_taker_amount: maker_fill,
                 unfilled_maker_amount: order_data.maker_amount,

--- a/zrml/orderbook/src/tests.rs
+++ b/zrml/orderbook/src/tests.rs
@@ -375,7 +375,7 @@ fn place_order_fails_if_market_base_asset_not_present() {
     ExtBuilder::default().build().execute_with(|| {
         let market_id = 0u128;
         let market = market_mock::<Runtime>();
-        Markets::<Runtime>::insert(market_id, market.clone());
+        Markets::<Runtime>::insert(market_id, market);
 
         let maker_asset = Asset::CategoricalOutcome(0, 1);
         let taker_asset = Asset::CategoricalOutcome(0, 2);

--- a/zrml/parimutuel/src/benchmarking.rs
+++ b/zrml/parimutuel/src/benchmarking.rs
@@ -36,7 +36,7 @@ fn setup_market<T: Config>(market_type: MarketType) -> MarketIdOf<T> {
     let mut market = market_mock::<T>(market_creator);
     market.market_type = market_type;
     market.status = MarketStatus::Active;
-    T::MarketCommons::push_market(market.clone()).unwrap();
+    T::MarketCommons::push_market(market).unwrap();
     market_id
 }
 

--- a/zrml/parimutuel/src/benchmarking.rs
+++ b/zrml/parimutuel/src/benchmarking.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Forecasting Technologies LTD.
+// Copyright 2023-2024 Forecasting Technologies LTD.
 //
 // This file is part of Zeitgeist.
 //

--- a/zrml/parimutuel/src/lib.rs
+++ b/zrml/parimutuel/src/lib.rs
@@ -276,15 +276,16 @@ mod pallet {
             if payoff < winning_balance {
                 log::debug!(
                     target: LOG_TARGET,
-                    "The payoff in base asset should be greater than or equal to the winning outcome \
-                    balance."
+                    "The payoff in base asset should be greater than or equal to the winning \
+                     outcome balance."
                 );
                 debug_assert!(false);
             }
             if pot_total < payoff {
                 log::debug!(
                     target: LOG_TARGET,
-                    "The payoff in base asset should not exceed the total amount of the base asset!"
+                    "The payoff in base asset should not exceed the total amount of the base \
+                     asset!"
                 );
                 debug_assert!(false);
             }
@@ -415,7 +416,7 @@ mod pallet {
                 asset: winning_asset,
                 withdrawn_asset_balance,
                 base_asset_payoff,
-                sender: who.clone(),
+                sender: who,
             });
 
             Ok(())
@@ -439,9 +440,9 @@ mod pallet {
             if refund_asset == winning_asset {
                 log::debug!(
                     target: LOG_TARGET,
-                    "Since we were checking the total issuance of the winning asset to be zero, if \
-                     the refund balance is non-zero, then the winning asset can't be the refund \
-                     asset!"
+                    "Since we were checking the total issuance of the winning asset to be zero, \
+                     if the refund balance is non-zero, then the winning asset can't be the \
+                     refund asset!"
                 );
                 debug_assert!(false);
             }
@@ -465,7 +466,7 @@ mod pallet {
                 market_id,
                 asset: refund_asset,
                 refunded_balance: refund_balance,
-                sender: who.clone(),
+                sender: who,
             });
 
             Ok(())

--- a/zrml/parimutuel/src/tests/buy.rs
+++ b/zrml/parimutuel/src/tests/buy.rs
@@ -90,7 +90,7 @@ fn buy_fails_if_asset_not_parimutuel_share() {
         let market_id = 0;
         let mut market = market_mock::<Runtime>(MARKET_CREATOR);
         market.status = MarketStatus::Active;
-        Markets::<Runtime>::insert(market_id, market.clone());
+        Markets::<Runtime>::insert(market_id, market);
 
         let asset = Asset::CategoricalOutcome(market_id, 0u16);
         let amount = <Runtime as Config>::MinBetSize::get();
@@ -110,7 +110,7 @@ fn buy_fails_if_invalid_scoring_rule(scoring_rule: ScoringRule) {
         market.status = MarketStatus::Active;
         market.scoring_rule = scoring_rule;
 
-        Markets::<Runtime>::insert(market_id, market.clone());
+        Markets::<Runtime>::insert(market_id, market);
 
         let asset = Asset::ParimutuelShare(market_id, 0u16);
         let amount = <Runtime as Config>::MinBetSize::get();
@@ -132,7 +132,7 @@ fn buy_fails_if_market_status_is_not_active(status: MarketStatus) {
         market.status = status;
         market.scoring_rule = ScoringRule::Parimutuel;
 
-        Markets::<Runtime>::insert(market_id, market.clone());
+        Markets::<Runtime>::insert(market_id, market);
 
         let asset = Asset::ParimutuelShare(market_id, 0u16);
         let amount = <Runtime as Config>::MinBetSize::get();
@@ -189,7 +189,7 @@ fn buy_fails_if_below_minimum_bet_size() {
         let market_id = 0;
         let mut market = market_mock::<Runtime>(MARKET_CREATOR);
         market.status = MarketStatus::Active;
-        Markets::<Runtime>::insert(market_id, market.clone());
+        Markets::<Runtime>::insert(market_id, market);
 
         let asset = Asset::ParimutuelShare(market_id, 0u16);
         let amount = <Runtime as Config>::MinBetSize::get() - 1;

--- a/zrml/prediction-markets/src/benchmarks.rs
+++ b/zrml/prediction-markets/src/benchmarks.rs
@@ -1083,7 +1083,7 @@ benchmarks! {
         )?;
 
         Pallet::<T>::dispute_early_close(
-            RawOrigin::Signed(caller.clone()).into(),
+            RawOrigin::Signed(caller).into(),
             market_id,
         )?;
 
@@ -1106,7 +1106,6 @@ benchmarks! {
         )?;
 
         let market = zrml_market_commons::Pallet::<T>::market(&market_id)?;
-        let market_creator = market.creator.clone();
 
         for i in 0..o {
             MarketIdsPerCloseTimeFrame::<T>::try_mutate(
@@ -1125,7 +1124,7 @@ benchmarks! {
             ).unwrap();
         }
 
-        let origin = RawOrigin::Signed(market_creator).into();
+        let origin = RawOrigin::Signed(market.creator).into();
         let call = Call::<T>::schedule_early_close { market_id };
     }: { call.dispatch_bypass_filter(origin)? }
 
@@ -1143,10 +1142,8 @@ benchmarks! {
             Some(MarketDisputeMechanism::Court),
         )?;
 
-        let market_creator = caller.clone();
-
         Pallet::<T>::schedule_early_close(
-            RawOrigin::Signed(market_creator.clone()).into(),
+            RawOrigin::Signed(caller.clone()).into(),
             market_id,
         )?;
 
@@ -1176,7 +1173,7 @@ benchmarks! {
             ).unwrap();
         }
 
-        let origin = RawOrigin::Signed(market_creator).into();
+        let origin = RawOrigin::Signed(caller).into();
         let call = Call::<T>::dispute_early_close { market_id };
     }: { call.dispatch_bypass_filter(origin)? }
 
@@ -1193,8 +1190,6 @@ benchmarks! {
             Some(MarketPeriod::Timestamp(range_start..old_range_end)),
             Some(MarketDisputeMechanism::Court),
         )?;
-
-        let market_creator = caller.clone();
 
         let close_origin = T::CloseMarketEarlyOrigin::try_successful_origin().unwrap();
         Pallet::<T>::schedule_early_close(
@@ -1242,15 +1237,13 @@ benchmarks! {
             Some(MarketDisputeMechanism::Court),
         )?;
 
-        let market_creator = caller.clone();
-
         Pallet::<T>::schedule_early_close(
-            RawOrigin::Signed(market_creator.clone()).into(),
+            RawOrigin::Signed(caller.clone()).into(),
             market_id,
         )?;
 
         Pallet::<T>::dispute_early_close(
-            RawOrigin::Signed(caller.clone()).into(),
+            RawOrigin::Signed(caller).into(),
             market_id,
         )?;
 

--- a/zrml/prediction-markets/src/lib.rs
+++ b/zrml/prediction-markets/src/lib.rs
@@ -130,10 +130,12 @@ mod pallet {
                     debug_assert!(false, "{}", warning);
                     return Ok(());
                 }
-                let missing = T::Currency::unreserve_named(&Self::reserve_id(), &bond.who, bond.value);
+                let missing =
+                    T::Currency::unreserve_named(&Self::reserve_id(), &bond.who, bond.value);
                 debug_assert!(
                     missing.is_zero(),
-                    "Could not unreserve all of the amount. reserve_id: {:?}, who: {:?}, value: {:?}.",
+                    "Could not unreserve all of the amount. reserve_id: {:?}, who: {:?}, value: \
+                     {:?}.",
                     &Self::reserve_id(),
                     &bond.who,
                     bond.value,
@@ -204,8 +206,8 @@ mod pallet {
                     );
                     debug_assert!(
                         missing.is_zero(),
-                        "Could not unreserve all of the amount. reserve_id: {:?}, \
-                         who: {:?}, amount: {:?}, missing: {:?}",
+                        "Could not unreserve all of the amount. reserve_id: {:?}, who: {:?}, \
+                         amount: {:?}, missing: {:?}",
                         Self::reserve_id(),
                         &bond.who,
                         unreserve_amount,
@@ -890,7 +892,7 @@ mod pallet {
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin.clone())?;
             let current_block = <frame_system::Pallet<T>>::block_number();
-            let market_report = Report { at: current_block, by: sender.clone(), outcome };
+            let market_report = Report { at: current_block, by: sender, outcome };
             let market = <zrml_market_commons::Pallet<T>>::market(&market_id)?;
             ensure!(market.report.is_none(), Error::<T>::MarketAlreadyReported);
             Self::ensure_market_is_closed(&market)?;
@@ -2112,7 +2114,7 @@ mod pallet {
                 period,
                 deadlines,
                 metadata,
-                creation.clone(),
+                creation,
                 market_type,
                 dispute_mechanism,
                 scoring_rule,

--- a/zrml/prediction-markets/src/tests/schedule_early_close.rs
+++ b/zrml/prediction-markets/src/tests/schedule_early_close.rs
@@ -54,7 +54,7 @@ fn schedule_early_close_emits_event() {
         System::assert_last_event(
             Event::MarketEarlyCloseScheduled {
                 market_id,
-                new_period: new_period.clone(),
+                new_period,
                 state: EarlyCloseState::ScheduledAsOther,
             }
             .into(),

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -159,12 +159,9 @@ fn rikiddo_pallet_fee_return_correct_result() {
         let max_difference = max_balance_difference(frac_dec_places, 0.3);
         assert!(
             difference_abs <= max_difference,
-            "\nReference fee result (Balance): {}\nRikiddo pallet fee result (Balance): \
-             {}\nDifference: {}\nMax_Allowed_Difference: {}",
-            fee_reference_balance,
-            fee_pallet_balance,
-            difference_abs,
-            max_difference,
+            "\nReference fee result (Balance): {fee_reference_balance}\nRikiddo pallet fee result \
+             (Balance): {fee_pallet_balance}\nDifference: \
+             {difference_abs}\nMax_Allowed_Difference: {max_difference}",
         );
 
         // Now we check if the fee has changed, since enough volume data was collected
@@ -193,12 +190,9 @@ fn rikiddo_pallet_cost_returns_correct_result() {
         let max_difference = max_balance_difference(frac_dec_places, 0.3);
         assert!(
             difference_abs <= max_difference,
-            "\nReference cost result (Balance): {}\nRikiddo pallet cost result (Balance): \
-             {}\nDifference: {}\nMax_Allowed_Difference: {}",
-            cost_reference_balance,
-            cost_pallet_balance,
-            difference_abs,
-            max_difference,
+            "\nReference cost result (Balance): {cost_reference_balance}\nRikiddo pallet cost \
+             result (Balance): {cost_pallet_balance}\nDifference: \
+             {difference_abs}\nMax_Allowed_Difference: {difference_abs}",
         );
 
         // The second part also compares the cost results, but uses the sigmoid fee.
@@ -213,12 +207,9 @@ fn rikiddo_pallet_cost_returns_correct_result() {
         let max_difference_with_fee = max_balance_difference(frac_dec_places, 0.3);
         assert!(
             difference_abs_with_fee <= max_difference_with_fee,
-            "\nReference cost result (Balance): {}\nRikiddo pallet cost result (Balance): \
-             {}\nDifference: {}\nMax_Allowed_Difference: {}",
-            cost_reference_balance_with_fee,
-            cost_pallet_balance_with_fee,
-            difference_abs_with_fee,
-            max_difference_with_fee,
+            "\nReference cost result (Balance): {cost_reference_balance_with_fee}\nRikiddo pallet \
+             cost result (Balance): {cost_pallet_balance_with_fee}\nDifference: \
+             {difference_abs_with_fee}\nMax_Allowed_Difference: {max_difference_with_fee}",
         );
     });
 }
@@ -266,12 +257,9 @@ fn rikiddo_pallet_price_returns_correct_result() {
         let max_difference = max_balance_difference(frac_dec_places, 0.3);
         assert!(
             difference_abs <= max_difference,
-            "\nReference price result (Balance): {}\nRikiddo pallet price result (Balance): \
-             {}\nDifference: {}\nMax_Allowed_Difference: {}",
-            price_reference_balance,
-            price_pallet_balance,
-            difference_abs,
-            max_difference,
+            "\nReference price result (Balance): {price_reference_balance}\nRikiddo pallet price \
+             result (Balance): {price_pallet_balance}\nDifference: \
+             {difference_abs}\nMax_Allowed_Difference: {max_difference}",
         );
 
         // The second part also compares the price results, but uses the sigmoid fee.
@@ -286,12 +274,9 @@ fn rikiddo_pallet_price_returns_correct_result() {
         let max_difference_fee = max_balance_difference(frac_dec_places, 0.3);
         assert!(
             difference_abs_fee <= max_difference_fee,
-            "\nReference price result (Balance): {}\nRikiddo pallet price result (Balance): \
-             {}\nDifference: {}\nMax_Allowed_Difference: {}",
-            price_reference_balance_fee,
-            price_pallet_balance_fee,
-            difference_abs_fee,
-            max_difference_fee,
+            "\nReference price result (Balance): {price_reference_balance_fee}\nRikiddo pallet \
+             price result (Balance): {price_pallet_balance_fee}\nDifference: \
+             {difference_abs_fee}\nMax_Allowed_Difference: {max_difference_fee}",
         );
     });
 }
@@ -321,12 +306,9 @@ fn rikiddo_pallet_all_prices_returns_correct_result() {
             asset_balances.len() as u128 * max_balance_difference(frac_dec_places, 0.3);
         assert!(
             difference_abs <= max_difference,
-            "\nReference all_prices result (Balance): {:?}\nRikiddo all_prices result (Balance): \
-             {:?}\nDifference: {}\nMax_Allowed_Difference: {}",
-            all_prices_reference_balance,
-            all_prices_pallet_balance,
-            difference_abs,
-            max_difference,
+            "\nReference all_prices result (Balance): {all_prices_reference_balance:?}\nRikiddo \
+             all_prices result (Balance): {all_prices_pallet_balance:?}\nDifference: \
+             {difference_abs}\nMax_Allowed_Difference: {max_difference}",
         );
 
         // The second part also compares the price results for all prices, but uses
@@ -350,12 +332,10 @@ fn rikiddo_pallet_all_prices_returns_correct_result() {
             asset_balances.len() as u128 * max_balance_difference(frac_dec_places, 0.3);
         assert!(
             difference_abs_fee <= max_difference_fee,
-            "\nReference all_prices result (Balance): {:?}\nRikiddo pallet all_prices result \
-             (Balance): {:?}\nDifference: {}\nMax_Allowed_Difference: {}",
-            all_prices_reference_balance_fee,
-            all_prices_pallet_balance_fee,
-            difference_abs_fee,
-            max_difference_fee,
+            "\nReference all_prices result (Balance): \
+             {all_prices_reference_balance_fee:?}\nRikiddo pallet all_prices result (Balance): \
+             {all_prices_pallet_balance_fee:?}\nDifference: \
+             {difference_abs_fee}\nMax_Allowed_Difference: {max_difference_fee}",
         );
     });
 }

--- a/zrml/rikiddo/src/tests/pallet.rs
+++ b/zrml/rikiddo/src/tests/pallet.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Forecasting Technologies LTD.
+// Copyright 2022, 2024 Forecasting Technologies LTD.
 // Copyright 2021-2022 Zeitgeist PM LLC.
 //
 // This file is part of Zeitgeist.

--- a/zrml/swaps/src/benchmarks.rs
+++ b/zrml/swaps/src/benchmarks.rs
@@ -81,14 +81,9 @@ where
 {
     let (assets, asset_amount) = generate_assets::<T>(&caller, asset_count, opt_asset_amount);
     let weights = opt_weights.unwrap_or_else(|| vec![T::MinWeight::get(); asset_count]);
-    let pool_id = Pallet::<T>::create_pool(
-        caller.clone(),
-        assets.clone(),
-        Zero::zero(),
-        asset_amount,
-        weights,
-    )
-    .unwrap();
+    let pool_id =
+        Pallet::<T>::create_pool(caller, assets.clone(), Zero::zero(), asset_amount, weights)
+            .unwrap();
     if open {
         Pallet::<T>::open_pool(pool_id).unwrap();
     }

--- a/zrml/swaps/src/lib.rs
+++ b/zrml/swaps/src/lib.rs
@@ -899,7 +899,7 @@ mod pallet {
                 pool_account_id: &pool_account_id,
                 pool_id,
                 pool: &pool,
-                who: who.clone(),
+                who,
             };
 
             swap_exact_amount::<_, _, T>(params)

--- a/zrml/swaps/src/tests.rs
+++ b/zrml/swaps/src/tests.rs
@@ -1623,7 +1623,7 @@ fn create_pool_fails_on_too_many_assets() {
         });
 
         assert_noop!(
-            Swaps::create_pool(BOB, assets.clone(), 0, DEFAULT_LIQUIDITY, weights,),
+            Swaps::create_pool(BOB, assets, 0, DEFAULT_LIQUIDITY, weights),
             Error::<Runtime>::TooManyAssets
         );
     });


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

Updates toolchain to rustc nightly-2023-02-01. Not going any further right now because of the [removal of stdsimd](https://github.com/rust-lang/rust/commit/ea37e8091fe87ae0a7e204c034e7d55061e56790) which some of our dependencies use.

The second commit fixes the usual "unnecessary `clone()`" and string formatting errors that clippy produces after an update.

### What important points should reviewers know?

Please ensure that all tests and benchmarks pass in case the CI fails to verify this.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

