### PR TITLE
Add previous stake information after rejoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14559,6 +14559,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "test-case",
+ "zeitgeist-macros",
  "zeitgeist-primitives",
  "zrml-market-commons",
 ]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Zeitgeist. If not, see <https://www.gnu.org/licenses/>.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 /// Creates an `alloc::collections::BTreeMap` from the pattern `{ key => value, ... }`.
 ///
 /// ```ignore

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -55,12 +55,15 @@ macro_rules! decl_common_types {
         use orml_traits::MultiCurrency;
         use sp_runtime::{generic, DispatchError, DispatchResult, SaturatedConversion};
         use zeitgeist_primitives::traits::{DeployPoolApi, DistributeFees, MarketCommonsPalletApi};
+        use zrml_court::migrations::MigrateCourtPoolItems;
 
         pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 
         type Address = sp_runtime::MultiAddress<AccountId, ()>;
 
-        type Migrations = ();
+        type Migrations = (
+            MigrateCourtPoolItems<Runtime>,
+        );
 
         pub type Executive = frame_executive::Executive<
             Runtime,

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -61,9 +61,7 @@ macro_rules! decl_common_types {
 
         type Address = sp_runtime::MultiAddress<AccountId, ()>;
 
-        type Migrations = (
-            MigrateCourtPoolItems<Runtime>,
-        );
+        type Migrations = (MigrateCourtPoolItems<Runtime>,);
 
         pub type Executive = frame_executive::Executive<
             Runtime,

--- a/zrml/court/Cargo.toml
+++ b/zrml/court/Cargo.toml
@@ -9,6 +9,7 @@ rand_chacha = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 sp-arithmetic = { workspace = true }
 sp-runtime = { workspace = true }
+zeitgeist-macros = { workspace = true }
 zeitgeist-primitives = { workspace = true }
 zrml-market-commons = { workspace = true }
 

--- a/zrml/court/src/benchmarks.rs
+++ b/zrml/court/src/benchmarks.rs
@@ -127,9 +127,8 @@ where
             court_participant: juror.clone(),
             consumed_stake,
             joined_at,
-            last_join_at: joined_at,
-            pre_period_join_at: joined_at,
-            pre_period_join_stake: stake,
+            uneligible_index: 0u64.saturated_into::<T::BlockNumber>(),
+            uneligible_stake: stake,
         };
         match pool.binary_search_by_key(&(stake, &juror), |pool_item| {
             (pool_item.stake, &pool_item.court_participant)

--- a/zrml/court/src/benchmarks.rs
+++ b/zrml/court/src/benchmarks.rs
@@ -261,16 +261,6 @@ benchmarks! {
         let new_stake = T::MinJurorStake::get()
             .saturating_add(1u128.saturated_into::<BalanceOf<T>>());
     }: _(RawOrigin::Signed(caller.clone()), new_stake)
-    verify {
-        let now = <frame_system::Pallet<T>>::block_number();
-        let pool = CourtPool::<T>::get();
-        // joined_at did not change, because it was rewritten to the newly created pool item
-        assert_ne!(now, joined_at_before);
-        assert_eq!(
-            pool.into_inner().iter().find(|i| i.court_participant == caller).unwrap().joined_at,
-            joined_at_before,
-        );
-    }
 
     delegate {
         // jurors greater or equal to MaxDelegations,
@@ -303,16 +293,6 @@ benchmarks! {
         let new_stake = T::MinJurorStake::get()
             .saturating_add(1u128.saturated_into::<BalanceOf<T>>());
     }: _(RawOrigin::Signed(caller.clone()), new_stake, delegations)
-    verify {
-        let now = <frame_system::Pallet<T>>::block_number();
-        let pool = CourtPool::<T>::get();
-        // joined_at did not change, because it was rewritten to the newly created pool item
-        assert_ne!(now, joined_at_before);
-        assert_eq!(
-            pool.into_inner().iter().find(|i| i.court_participant == caller).unwrap().joined_at,
-            joined_at_before,
-        );
-    }
 
     prepare_exit_court {
         let j in 0..(T::MaxCourtParticipants::get() - 1);

--- a/zrml/court/src/benchmarks.rs
+++ b/zrml/court/src/benchmarks.rs
@@ -268,6 +268,16 @@ benchmarks! {
         let new_stake = T::MinJurorStake::get()
             .saturating_add(1u128.saturated_into::<BalanceOf<T>>());
     }: _(RawOrigin::Signed(caller.clone()), new_stake)
+    verify {
+        let now = <frame_system::Pallet<T>>::block_number();
+        let pool = CourtPool::<T>::get();
+        // joined_at did not change, because it was rewritten to the newly created pool item
+        assert_ne!(now, joined_at_before);
+        assert_eq!(
+            pool.into_inner().iter().find(|i| i.court_participant == caller).unwrap().joined_at,
+            joined_at_before,
+        );
+    }
 
     delegate {
         // jurors greater or equal to MaxDelegations,
@@ -300,6 +310,16 @@ benchmarks! {
         let new_stake = T::MinJurorStake::get()
             .saturating_add(1u128.saturated_into::<BalanceOf<T>>());
     }: _(RawOrigin::Signed(caller.clone()), new_stake, delegations)
+    verify {
+        let now = <frame_system::Pallet<T>>::block_number();
+        let pool = CourtPool::<T>::get();
+        // joined_at did not change, because it was rewritten to the newly created pool item
+        assert_ne!(now, joined_at_before);
+        assert_eq!(
+            pool.into_inner().iter().find(|i| i.court_participant == caller).unwrap().joined_at,
+            joined_at_before,
+        );
+    }
 
     prepare_exit_court {
         let j in 0..(T::MaxCourtParticipants::get() - 1);

--- a/zrml/court/src/benchmarks.rs
+++ b/zrml/court/src/benchmarks.rs
@@ -128,7 +128,7 @@ where
             consumed_stake,
             joined_at,
             uneligible_index: 0u64.saturated_into::<T::BlockNumber>(),
-            uneligible_stake: stake,
+            uneligible_stake: BalanceOf::<T>::zero(),
         };
         match pool.binary_search_by_key(&(stake, &juror), |pool_item| {
             (pool_item.stake, &pool_item.court_participant)
@@ -676,7 +676,7 @@ benchmarks! {
         let j in 1..T::MaxCourtParticipants::get();
         fill_pool::<T>(j)?;
 
-        <frame_system::Pallet<T>>::set_block_number(T::InflationPeriod::get());
+        <frame_system::Pallet<T>>::set_block_number(T::InflationPeriod::get().saturating_mul(2u32.into()));
         let now = <frame_system::Pallet<T>>::block_number();
         YearlyInflation::<T>::put(Perbill::from_percent(2));
     }: {

--- a/zrml/court/src/benchmarks.rs
+++ b/zrml/court/src/benchmarks.rs
@@ -122,8 +122,15 @@ where
             },
         );
         let consumed_stake = BalanceOf::<T>::zero();
-        let pool_item =
-            CourtPoolItem { stake, court_participant: juror.clone(), consumed_stake, joined_at };
+        let pool_item = CourtPoolItem {
+            stake,
+            court_participant: juror.clone(),
+            consumed_stake,
+            joined_at,
+            last_join_at: joined_at,
+            pre_period_join_at: joined_at,
+            pre_period_join_stake: stake,
+        };
         match pool.binary_search_by_key(&(stake, &juror), |pool_item| {
             (pool_item.stake, &pool_item.court_participant)
         }) {

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -29,6 +29,7 @@ use crate::{
 };
 use alloc::{
     collections::{BTreeMap, BTreeSet},
+    format,
     vec::Vec,
 };
 use core::marker::PhantomData;

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -1228,7 +1228,6 @@ mod pallet {
 
             let mut active_lock = BalanceOf::<T>::zero();
             let mut consumed_stake = BalanceOf::<T>::zero();
-            let mut joined_at = now;
 
             if let Some(prev_p_info) = <Participants<T>>::get(who) {
                 ensure!(amount >= prev_p_info.stake, Error::<T>::AmountBelowLastJoin);
@@ -1238,7 +1237,6 @@ mod pallet {
                 {
                     active_lock = prev_p_info.active_lock;
                     consumed_stake = pool_item.consumed_stake;
-                    joined_at = pool_item.joined_at;
 
                     pool.remove(index);
                 } else {
@@ -1251,7 +1249,7 @@ mod pallet {
                 pool = remove_weakest_if_full(pool)?;
             }
 
-            let (active_lock, consumed_stake, joined_at) = (active_lock, consumed_stake, joined_at);
+            let (active_lock, consumed_stake) = (active_lock, consumed_stake);
 
             match pool.binary_search_by_key(&(amount, who), |pool_item| {
                 (pool_item.stake, &pool_item.court_participant)
@@ -1271,7 +1269,7 @@ mod pallet {
                             stake: amount,
                             court_participant: who.clone(),
                             consumed_stake,
-                            joined_at,
+                            joined_at: now,
                         },
                     )
                     .map_err(|_| {

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -203,7 +203,7 @@ mod pallet {
     /// Number of draws for the initial court round.
     const INITIAL_DRAWS_NUM: usize = 31;
     /// The current storage version.
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
     const LOG_TARGET: &str = "runtime::zrml-court";
     /// Weight used to increase the number of jurors for subsequent appeals
     /// of the same court.
@@ -212,6 +212,7 @@ mod pallet {
     const APPEAL_BOND_BASIS: u32 = 2;
 
     pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+    pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
     pub(crate) type BalanceOf<T> = <<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
     pub(crate) type NegativeImbalanceOf<T> =
         <<T as Config>::Currency as Currency<AccountIdOf<T>>>::NegativeImbalance;

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -1419,7 +1419,7 @@ mod pallet {
             let pool_len = pool.len() as u32;
             debug_assert!(!inflation_period.is_zero());
             let current_period_index =
-                now.checked_div(&inflation_period.saturating_add(One::one()));
+                now.checked_div(&inflation_period).map(|x| x.saturating_sub(One::one()));
             let eligible_stake = |pool_item: &CourtPoolItemOf<T>| match current_period_index {
                 Some(index) if index != pool_item.uneligible_index => pool_item.stake,
                 _ => pool_item.stake.saturating_sub(pool_item.uneligible_stake),

--- a/zrml/court/src/lib.rs
+++ b/zrml/court/src/lib.rs
@@ -1200,7 +1200,6 @@ mod pallet {
                 None => return Ok((amount, now)),
             };
 
-            // TODO check if this is correct when on_initialize is running at exactly this block
             let current_period_index = now
                 .checked_div(&T::InflationPeriod::get())
                 .ok_or(Error::<T>::Unexpected(UnexpectedError::InflationPeriodIsZero))?;

--- a/zrml/court/src/migrations.rs
+++ b/zrml/court/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 Zeitgeist PM LLC.
+// Copyright 2024 Forecasting Technologies LTD.
 //
 // This file is part of Zeitgeist.
 //
@@ -14,3 +14,211 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Zeitgeist. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    AccountIdOf, BalanceOf, BlockNumberOf, Config, CourtPoolItemOf, CourtPoolOf, Pallet as Court,
+};
+#[cfg(feature = "try-runtime")]
+use alloc::vec;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use frame_support::{
+    log,
+    pallet_prelude::{StorageVersion, ValueQuery, Weight},
+    traits::{Get, OnRuntimeUpgrade},
+    BoundedVec,
+};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+
+#[derive(Decode, Encode, MaxEncodedLen, TypeInfo, Clone, Debug, PartialEq, Eq)]
+pub struct OldCourtPoolItem<AccountId, Balance, BlockNumber> {
+    pub stake: Balance,
+    pub court_participant: AccountId,
+    pub consumed_stake: Balance,
+    pub joined_at: BlockNumber,
+}
+
+type OldCourtPoolItemOf<T> = OldCourtPoolItem<AccountIdOf<T>, BalanceOf<T>, BlockNumberOf<T>>;
+type OldCourtPoolOf<T> = BoundedVec<OldCourtPoolItemOf<T>, <T as Config>::MaxCourtParticipants>;
+
+#[frame_support::storage_alias]
+pub(crate) type CourtPool<T: Config> = StorageValue<Court<T>, OldCourtPoolOf<T>, ValueQuery>;
+
+const COURT_REQUIRED_STORAGE_VERSION: u16 = 2;
+const COURT_NEXT_STORAGE_VERSION: u16 = 3;
+
+pub struct MigrateCourtPoolItems<T>(PhantomData<T>);
+
+/// Migrates AMM and CDA markets to the new combined scoring rule.
+impl<T> OnRuntimeUpgrade for MigrateCourtPoolItems<T>
+where
+    T: Config,
+{
+    fn on_runtime_upgrade() -> Weight {
+        let mut total_weight = T::DbWeight::get().reads(1);
+        let market_commons_version = StorageVersion::get::<Court<T>>();
+        if market_commons_version != COURT_REQUIRED_STORAGE_VERSION {
+            log::info!(
+                "MigrateCourtPoolItems: court storage version is {:?}, but {:?} is required",
+                market_commons_version,
+                COURT_REQUIRED_STORAGE_VERSION,
+            );
+            return total_weight;
+        }
+        log::info!("MigrateCourtPoolItems: Starting...");
+
+        let res = crate::CourtPool::<T>::translate::<OldCourtPoolOf<T>, _>(|old_pool_opt| {
+            old_pool_opt.map(|mut old_pool| {
+                <CourtPoolOf<T>>::truncate_from(
+                    old_pool
+                        .iter_mut()
+                        .map(|old_pool_item: &mut OldCourtPoolItemOf<T>| CourtPoolItemOf::<T> {
+                            stake: old_pool_item.stake,
+                            court_participant: old_pool_item.court_participant.clone(),
+                            consumed_stake: old_pool_item.consumed_stake,
+                            joined_at: old_pool_item.joined_at,
+                            last_join_at: old_pool_item.joined_at,
+                            pre_period_join_stake: old_pool_item.stake,
+                            pre_period_join_at: old_pool_item.joined_at,
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            })
+        });
+        match res {
+            Ok(_) => log::info!("MigrateCourtPoolItems: Success!"),
+            Err(e) => log::error!("MigrateCourtPoolItems: Error: {:?}", e),
+        }
+
+        total_weight = total_weight.saturating_add(T::DbWeight::get().writes(1));
+
+        StorageVersion::new(COURT_NEXT_STORAGE_VERSION).put::<Court<T>>();
+        total_weight = total_weight.saturating_add(T::DbWeight::get().writes(1));
+        log::info!("MigrateCourtPoolItems: Done!");
+        total_weight
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+        log::info!("MigrateCourtPoolItems: Preparing to migrate old pool items...");
+        Ok(vec![])
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(_previous_state: Vec<u8>) -> Result<(), &'static str> {
+        let court_pool = crate::CourtPool::<T>::get();
+        log::info!(
+            "MigrateCourtPoolItems: post-upgrade executed. Migrated {:?} pool items",
+            court_pool.len()
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock::{ExtBuilder, Runtime};
+    use frame_support::storage_root;
+    use sp_runtime::StateVersion;
+
+    #[test]
+    fn on_runtime_upgrade_increments_the_storage_version() {
+        ExtBuilder::default().build().execute_with(|| {
+            set_up_version();
+            MigrateCourtPoolItems::<Runtime>::on_runtime_upgrade();
+            assert_eq!(StorageVersion::get::<Court<Runtime>>(), COURT_NEXT_STORAGE_VERSION);
+        });
+    }
+
+    #[test]
+    fn on_runtime_upgrade_works_as_expected() {
+        ExtBuilder::default().build().execute_with(|| {
+            set_up_version();
+            let stake_0 = 100;
+            let stake_1 = 101;
+            let court_participant = 200;
+            let consumed_stake = 300;
+            let joined_at_0 = 42;
+            let joined_at_1 = 123;
+            let old_court_pool = OldCourtPoolOf::<Runtime>::truncate_from(vec![
+                OldCourtPoolItemOf::<Runtime> {
+                    stake: stake_0,
+                    court_participant,
+                    consumed_stake,
+                    joined_at: joined_at_0,
+                },
+                OldCourtPoolItemOf::<Runtime> {
+                    stake: stake_1,
+                    court_participant,
+                    consumed_stake,
+                    joined_at: joined_at_1,
+                },
+            ]);
+            let new_court_pool = CourtPoolOf::<Runtime>::truncate_from(vec![
+                CourtPoolItemOf::<Runtime> {
+                    stake: stake_0,
+                    court_participant,
+                    consumed_stake,
+                    joined_at: joined_at_0,
+                    last_join_at: joined_at_0,
+                    pre_period_join_stake: stake_0,
+                    pre_period_join_at: joined_at_0,
+                },
+                CourtPoolItemOf::<Runtime> {
+                    stake: stake_1,
+                    court_participant,
+                    consumed_stake,
+                    joined_at: joined_at_1,
+                    last_join_at: joined_at_1,
+                    pre_period_join_stake: stake_1,
+                    pre_period_join_at: joined_at_1,
+                },
+            ]);
+            CourtPool::<Runtime>::put::<OldCourtPoolOf<Runtime>>(old_court_pool);
+            // notice we use the old storage item here to find out if we added the old elements
+            // decoding of the values would fail
+            assert_eq!(crate::CourtPool::<Runtime>::decode_len().unwrap(), 2usize);
+            MigrateCourtPoolItems::<Runtime>::on_runtime_upgrade();
+
+            let actual = crate::CourtPool::<Runtime>::get();
+            assert_eq!(actual, new_court_pool);
+        });
+    }
+
+    #[test]
+    fn on_runtime_upgrade_is_noop_if_versions_are_not_correct() {
+        ExtBuilder::default().build().execute_with(|| {
+            StorageVersion::new(COURT_NEXT_STORAGE_VERSION).put::<Court<Runtime>>();
+            let court_pool = <CourtPoolOf<Runtime>>::truncate_from(vec![
+                CourtPoolItemOf::<Runtime> {
+                    stake: 1,
+                    court_participant: 2,
+                    consumed_stake: 3,
+                    joined_at: 4,
+                    last_join_at: 4,
+                    pre_period_join_stake: 4,
+                    pre_period_join_at: 4,
+                },
+                CourtPoolItemOf::<Runtime> {
+                    stake: 8,
+                    court_participant: 9,
+                    consumed_stake: 10,
+                    joined_at: 11,
+                    last_join_at: 11,
+                    pre_period_join_stake: 11,
+                    pre_period_join_at: 11,
+                },
+            ]);
+            crate::CourtPool::<Runtime>::put(court_pool);
+            let tmp = storage_root(StateVersion::V1);
+            MigrateCourtPoolItems::<Runtime>::on_runtime_upgrade();
+            assert_eq!(tmp, storage_root(StateVersion::V1));
+        });
+    }
+
+    fn set_up_version() {
+        StorageVersion::new(COURT_REQUIRED_STORAGE_VERSION).put::<Court<Runtime>>();
+    }
+}

--- a/zrml/court/src/migrations.rs
+++ b/zrml/court/src/migrations.rs
@@ -85,7 +85,7 @@ where
                                 // however, if not use the current period index
                                 // 5_184_000 is the block of the inflation reward distribution
                                 // 5_184_000 / 216_000 (blocks per 30 day inflation period) = 24
-                                .unwrap_or(24u64.saturated_into::<BlockNumberOf<T>>()),
+                                .unwrap_or(0u64.saturated_into::<BlockNumberOf<T>>()),
                             // using old_pool_item.stake leads to all joins in period 24
                             // to be uneligible, which is exactly what we want
                             // if using zero, all joins of period 24 would be eligible,
@@ -102,7 +102,7 @@ where
             Err(e) => log::error!("MigrateCourtPoolItems: Error: {:?}", e),
         }
 
-        total_weight = total_weight.saturating_add(T::DbWeight::get().writes(1));
+        total_weight = total_weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
         StorageVersion::new(COURT_NEXT_STORAGE_VERSION).put::<Court<T>>();
         total_weight = total_weight.saturating_add(T::DbWeight::get().writes(1));

--- a/zrml/court/src/migrations.rs
+++ b/zrml/court/src/migrations.rs
@@ -50,7 +50,6 @@ const COURT_NEXT_STORAGE_VERSION: u16 = 3;
 
 pub struct MigrateCourtPoolItems<T>(PhantomData<T>);
 
-/// Migrates AMM and CDA markets to the new combined scoring rule.
 impl<T> OnRuntimeUpgrade for MigrateCourtPoolItems<T>
 where
     T: Config,

--- a/zrml/court/src/types.rs
+++ b/zrml/court/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Forecasting Technologies LTD.
+// Copyright 2022-2024 Forecasting Technologies LTD.
 // Copyright 2021-2022 Zeitgeist PM LLC.
 //
 // This file is part of Zeitgeist.

--- a/zrml/court/src/types.rs
+++ b/zrml/court/src/types.rs
@@ -285,12 +285,8 @@ pub struct CourtPoolItem<AccountId, Balance, BlockNumber> {
     pub consumed_stake: Balance,
     /// The block number at which the participant initially joined.
     pub joined_at: BlockNumber,
-    /// The block number at which the participant lastly joined.
-    pub last_join_at: BlockNumber,
-    /// The amount of the join for the past inflation period.
-    pub pre_period_join_stake: Balance,
-    /// The relevant block number to determine the join for the past inflation period.
-    pub pre_period_join_at: BlockNumber,
+    pub uneligible_index: BlockNumber,
+    pub uneligible_stake: Balance,
 }
 
 /// The information about an internal selected draw of a juror or delegator.

--- a/zrml/court/src/types.rs
+++ b/zrml/court/src/types.rs
@@ -283,8 +283,14 @@ pub struct CourtPoolItem<AccountId, Balance, BlockNumber> {
     /// The consumed amount of the stake for all draws. This is useful to reduce the probability
     /// of a court participant to be selected again.
     pub consumed_stake: Balance,
-    /// The block number at which the participant joined.
+    /// The block number at which the participant initially joined.
     pub joined_at: BlockNumber,
+    /// The block number at which the participant lastly joined.
+    pub last_join_at: BlockNumber,
+    /// The amount of the join for the past inflation period.
+    pub pre_period_join_stake: Balance,
+    /// The relevant block number to determine the join for the past inflation period.
+    pub pre_period_join_at: BlockNumber,
 }
 
 /// The information about an internal selected draw of a juror or delegator.

--- a/zrml/court/src/types.rs
+++ b/zrml/court/src/types.rs
@@ -285,7 +285,10 @@ pub struct CourtPoolItem<AccountId, Balance, BlockNumber> {
     pub consumed_stake: Balance,
     /// The block number at which the participant initially joined.
     pub joined_at: BlockNumber,
+    /// The index of the inflation period in which the court participant increased the stake lastly.
+    /// The court participant can increase the stake by joining the court with a higher stake.
     pub uneligible_index: BlockNumber,
+    /// The additional stake added in the inflation period of the uneligible index.
     pub uneligible_stake: Balance,
 }
 


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

It rewards inflation based on the stake information before the current inflation period..

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

