### PR TITLE
Remove storage weight reclaim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,6 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
- "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "env_logger 0.11.8",
@@ -1810,7 +1809,6 @@ dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-storage-weight-reclaim",
  "frame-support",
  "frame-system",
  "log",
@@ -2567,22 +2565,6 @@ dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
  "sp-trie",
-]
-
-[[package]]
-name = "cumulus-primitives-storage-weight-reclaim"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
-dependencies = [
- "cumulus-primitives-core",
- "cumulus-primitives-proof-size-hostfunction",
- "docify",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
 ]
 
 [[package]]
@@ -16942,7 +16924,6 @@ dependencies = [
  "cumulus-client-service",
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
- "cumulus-primitives-storage-weight-reclaim",
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
@@ -17058,7 +17039,6 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
- "cumulus-primitives-storage-weight-reclaim",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "env_logger 0.11.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,6 @@ cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/polkado
 cumulus-pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
 cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
 cumulus-primitives-core = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
 cumulus-primitives-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
 cumulus-primitives-utility = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
 nimbus-primitives = { git = "https://github.com/zeitgeistpm/moonkit", branch = "zeitgeist-polkadot-stable2409", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -63,7 +63,6 @@ cumulus-client-network = { workspace = true, optional = true }
 cumulus-client-service = { workspace = true, optional = true }
 cumulus-primitives-core = { workspace = true, features = ["default"], optional = true }
 cumulus-primitives-parachain-inherent = { workspace = true, optional = true }
-cumulus-primitives-storage-weight-reclaim = { workspace = true }
 cumulus-relay-chain-inprocess-interface = { workspace = true, optional = true }
 cumulus-relay-chain-interface = { workspace = true, optional = true }
 cumulus-relay-chain-minimal-node = { workspace = true, optional = true }

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -164,27 +164,19 @@ pub fn create_benchmark_extrinsic_zeitgeist<RuntimeApi>(
         .map(|c| c / 2)
         .unwrap_or(2);
 
-    let extra: zeitgeist_runtime::SignedExtra =
-        (
-            zeitgeist_runtime::CheckNonZeroSender::<zeitgeist_runtime::Runtime>::new(),
-            zeitgeist_runtime::CheckSpecVersion::<zeitgeist_runtime::Runtime>::new(),
-            zeitgeist_runtime::CheckTxVersion::<zeitgeist_runtime::Runtime>::new(),
-            zeitgeist_runtime::CheckGenesis::<zeitgeist_runtime::Runtime>::new(),
-            zeitgeist_runtime::CheckEra::<zeitgeist_runtime::Runtime>::from(
-                sp_runtime::generic::Era::mortal(period, best_block.saturated_into()),
-            ),
-            zeitgeist_runtime::CheckNonce::<zeitgeist_runtime::Runtime>::from(nonce.into()),
-            zeitgeist_runtime::CheckWeight::<zeitgeist_runtime::Runtime>::new(),
-            pallet_asset_tx_payment::ChargeAssetTxPayment::<zeitgeist_runtime::Runtime>::from(
-                0, None,
-            ),
-            frame_metadata_hash_extension::CheckMetadataHash::<zeitgeist_runtime::Runtime>::new(
-                true,
-            ),
-            cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim::<
-                zeitgeist_runtime::Runtime,
-            >::new(),
-        );
+    let extra: zeitgeist_runtime::SignedExtra = (
+        zeitgeist_runtime::CheckNonZeroSender::<zeitgeist_runtime::Runtime>::new(),
+        zeitgeist_runtime::CheckSpecVersion::<zeitgeist_runtime::Runtime>::new(),
+        zeitgeist_runtime::CheckTxVersion::<zeitgeist_runtime::Runtime>::new(),
+        zeitgeist_runtime::CheckGenesis::<zeitgeist_runtime::Runtime>::new(),
+        zeitgeist_runtime::CheckEra::<zeitgeist_runtime::Runtime>::from(
+            sp_runtime::generic::Era::mortal(period, best_block.saturated_into()),
+        ),
+        zeitgeist_runtime::CheckNonce::<zeitgeist_runtime::Runtime>::from(nonce.into()),
+        zeitgeist_runtime::CheckWeight::<zeitgeist_runtime::Runtime>::new(),
+        pallet_asset_tx_payment::ChargeAssetTxPayment::<zeitgeist_runtime::Runtime>::from(0, None),
+        frame_metadata_hash_extension::CheckMetadataHash::<zeitgeist_runtime::Runtime>::new(true),
+    );
 
     let raw_payload = zeitgeist_runtime::SignedPayload::from_raw(
         call.clone(),
@@ -199,7 +191,6 @@ pub fn create_benchmark_extrinsic_zeitgeist<RuntimeApi>(
             (),
             (),
             None,
-            (),
         ),
     );
     let signature = raw_payload.using_encoded(|e| sender.sign(e));
@@ -247,9 +238,6 @@ pub fn create_benchmark_extrinsic_battery_station<RuntimeApi>(
         frame_metadata_hash_extension::CheckMetadataHash::<battery_station_runtime::Runtime>::new(
             true,
         ),
-        cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim::<
-            battery_station_runtime::Runtime,
-        >::new(),
     );
 
     let raw_payload = battery_station_runtime::SignedPayload::from_raw(
@@ -265,7 +253,6 @@ pub fn create_benchmark_extrinsic_battery_station<RuntimeApi>(
             (),
             (),
             None,
-            (),
         ),
     );
     let signature = raw_payload.using_encoded(|e| sender.sign(e));

--- a/node/src/service/service_parachain.rs
+++ b/node/src/service/service_parachain.rs
@@ -144,11 +144,10 @@ where
         .build();
 
     let (client, backend, keystore_container, task_manager) =
-        sc_service::new_full_parts_record_import::<Block, RuntimeApi, _>(
+        sc_service::new_full_parts::<Block, RuntimeApi, _>(
             config,
             telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
             executor,
-            true,
         )?;
     let client = Arc::new(client);
 

--- a/node/src/service/service_standalone.rs
+++ b/node/src/service/service_standalone.rs
@@ -345,11 +345,10 @@ where
 
     let executor = sc_service::new_wasm_executor::<HostFunctions>(&config.executor);
     let (client, backend, keystore_container, task_manager) =
-        sc_service::new_full_parts_record_import::<Block, RuntimeApi, _>(
+        sc_service::new_full_parts::<Block, RuntimeApi, _>(
             &config,
             telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
             executor,
-            true,
         )?;
     let client = Arc::new(client);
 

--- a/runtime/battery-station/Cargo.toml
+++ b/runtime/battery-station/Cargo.toml
@@ -63,7 +63,6 @@ cumulus-pallet-parachain-system = { workspace = true, optional = true }
 cumulus-pallet-xcm = { workspace = true, optional = true }
 cumulus-pallet-xcmp-queue = { workspace = true, optional = true }
 cumulus-primitives-core = { workspace = true, optional = true }
-cumulus-primitives-storage-weight-reclaim = { workspace = true }
 cumulus-primitives-timestamp = { workspace = true, optional = true }
 cumulus-primitives-utility = { workspace = true, optional = true }
 parachain-info = { workspace = true, optional = true }
@@ -300,7 +299,6 @@ std = [
     "cumulus-pallet-xcm?/std",
     "cumulus-pallet-xcmp-queue?/std",
     "cumulus-primitives-core?/std",
-    "cumulus-primitives-storage-weight-reclaim/std",
     "cumulus-primitives-timestamp?/std",
     "cumulus-primitives-utility?/std",
     "parachain-info?/std",

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -3,7 +3,6 @@
 cumulus-pallet-dmp-queue = { workspace = true, optional = true }
 cumulus-pallet-parachain-system = { workspace = true, optional = true }
 cumulus-pallet-xcmp-queue = { workspace = true, optional = true }
-cumulus-primitives-storage-weight-reclaim = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 orml-currencies = { workspace = true }
@@ -54,7 +53,6 @@ std = [
     "cumulus-pallet-parachain-system?/std",
     "cumulus-pallet-dmp-queue?/std",
     "cumulus-pallet-xcmp-queue?/std",
-    "cumulus-primitives-storage-weight-reclaim/std",
     "frame-system/std",
     "frame-support/std",
     "orml-currencies/std",

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -151,7 +151,6 @@ macro_rules! decl_common_types {
             // https://docs.rs/pallet-asset-tx-payment/latest/src/pallet_asset_tx_payment/lib.rs.html#32-34
             pallet_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
             frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
-            cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
         );
         pub type EventRecord = frame_system::EventRecord<
             <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/zeitgeist/Cargo.toml
+++ b/runtime/zeitgeist/Cargo.toml
@@ -62,7 +62,6 @@ cumulus-pallet-parachain-system = { workspace = true, optional = true }
 cumulus-pallet-xcm = { workspace = true, optional = true }
 cumulus-pallet-xcmp-queue = { workspace = true, optional = true }
 cumulus-primitives-core = { workspace = true, optional = true }
-cumulus-primitives-storage-weight-reclaim = { workspace = true }
 cumulus-primitives-timestamp = { workspace = true, optional = true }
 cumulus-primitives-utility = { workspace = true, optional = true }
 parachain-info = { workspace = true, optional = true }
@@ -294,7 +293,6 @@ std = [
     "cumulus-pallet-xcm?/std",
     "cumulus-pallet-xcmp-queue?/std",
     "cumulus-primitives-core?/std",
-    "cumulus-primitives-storage-weight-reclaim/std",
     "cumulus-primitives-timestamp?/std",
     "cumulus-primitives-utility?/std",
     "parachain-info?/std",


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

It removes the storage weight reclaim feature.

[More on it here.](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/enable_pov_reclaim/index.html)

### What important points should reviewers know?

It has been removed, because the chopsticks and zombienet integration tests failed, because of it. [Try to reintroduce it](https://github.com/zeitgeistpm/zeitgeist/issues/1438) in the next runtime upgrade.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

