### PR TITLE
Fix github workflows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
           cp target/release/wbuild/zeitgeist-runtime/zeitgeist_runtime.compact.compressed.wasm runtimes/;
 
       - name: Upload runtimes
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: runtimes
           path: runtimes
@@ -41,7 +41,7 @@ jobs:
           cp target/release/zeitgeist binaries/;
 
       - name: Upload binary
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: binaries
@@ -80,13 +80,13 @@ jobs:
           mkdir -p integration-tests/tmp
 
       - name: Download runtime
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: runtimes
           path: target/release/wbuild/zeitgeist-runtime/
 
       - name: Download binary
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: binaries
           path: target/release
@@ -137,13 +137,13 @@ jobs:
           mkdir -p integration-tests/tmp
 
       - name: Download runtime
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: runtimes
           path: target/release/wbuild/zeitgeist-runtime/
 
       - name: Download binary
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: binaries
           path: target/release
@@ -193,7 +193,7 @@ jobs:
           mkdir -p integration-tests/tmp/node_logs
 
       - name: Download runtime
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: runtimes
           path: target/release/wbuild/battery-station-runtime/
@@ -248,7 +248,7 @@ jobs:
           mkdir -p integration-tests/tmp/node_logs
 
       - name: "Download runtime"
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: runtimes
           path: target/release/wbuild/zeitgeist-runtime/

--- a/scripts/tests/format.sh
+++ b/scripts/tests/format.sh
@@ -66,7 +66,7 @@ taplo_fmt() {
 has_taplo=$(which taplo)
 if [ $? -eq 1 ]; then
     echo "Installing taplo ..."
-    cargo install taplo-cli --git https://github.com/tamasfe/taplo --rev 848722f2c604de68535e5a3e0bb2a2c1d3c7dc74
+    cargo install taplo-cli --locked --git https://github.com/tamasfe/taplo --rev ab68333d17afab9319d0516b311a71bde828f900
 fi
 # install rustfmt if it isn't already
 has_rustfmt=$(which rustfmt)


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

It fixes two issues that result in failing workflows.

### What important points should reviewers know?

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

```bash
error: failed to compile `taplo-cli v0.8.1 (https://github.com/tamasfe/taplo?rev=848722f2c604de68535e5a3e0bb2a2c1d3c7dc74#848722f2)`, intermediate artifacts can be found at `/tmp/cargo-installSF7V0Q`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.79.0-nightly is not supported by the following packages:
    litemap@0.7.5 requires rustc 1.81
    zerofrom@0.1.6 requires rustc 1.81
  Either upgrade rustc or select compatible dependency versions with
  `cargo update <name>@<current-ver> --precise <compatible-ver>`
  where `<compatible-ver>` is the latest version supporting rustc 1.79.0-nightly
Running cargo formatting ...
OK
Running taplo formatting ...
./scripts/tests/format.sh: line 57: taplo: command not found
Error: Process completed with exit code 1.
```

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

