### PR TITLE
Update ubuntu version for docker Hadolint

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   hadolint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: "Hadolint"
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

![image](https://github.com/user-attachments/assets/c5bec4cb-17a3-434b-ad7c-3ae9cfdcac93)

Our current CI workflow for docker has a problem. More on that [here](https://github.com/zeitgeistpm/zeitgeist/actions/runs/16074646982). 

This PR updates the ubuntu version of the runner to from 20.04 to 22.04.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References

