### PR TITLE
Fix Rikiddo migration

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -96,7 +96,7 @@ macro_rules! decl_common_types {
             pub const CustomAssetsPalletStr: &'static str = "CustomAssets";
             pub const MarketAssetsPalletStr: &'static str = "MarketAssets";
             pub const LiquidityMiningPalletStr: &'static str = "LiquidityMining";
-            pub const RikiddoPalletStr: &'static str = "Rikiddo";
+            pub const RikiddoPalletStr: &'static str = "RikiddoSigmoidFeeMarketEma";
             pub const SimpleDisputesPalletStr: &'static str = "SimpleDisputes";
         }
 


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

The pallet prefix for zrml-rikiddo was specified incorrectly in the migration which clears the pallet. This is now mitigated. You can see that clearing the rikiddo pallet now actually deletes a key. That key is for the storage version of the pallet.

It may seem strange that the pallet for custom assets, for instance, doesn't have any keys. This seems to be due to the very different ways these two pallets were initialized, with the `CustomAssets` instance falling victim to the substrate bug that doesn't set the storage version when a pallet is added to a live chain. You can test this by finding what the storage key for the storage version of `CustomAssets` is (`0x97ca552d2b66546c8271d80839408bfd4e7b9012096b41c4eb3aaf947f6ea429`) and then querying it on Battery Station or Zeitgeist. The result is `0x`, i.e. there is no storage under this key. By contrast, the storage key for the storage version of the Rikiddo pallet returns `0x0000`, the correct zero-initialized value.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

