### PR TITLE
Allow to run intergation test workflow on tag pushes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,9 +1,10 @@
 name: Integration Tests
 
 on:
+  workflow_dispatch:
   push:
     tags:
-      - '^v[0-9]+.[0-9]+.[0-9]+(-rc[0-9]+)?$'
+      - "^v[0-9]+.[0-9]+.[0-9]+(-rc[0-9]+)?$"
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,29 +22,29 @@ jobs:
 
       - name: Build Parachain
         run: cargo build --release --features parachain
-      
+
       - name: Save runtime wasm
         run: |
-            mkdir -p runtimes
-            cp target/release/wbuild/battery-station-runtime/battery_station_runtime.compact.compressed.wasm runtimes/;
-            cp target/release/wbuild/zeitgeist-runtime/zeitgeist_runtime.compact.compressed.wasm runtimes/;
+          mkdir -p runtimes
+          cp target/release/wbuild/battery-station-runtime/battery_station_runtime.compact.compressed.wasm runtimes/;
+          cp target/release/wbuild/zeitgeist-runtime/zeitgeist_runtime.compact.compressed.wasm runtimes/;
 
       - name: Upload runtimes
         uses: actions/upload-artifact@v3.1.2
         with:
-            name: runtimes
-            path: runtimes
+          name: runtimes
+          path: runtimes
 
       - name: Save zeitgeist binary
         run: |
-            mkdir -p binaries
-            cp target/release/zeitgeist binaries/;
+          mkdir -p binaries
+          cp target/release/zeitgeist binaries/;
 
       - name: Upload binary
         uses: actions/upload-artifact@v3.1.2
         with:
-            name: binaries
-            path: binaries
+          name: binaries
+          path: binaries
 
   zombienet_zndsl:
     name: ZNDSL Tests
@@ -64,7 +65,7 @@ jobs:
           node-version: 20.x
           cache: "pnpm"
           cache-dependency-path: "./integration-tests/pnpm-lock.yaml"
-      
+
       - name: Install pnpm packages
         run: |
           cd integration-tests
@@ -87,9 +88,9 @@ jobs:
       - name: Download binary
         uses: actions/download-artifact@v3.0.2
         with:
-            name: binaries
-            path: target/release
-          
+          name: binaries
+          path: target/release
+
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: target/
@@ -121,7 +122,7 @@ jobs:
           node-version: 20.x
           cache: "pnpm"
           cache-dependency-path: "./integration-tests/pnpm-lock.yaml"
-        
+
       - name: Install pnpm packages
         run: |
           cd integration-tests
@@ -144,8 +145,8 @@ jobs:
       - name: Download binary
         uses: actions/download-artifact@v3.0.2
         with:
-            name: binaries
-            path: target/release
+          name: binaries
+          path: target/release
 
       - name: Display structure of downloaded files
         run: ls -R
@@ -154,7 +155,7 @@ jobs:
       - name: Test zeitgeist runtime upgrade using Zombienet
         run: |
           chmod uog+x target/release/zeitgeist
-          
+
           cd integration-tests
           pnpm exec moonwall test zombienet_zeitgeist_upgrade
 
@@ -177,7 +178,7 @@ jobs:
           node-version: 20.x
           cache: "pnpm"
           cache-dependency-path: "./integration-tests/pnpm-lock.yaml"
-        
+
       - name: Install pnpm packages
         run: |
           cd integration-tests


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

For the `v0.5.1` tag the integration test workflow was not run, which you might see [here](https://github.com/zeitgeistpm/zeitgeist/actions/workflows/integration-tests.yml). Now the workflow allows for [manual triggers](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) using `workflow_dispatch`. 

Additionally it formats the code.
 
### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

