### PR TITLE
Remove migrations from v0.6.1

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -110,20 +110,8 @@ macro_rules! decl_common_types {
 
         #[cfg(feature = "parachain")]
         type Migrations = (
-            pallet_parachain_staking::migrations::MigrateRoundWithFirstSlot<Runtime>,
-            pallet_parachain_staking::migrations::MigrateParachainBondConfig<Runtime>,
-            cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
-            cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
             // This `MigrateToLatestXcmVersion` migration can be permanently added to the runtime migrations. https://github.com/paritytech/polkadot-sdk/blob/87971b3e92721bdf10bf40b410eaae779d494ca0/polkadot/xcm/pallet-xcm/src/migration.rs#L83
             pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
-            // u64::MAX from here: https://github.com/paritytech/polkadot-sdk/blob/304bbb8711f61503ae7afa3a5bfd4f78af5cbd62/polkadot/runtime/rococo/src/lib.rs#L1629-L1630
-            pallet_identity::migration::versioned::V0ToV1<Runtime, { u64::MAX }>,
-        );
-        #[cfg(not(feature = "parachain"))]
-        type Migrations = (
-            pallet_grandpa::migrations::MigrateV4ToV5<Runtime>,
-            // u64::MAX from here: https://github.com/paritytech/polkadot-sdk/blob/304bbb8711f61503ae7afa3a5bfd4f78af5cbd62/polkadot/runtime/rococo/src/lib.rs#L1629-L1630
-            pallet_identity::migration::versioned::V0ToV1<Runtime, { u64::MAX }>,
         );
 
         pub type Executive = frame_executive::Executive<


### PR DESCRIPTION
<!-- Please adhere to the style guide at -->
<!-- https://github.com/zeitgeistpm/zeitgeist/blob/main/docs/STYLE_GUIDE.md -->
### What does it do?

It removes the migration from the last runtime upgrade.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues?
<!-- Include references to the issues it fixes here separated by whitespaces. -->
<!-- Use a valid GitHub keyword for that, such as "closes" or "fixes". -->
<!-- Example: closes #500 #700 -->

<!-- Include references to relevant issues outside of Zeitgeist here -->
<!-- Include references to relevant PRs here -->

### References



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified runtime upgrade configuration by removing obsolete migration paths to streamline future releases. No changes to features or behavior are expected.
* **Chores**
  * Internal cleanup to reduce technical debt and improve maintainability, resulting in a leaner runtime footprint and fewer moving parts. No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->