### PR TITLE
Revert "Use three out of five membership threshold (#1404)"

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 Forecasting Technologies LTD.
+// Copyright 2022-2024 Forecasting Technologies LTD.
 // Copyright 2021-2022 Zeitgeist PM LLC.
 // Copyright 2019-2020 Parity Technologies (UK) Ltd.
 //
@@ -202,12 +202,6 @@ macro_rules! decl_common_types {
             EnsureProportionAtLeast<AccountId, CouncilInstance, 1, 2>,
         >;
 
-        // At least 60%
-        type EnsureRootOrThreeFifthsCouncil = EitherOfDiverse<
-            EnsureRoot<AccountId>,
-            EnsureProportionAtLeast<AccountId, CouncilInstance, 3, 5>,
-        >;
-
         // At least 66%
         type EnsureRootOrTwoThirdsCouncil = EitherOfDiverse<
             EnsureRoot<AccountId>,
@@ -232,12 +226,6 @@ macro_rules! decl_common_types {
         type EnsureRootOrHalfTechnicalCommittee = EitherOfDiverse<
             EnsureRoot<AccountId>,
             EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 2>,
-        >;
-
-        // At least 60%
-        type EnsureRootOrThreeFifthsTechnicalCommittee = EitherOfDiverse<
-            EnsureRoot<AccountId>,
-            EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 3, 5>,
         >;
 
         // At least 66%
@@ -495,7 +483,7 @@ macro_rules! impl_config_traits {
         #[cfg(feature = "parachain")]
         impl cumulus_pallet_xcmp_queue::Config for Runtime {
             type ChannelInfo = ParachainSystem;
-            type ControllerOrigin = EnsureRootOrThreeFifthsTechnicalCommittee;
+            type ControllerOrigin = EnsureRootOrTwoThirdsTechnicalCommittee;
             type ControllerOriginConverter = XcmOriginToTransactDispatchOrigin;
             type ExecuteOverweightOrigin = EnsureRootOrHalfTechnicalCommittee;
             type PriceForSiblingDelivery = ();
@@ -676,7 +664,7 @@ macro_rules! impl_config_traits {
         impl orml_asset_registry::Config for Runtime {
             type AssetId = CurrencyId;
             type AssetProcessor = CustomAssetProcessor;
-            type AuthorityOrigin = AsEnsureOriginWithArg<EnsureRootOrThreeFifthsCouncil>;
+            type AuthorityOrigin = AsEnsureOriginWithArg<EnsureRootOrTwoThirdsCouncil>;
             type Balance = Balance;
             type CustomMetadata = CustomMetadata;
             type RuntimeEvent = RuntimeEvent;
@@ -826,7 +814,7 @@ macro_rules! impl_config_traits {
             type ExternalDefaultOrigin = EnsureRootOrAllCouncil;
             /// Origin that can have an ExternalMajority/ExternalDefault vote
             /// be tabled immediately and with a shorter voting/enactment period.
-            type FastTrackOrigin = EnsureRootOrThreeFifthsTechnicalCommittee;
+            type FastTrackOrigin = EnsureRootOrTwoThirdsTechnicalCommittee;
             /// Origin from which the next majority-carries (or more permissive) referendum may be tabled
             /// to vote immediately and asynchronously in a similar manner to the emergency origin.
             type InstantOrigin = EnsureRootOrAllTechnicalCommittee;
@@ -870,41 +858,41 @@ macro_rules! impl_config_traits {
         }
 
         impl pallet_membership::Config<AdvisoryCommitteeMembershipInstance> for Runtime {
-            type AddOrigin = EnsureRootOrThreeFifthsCouncil;
+            type AddOrigin = EnsureRootOrTwoThirdsCouncil;
             type RuntimeEvent = RuntimeEvent;
             type MaxMembers = AdvisoryCommitteeMaxMembers;
             type MembershipChanged = AdvisoryCommittee;
             type MembershipInitialized = AdvisoryCommittee;
-            type PrimeOrigin = EnsureRootOrThreeFifthsCouncil;
-            type RemoveOrigin = EnsureRootOrThreeFifthsCouncil;
-            type ResetOrigin = EnsureRootOrThreeFifthsCouncil;
-            type SwapOrigin = EnsureRootOrThreeFifthsCouncil;
+            type PrimeOrigin = EnsureRootOrTwoThirdsCouncil;
+            type RemoveOrigin = EnsureRootOrTwoThirdsCouncil;
+            type ResetOrigin = EnsureRootOrTwoThirdsCouncil;
+            type SwapOrigin = EnsureRootOrTwoThirdsCouncil;
             type WeightInfo = weights::pallet_membership::WeightInfo<Runtime>;
         }
 
         impl pallet_membership::Config<CouncilMembershipInstance> for Runtime {
-            type AddOrigin = EnsureRootOrThreeFifthsCouncil;
+            type AddOrigin = EnsureRootOrThreeFourthsCouncil;
             type RuntimeEvent = RuntimeEvent;
             type MaxMembers = CouncilMaxMembers;
             type MembershipChanged = Council;
             type MembershipInitialized = Council;
-            type PrimeOrigin = EnsureRootOrThreeFifthsCouncil;
-            type RemoveOrigin = EnsureRootOrThreeFifthsCouncil;
-            type ResetOrigin = EnsureRootOrThreeFifthsCouncil;
-            type SwapOrigin = EnsureRootOrThreeFifthsCouncil;
+            type PrimeOrigin = EnsureRootOrThreeFourthsCouncil;
+            type RemoveOrigin = EnsureRootOrThreeFourthsCouncil;
+            type ResetOrigin = EnsureRootOrThreeFourthsCouncil;
+            type SwapOrigin = EnsureRootOrThreeFourthsCouncil;
             type WeightInfo = weights::pallet_membership::WeightInfo<Runtime>;
         }
 
         impl pallet_membership::Config<TechnicalCommitteeMembershipInstance> for Runtime {
-            type AddOrigin = EnsureRootOrThreeFifthsCouncil;
+            type AddOrigin = EnsureRootOrTwoThirdsCouncil;
             type RuntimeEvent = RuntimeEvent;
             type MaxMembers = TechnicalCommitteeMaxMembers;
             type MembershipChanged = TechnicalCommittee;
             type MembershipInitialized = TechnicalCommittee;
-            type PrimeOrigin = EnsureRootOrThreeFifthsCouncil;
-            type RemoveOrigin = EnsureRootOrThreeFifthsCouncil;
-            type ResetOrigin = EnsureRootOrThreeFifthsCouncil;
-            type SwapOrigin = EnsureRootOrThreeFifthsCouncil;
+            type PrimeOrigin = EnsureRootOrTwoThirdsCouncil;
+            type RemoveOrigin = EnsureRootOrTwoThirdsCouncil;
+            type ResetOrigin = EnsureRootOrTwoThirdsCouncil;
+            type SwapOrigin = EnsureRootOrTwoThirdsCouncil;
             type WeightInfo = weights::pallet_membership::WeightInfo<Runtime>;
         }
 


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

This reverts commit adc944378fda7057ce68e3a7fcb25487857ab467.

### What important points should reviewers know?

This needs to go before the merge of https://github.com/zeitgeistpm/zeitgeist/pull/1398.

This PR was accidentally merged before the last release branch has been incorporated into the main commit history.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

